### PR TITLE
fix FastPay shop and callback integration

### DIFF
--- a/controller/subscription_payment_fastpay.go
+++ b/controller/subscription_payment_fastpay.go
@@ -1,17 +1,15 @@
 package controller
 
 import (
-	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
-	"github.com/QuantumNous/new-api/service"
 	"github.com/gin-gonic/gin"
 )
 
@@ -79,9 +77,7 @@ func SubscriptionRequestFastPay(c *gin.Context) {
 		}
 	}
 
-	callBackAddress := service.GetCallbackAddress()
 	returnUrl := paymentReturnPath("/wallet?pay=success")
-	notifyUrl := callBackAddress + "/api/subscription/fastpay/notify"
 	tradeNo := fmt.Sprintf("SUBUSR%dNO%s%d", userId, common.GetRandomString(6), time.Now().Unix())
 
 	order := &model.SubscriptionOrder{
@@ -99,17 +95,15 @@ func SubscriptionRequestFastPay(c *gin.Context) {
 		return
 	}
 
-	params := map[string]string{
-		"merchantNo": cfg.MerchantNo,
-		"outTradeNo": tradeNo,
-		"amount":     strconv.FormatFloat(plan.PriceAmount, 'f', 2, 64),
-		"subject":    fmt.Sprintf("SUB:%s", plan.Title),
-		"payType":    req.PaymentMethod,
-		"notifyUrl":  notifyUrl,
-		"returnUrl":  returnUrl,
-		"timestamp":  strconv.FormatInt(time.Now().Unix(), 10),
-	}
-	params["sign"] = GenerateFastPaySign(params, cfg.ApiSecret)
+	params := buildFastPayOrderParams(
+		cfg,
+		tradeNo,
+		strconv.FormatFloat(plan.PriceAmount, 'f', 2, 64),
+		fmt.Sprintf("SUB:%s", plan.Title),
+		req.PaymentMethod,
+		returnUrl,
+		time.Now().Unix(),
+	)
 
 	submitUrl := getFastPaySubmitUrl(cfg.Address)
 
@@ -117,29 +111,13 @@ func SubscriptionRequestFastPay(c *gin.Context) {
 }
 
 func SubscriptionFastPayNotify(c *gin.Context) {
-	bodyBytes, err := io.ReadAll(c.Request.Body)
-	if err != nil || len(bodyBytes) == 0 {
+	payload, bodyBytes, err := readFastPayNotifyPayload(c)
+	if err != nil {
 		_, _ = c.Writer.Write([]byte("fail"))
 		return
 	}
 
-	var payload FastPayNotifyPayload
-	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
-		_, _ = c.Writer.Write([]byte("fail"))
-		return
-	}
-
-	params := map[string]string{
-		"merchantNo": payload.MerchantNo,
-		"orderNo":    payload.OrderNo,
-		"outTradeNo": payload.OutTradeNo,
-		"amount":     fmt.Sprintf("%v", payload.Amount),
-		"payAmount":  fmt.Sprintf("%v", payload.PayAmount),
-		"payType":    payload.PayType,
-		"status":     fmt.Sprintf("%v", payload.Status),
-		"payTime":    payload.PayTime,
-		"timestamp":  fmt.Sprintf("%v", payload.Timestamp),
-	}
+	params := fastPayNotifySignParams(payload)
 
 	cfg := getFastPayConfig()
 	secret := ""
@@ -158,11 +136,18 @@ func SubscriptionFastPayNotify(c *gin.Context) {
 		_, _ = c.Writer.Write([]byte("fail"))
 		return
 	}
+	completeSubscriptionFastPayNotify(c, payload, string(bodyBytes))
+}
 
+func isSubscriptionFastPayTradeNo(tradeNo string) bool {
+	return strings.HasPrefix(tradeNo, "SUBUSR")
+}
+
+func completeSubscriptionFastPayNotify(c *gin.Context, payload FastPayNotifyPayload, rawPayload string) {
 	LockOrder(payload.OutTradeNo)
 	defer UnlockOrder(payload.OutTradeNo)
 
-	if err := model.CompleteSubscriptionOrder(payload.OutTradeNo, string(bodyBytes), model.PaymentProviderFastPay, payload.PayType); err != nil {
+	if err := model.CompleteSubscriptionOrder(payload.OutTradeNo, rawPayload, model.PaymentProviderFastPay, payload.PayType); err != nil {
 		_, _ = c.Writer.Write([]byte("fail"))
 		return
 	}

--- a/controller/topup_fastpay.go
+++ b/controller/topup_fastpay.go
@@ -1,12 +1,14 @@
 package controller
 
 import (
+	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,7 +17,6 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
-	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 	"github.com/gin-gonic/gin"
@@ -30,12 +31,14 @@ type FastPayPayRequest struct {
 type FastPayConfig struct {
 	Address    string
 	MerchantNo string
+	ShopNo     string
 	ApiSecret  string
 }
 
 func getFastPayConfig() *FastPayConfig {
 	addr := strings.TrimSpace(setting.FastPayAddress)
 	merchantNo := strings.TrimSpace(setting.FastPayMerchantNo)
+	shopNo := strings.TrimSpace(setting.FastPayShopNo)
 	secret := strings.TrimSpace(setting.FastPayApiSecret)
 
 	// Fallback to operation_setting PayAddress/EpayId/EpayKey if PayAddress contains fastpay
@@ -49,13 +52,14 @@ func getFastPayConfig() *FastPayConfig {
 		secret = strings.TrimSpace(operation_setting.EpayKey)
 	}
 
-	if addr == "" || merchantNo == "" || secret == "" {
+	if addr == "" || merchantNo == "" || shopNo == "" || secret == "" {
 		return nil
 	}
 
 	return &FastPayConfig{
 		Address:    addr,
 		MerchantNo: merchantNo,
+		ShopNo:     shopNo,
 		ApiSecret:  secret,
 	}
 }
@@ -106,6 +110,21 @@ func VerifyFastPaySign(params map[string]string, secret string, expectedSign str
 	}
 	sign := GenerateFastPaySign(params, secret)
 	return strings.EqualFold(sign, expectedSign)
+}
+
+func buildFastPayOrderParams(cfg *FastPayConfig, outTradeNo, amount, subject, payType, returnUrl string, timestamp int64) map[string]string {
+	params := map[string]string{
+		"merchantNo": cfg.MerchantNo,
+		"shopNo":     cfg.ShopNo,
+		"outTradeNo": outTradeNo,
+		"amount":     amount,
+		"subject":    subject,
+		"payType":    payType,
+		"returnUrl":  returnUrl,
+		"timestamp":  strconv.FormatInt(timestamp, 10),
+	}
+	params["sign"] = GenerateFastPaySign(params, cfg.ApiSecret)
+	return params
 }
 
 func parsePayRequest(c *gin.Context, amount *float64, paymentMethod *string) error {
@@ -198,22 +217,18 @@ func RequestFastPay(c *gin.Context) {
 		return
 	}
 
-	callBackAddress := service.GetCallbackAddress()
 	returnUrl := paymentReturnPath("/usage-logs")
-	notifyUrl := callBackAddress + "/api/user/fastpay/notify"
 	tradeNo := fmt.Sprintf("USR%dNO%s%d", id, common.GetRandomString(6), time.Now().Unix())
 
-	params := map[string]string{
-		"merchantNo": cfg.MerchantNo,
-		"outTradeNo": tradeNo,
-		"amount":     strconv.FormatFloat(payMoney, 'f', 2, 64),
-		"subject":    fmt.Sprintf("TUC%d", int64Amount),
-		"payType":    req.PaymentMethod,
-		"notifyUrl":  notifyUrl,
-		"returnUrl":  returnUrl,
-		"timestamp":  strconv.FormatInt(time.Now().Unix(), 10),
-	}
-	params["sign"] = GenerateFastPaySign(params, cfg.ApiSecret)
+	params := buildFastPayOrderParams(
+		cfg,
+		tradeNo,
+		strconv.FormatFloat(payMoney, 'f', 2, 64),
+		fmt.Sprintf("TUC%d", int64Amount),
+		req.PaymentMethod,
+		returnUrl,
+		time.Now().Unix(),
+	)
 
 	amount := int64Amount
 	if operation_setting.GetQuotaDisplayType() == operation_setting.QuotaDisplayTypeTokens {
@@ -260,20 +275,42 @@ type FastPayNotifyPayload struct {
 	Sign       string      `json:"sign"`
 }
 
-func FastPayNotify(c *gin.Context) {
+func readFastPayNotifyPayload(c *gin.Context) (FastPayNotifyPayload, []byte, error) {
 	bodyBytes, err := io.ReadAll(c.Request.Body)
-	if err != nil || len(bodyBytes) == 0 {
-		_, _ = c.Writer.Write([]byte("fail"))
-		return
+	if err != nil || len(bytes.TrimSpace(bodyBytes)) == 0 {
+		return FastPayNotifyPayload{}, nil, fmt.Errorf("empty callback body")
 	}
 
 	var payload FastPayNotifyPayload
-	if err := json.Unmarshal(bodyBytes, &payload); err != nil {
-		_, _ = c.Writer.Write([]byte("fail"))
-		return
+	contentType := strings.ToLower(c.GetHeader("Content-Type"))
+	if strings.Contains(contentType, "application/json") || bytes.HasPrefix(bytes.TrimSpace(bodyBytes), []byte("{")) {
+		if err := json.Unmarshal(bodyBytes, &payload); err != nil {
+			return FastPayNotifyPayload{}, nil, err
+		}
+		return payload, bodyBytes, nil
 	}
 
-	params := map[string]string{
+	values, err := url.ParseQuery(string(bodyBytes))
+	if err != nil {
+		return FastPayNotifyPayload{}, nil, err
+	}
+	payload = FastPayNotifyPayload{
+		MerchantNo: values.Get("merchantNo"),
+		OrderNo:    values.Get("orderNo"),
+		OutTradeNo: values.Get("outTradeNo"),
+		Amount:     values.Get("amount"),
+		PayAmount:  values.Get("payAmount"),
+		PayType:    values.Get("payType"),
+		Status:     values.Get("status"),
+		PayTime:    values.Get("payTime"),
+		Timestamp:  values.Get("timestamp"),
+		Sign:       values.Get("sign"),
+	}
+	return payload, bodyBytes, nil
+}
+
+func fastPayNotifySignParams(payload FastPayNotifyPayload) map[string]string {
+	return map[string]string{
 		"merchantNo": payload.MerchantNo,
 		"orderNo":    payload.OrderNo,
 		"outTradeNo": payload.OutTradeNo,
@@ -284,6 +321,16 @@ func FastPayNotify(c *gin.Context) {
 		"payTime":    payload.PayTime,
 		"timestamp":  fmt.Sprintf("%v", payload.Timestamp),
 	}
+}
+
+func FastPayNotify(c *gin.Context) {
+	payload, bodyBytes, err := readFastPayNotifyPayload(c)
+	if err != nil {
+		_, _ = c.Writer.Write([]byte("fail"))
+		return
+	}
+
+	params := fastPayNotifySignParams(payload)
 
 	cfg := getFastPayConfig()
 	secret := ""
@@ -300,6 +347,10 @@ func FastPayNotify(c *gin.Context) {
 	statusStr := fmt.Sprintf("%v", payload.Status)
 	if statusStr != "1" && statusStr != "SUCCESS" {
 		_, _ = c.Writer.Write([]byte("fail"))
+		return
+	}
+	if isSubscriptionFastPayTradeNo(payload.OutTradeNo) {
+		completeSubscriptionFastPayNotify(c, payload, string(bodyBytes))
 		return
 	}
 

--- a/controller/topup_fastpay_test.go
+++ b/controller/topup_fastpay_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +34,19 @@ func TestFastPaySignAndVerify(t *testing.T) {
 
 func TestFastPayNotify_InvalidSign(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	oldAddress := setting.FastPayAddress
+	oldMerchantNo := setting.FastPayMerchantNo
+	oldShopNo := setting.FastPayShopNo
+	oldApiSecret := setting.FastPayApiSecret
+	t.Cleanup(func() {
+		setting.FastPayAddress = oldAddress
+		setting.FastPayMerchantNo = oldMerchantNo
+		setting.FastPayShopNo = oldShopNo
+		setting.FastPayApiSecret = oldApiSecret
+	})
+	setting.FastPayAddress = "https://pay.example.com/fastpay-server"
+	setting.FastPayMerchantNo = "M12345678"
+	setting.FastPayShopNo = "S12345678"
 	setting.FastPayApiSecret = "secret123"
 
 	payload := FastPayNotifyPayload{
@@ -56,6 +71,98 @@ func TestFastPayNotify_InvalidSign(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "fail", w.Body.String())
+}
+
+func TestBuildFastPayOrderParamsMatchesServerContract(t *testing.T) {
+	cfg := &FastPayConfig{
+		Address:    "https://pay.example.com/fastpay-server",
+		MerchantNo: "M12345678",
+		ShopNo:     "S12345678",
+		ApiSecret:  "secret123",
+	}
+
+	params := buildFastPayOrderParams(
+		cfg,
+		"ORDER202607310001",
+		"10.00",
+		"测试商品",
+		"alipay",
+		"https://api.example.com/usage-logs",
+		1785489235,
+	)
+
+	assert.Equal(t, cfg.MerchantNo, params["merchantNo"])
+	assert.Equal(t, cfg.ShopNo, params["shopNo"])
+	assert.NotContains(t, params, "notifyUrl")
+	assert.True(t, VerifyFastPaySign(params, cfg.ApiSecret, params["sign"]))
+}
+
+func TestReadFastPayNotifyPayload_Form(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	secret := "secret123"
+	signParams := map[string]string{
+		"merchantNo": "M12345678",
+		"orderNo":    "FP123",
+		"outTradeNo": "USR1NO123",
+		"amount":     "10.00",
+		"payAmount":  "10.00",
+		"payType":    "alipay",
+		"status":     "1",
+		"payTime":    "2026-07-31T15:00:00",
+		"timestamp":  "1785489235",
+	}
+	form := url.Values{
+		"merchantNo": {"M12345678"},
+		"orderNo":    {"FP123"},
+		"outTradeNo": {"USR1NO123"},
+		"amount":     {"10.00"},
+		"payAmount":  {"10.00"},
+		"payType":    {"alipay"},
+		"status":     {"1"},
+		"payTime":    {"2026-07-31T15:00:00"},
+		"timestamp":  {"1785489235"},
+		"sign":       {GenerateFastPaySign(signParams, secret)},
+	}
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/user/fastpay/notify", strings.NewReader(form.Encode()))
+	c.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	payload, rawBody, err := readFastPayNotifyPayload(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "M12345678", payload.MerchantNo)
+	assert.Equal(t, "USR1NO123", payload.OutTradeNo)
+	assert.Equal(t, "1", payload.Status)
+	assert.True(t, VerifyFastPaySign(fastPayNotifySignParams(payload), secret, payload.Sign))
+	assert.Equal(t, form.Encode(), string(rawBody))
+}
+
+func TestGetFastPayConfigRequiresShopNo(t *testing.T) {
+	oldAddress := setting.FastPayAddress
+	oldMerchantNo := setting.FastPayMerchantNo
+	oldShopNo := setting.FastPayShopNo
+	oldApiSecret := setting.FastPayApiSecret
+	t.Cleanup(func() {
+		setting.FastPayAddress = oldAddress
+		setting.FastPayMerchantNo = oldMerchantNo
+		setting.FastPayShopNo = oldShopNo
+		setting.FastPayApiSecret = oldApiSecret
+	})
+
+	setting.FastPayAddress = "https://pay.example.com/fastpay-server"
+	setting.FastPayMerchantNo = "M12345678"
+	setting.FastPayShopNo = ""
+	setting.FastPayApiSecret = "secret123"
+	assert.Nil(t, getFastPayConfig())
+
+	setting.FastPayShopNo = "S12345678"
+	assert.Equal(t, "S12345678", getFastPayConfig().ShopNo)
+}
+
+func TestIsSubscriptionFastPayTradeNo(t *testing.T) {
+	assert.True(t, isSubscriptionFastPayTradeNo("SUBUSR1NO123"))
+	assert.False(t, isSubscriptionFastPayTradeNo("USR1NO123"))
 }
 
 func TestGetFastPaySubmitUrl(t *testing.T) {

--- a/model/option.go
+++ b/model/option.go
@@ -95,6 +95,7 @@ func InitOptionMap() {
 	common.OptionMap["CreemWebhookSecret"] = setting.CreemWebhookSecret
 	common.OptionMap["FastPayAddress"] = setting.FastPayAddress
 	common.OptionMap["FastPayMerchantNo"] = setting.FastPayMerchantNo
+	common.OptionMap["FastPayShopNo"] = setting.FastPayShopNo
 	common.OptionMap["FastPayApiSecret"] = setting.FastPayApiSecret
 	common.OptionMap["WaffoEnabled"] = strconv.FormatBool(setting.WaffoEnabled)
 	common.OptionMap["WaffoApiKey"] = setting.WaffoApiKey
@@ -452,6 +453,8 @@ func updateOptionMap(key string, value string) (err error) {
 		setting.FastPayAddress = value
 	case "FastPayMerchantNo":
 		setting.FastPayMerchantNo = value
+	case "FastPayShopNo":
+		setting.FastPayShopNo = value
 	case "FastPayApiSecret":
 		setting.FastPayApiSecret = value
 	case "WaffoEnabled":

--- a/setting/payment_fastpay.go
+++ b/setting/payment_fastpay.go
@@ -2,4 +2,5 @@ package setting
 
 var FastPayAddress = ""
 var FastPayMerchantNo = ""
+var FastPayShopNo = ""
 var FastPayApiSecret = ""

--- a/web/src/features/system-settings/billing/index.tsx
+++ b/web/src/features/system-settings/billing/index.tsx
@@ -63,6 +63,7 @@ const defaultBillingSettings: BillingSettings = {
   EpayKey: '',
   FastPayAddress: '',
   FastPayMerchantNo: '',
+  FastPayShopNo: '',
   FastPayApiSecret: '',
   Price: 7.3,
   MinTopUp: 1,

--- a/web/src/features/system-settings/billing/section-registry.tsx
+++ b/web/src/features/system-settings/billing/section-registry.tsx
@@ -138,6 +138,7 @@ const BILLING_SECTIONS = [
           EpayKey: settings.EpayKey,
           FastPayAddress: settings.FastPayAddress,
           FastPayMerchantNo: settings.FastPayMerchantNo,
+          FastPayShopNo: settings.FastPayShopNo,
           FastPayApiSecret: settings.FastPayApiSecret,
           Price: settings.Price,
           MinTopUp: settings.MinTopUp,

--- a/web/src/features/system-settings/integrations/payment-settings-section.tsx
+++ b/web/src/features/system-settings/integrations/payment-settings-section.tsx
@@ -108,6 +108,7 @@ const paymentSchema = z.object({
     return /^https?:\/\//.test(trimmed)
   }, 'Provide a valid URL starting with http:// or https://'),
   FastPayMerchantNo: z.string(),
+  FastPayShopNo: z.string(),
   FastPayApiSecret: z.string(),
   Price: z.coerce.number().min(0),
   MinTopUp: z.coerce.number().min(0),
@@ -430,6 +431,7 @@ export function PaymentSettingsSection({
       EpayKey: values.EpayKey.trim(),
       FastPayAddress: removeTrailingSlash(values.FastPayAddress),
       FastPayMerchantNo: values.FastPayMerchantNo.trim(),
+      FastPayShopNo: values.FastPayShopNo.trim(),
       FastPayApiSecret: values.FastPayApiSecret.trim(),
       Price: values.Price,
       MinTopUp: values.MinTopUp,
@@ -475,6 +477,7 @@ export function PaymentSettingsSection({
       EpayKey: initialRef.current.EpayKey.trim(),
       FastPayAddress: removeTrailingSlash(initialRef.current.FastPayAddress),
       FastPayMerchantNo: initialRef.current.FastPayMerchantNo.trim(),
+      FastPayShopNo: initialRef.current.FastPayShopNo.trim(),
       FastPayApiSecret: initialRef.current.FastPayApiSecret.trim(),
       Price: initialRef.current.Price,
       MinTopUp: initialRef.current.MinTopUp,
@@ -538,11 +541,24 @@ export function PaymentSettingsSection({
     }
 
     if (sanitized.FastPayMerchantNo !== initial.FastPayMerchantNo) {
-      updates.push({ key: 'FastPayMerchantNo', value: sanitized.FastPayMerchantNo })
+      updates.push({
+        key: 'FastPayMerchantNo',
+        value: sanitized.FastPayMerchantNo,
+      })
     }
 
-    if (sanitized.FastPayApiSecret && sanitized.FastPayApiSecret !== initial.FastPayApiSecret) {
-      updates.push({ key: 'FastPayApiSecret', value: sanitized.FastPayApiSecret })
+    if (sanitized.FastPayShopNo !== initial.FastPayShopNo) {
+      updates.push({ key: 'FastPayShopNo', value: sanitized.FastPayShopNo })
+    }
+
+    if (
+      sanitized.FastPayApiSecret &&
+      sanitized.FastPayApiSecret !== initial.FastPayApiSecret
+    ) {
+      updates.push({
+        key: 'FastPayApiSecret',
+        value: sanitized.FastPayApiSecret,
+      })
     }
 
     if (sanitized.Price !== initial.Price) {
@@ -1277,7 +1293,9 @@ export function PaymentSettingsSection({
                 </div>
 
                 <div className='mt-6 border-t pt-6'>
-                  <h4 className='mb-4 text-base font-semibold'>FAST 易支付 (FastPay)</h4>
+                  <h4 className='mb-4 text-base font-semibold'>
+                    FAST 易支付 (FastPay)
+                  </h4>
                   <FormField
                     control={form.control}
                     name='FastPayAddress'
@@ -1295,13 +1313,15 @@ export function PaymentSettingsSection({
                           />
                         </FormControl>
                         <FormDescription>
-                          {t('The gateway base URL for FastPay API')}
+                          {t(
+                            "The gateway base URL for FastPay API. Set the FastPay merchant callback URL to this site's /api/user/fastpay/notify endpoint."
+                          )}
                         </FormDescription>
                         <FormMessage />
                       </FormItem>
                     )}
                   />
-                  <div className='grid gap-6 md:grid-cols-2'>
+                  <div className='grid gap-6 md:grid-cols-3'>
                     <FormField
                       control={form.control}
                       name='FastPayMerchantNo'
@@ -1318,6 +1338,30 @@ export function PaymentSettingsSection({
                               }
                             />
                           </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name='FastPayShopNo'
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>{t('FastPay Shop No')}</FormLabel>
+                          <FormControl>
+                            <Input
+                              placeholder='S12345678'
+                              autoComplete='off'
+                              {...field}
+                              onChange={(event) =>
+                                field.onChange(event.target.value)
+                              }
+                            />
+                          </FormControl>
+                          <FormDescription>
+                            {t('The shop that receives FastPay payments')}
+                          </FormDescription>
                           <FormMessage />
                         </FormItem>
                       )}

--- a/web/src/features/system-settings/types.ts
+++ b/web/src/features/system-settings/types.ts
@@ -284,6 +284,7 @@ export type BillingSettings = {
   EpayKey: string
   FastPayAddress: string
   FastPayMerchantNo: string
+  FastPayShopNo: string
   FastPayApiSecret: string
   Price: number
   MinTopUp: number


### PR DESCRIPTION
## What changed

- Add a dedicated FastPay shop number setting to the backend options and billing UI.
- Include `shopNo` in wallet and subscription payment requests and sign only the fields FastPay actually verifies.
- Accept FastPay's form-encoded callbacks while preserving JSON compatibility.
- Route verified subscription callbacks through the single merchant callback endpoint by trade-number prefix.
- Add regression coverage for request parameters, required configuration, form callback parsing/signature verification, and callback routing.

## Root cause

The FastPay adapter omitted the server-required `shopNo`, so `/api/pay/submit` returned `400 店铺编号不能为空`. It also signed an unsupported per-order `notifyUrl` and expected JSON callbacks even though the deployed FastPay server posts form data. Fixing only the first validation error would have exposed the signature and crediting failures immediately afterward.

## User impact

After the administrator sets **FastPay Shop No** and configures the FastPay merchant callback as this site's `/api/user/fastpay/notify`, selecting Alipay from Wallet can enter the FastPay payment page and verified successful callbacks can credit the correct wallet or subscription exactly once.

## Validation

- `go vet ./...`
- `go vet ./...` in `relaykit`
- `go build ./...`
- `go build ./...` in `relaykit`
- `make test`
- `bun run typecheck`
- `bun test` — 112 passed
- `oxfmt --check` on all changed frontend files

## Summary by Sourcery

集成 FastPay 店铺级配置，并使支付与回调处理与 FastPay 服务器约定保持一致。

新功能：
- 添加 FastPay 店铺编号作为可配置的后端与计费设置，并在支付请求中使用该配置。

缺陷修复：
- 在钱包与订阅支付请求中包含必需的 FastPay `shopNo`，并从签名参数中移除不受支持的 `notifyUrl`。
- 接受 FastPay 回调以表单编码和 JSON 两种格式，并仅针对 FastPay验证的字段进行签名校验。
- 基于交易号前缀，将订阅类 FastPay 回调通过统一的商户回调端点进行路由，以确保订单正确完成。

优化：
- 重构共享的 FastPay 回调解析逻辑以及签名参数构造逻辑，以在钱包与订阅流程之间复用。
- 在完成订阅订单时暴露原始回调载荷，以便更精确地审计 FastPay 通知。

文档：
- 更新管理员计费界面的文案，以说明 FastPay 网关的使用方式和商户回调 URL，并在支付设置表单中添加 FastPay 店铺编号字段。

测试：
- 添加回归测试，用于覆盖 FastPay 订单参数构造、包括 `shopNo` 在内的必需配置、表单编码回调解析与签名验证，以及订阅交易号检测。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate FastPay shop-level configuration and align payment and callback handling with the FastPay server contract.

New Features:
- Add FastPay shop number as a configurable backend and billing setting used in payment requests.

Bug Fixes:
- Include required FastPay shopNo in wallet and subscription payment requests and remove unsupported notifyUrl from signed parameters.
- Accept FastPay callbacks as form-encoded as well as JSON, and verify signatures only over the fields FastPay validates.
- Route subscription FastPay callbacks through the unified merchant callback endpoint based on trade-number prefix to ensure correct order completion.

Enhancements:
- Refactor shared FastPay callback parsing and signature parameter construction for reuse between wallet and subscription flows.
- Expose the raw callback payload when completing subscription orders for more accurate auditing of FastPay notifications.

Documentation:
- Update admin billing UI copy to document FastPay gateway usage and merchant callback URL, and add a FastPay Shop No field to the payment settings form.

Tests:
- Add regression tests covering FastPay order parameter construction, required configuration including shopNo, form-encoded callback parsing and signature verification, and subscription trade-number detection.

</details>