### PR TITLE
fix(payment): route configured FastPay requests correctly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "api-lmm-best-pay"]
+	path = api-lmm-best-pay
+	url = https://github.com/LIghtJUNction/api-lmm-best-pay.git

--- a/controller/subscription_payment_epay.go
+++ b/controller/subscription_payment_epay.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/Calcium-Ion/go-epay/epay"
@@ -51,9 +50,9 @@ func SubscriptionRequestEpay(c *gin.Context) {
 		return
 	}
 
-	if req.PaymentMethod == "fastpay" || strings.HasPrefix(req.PaymentMethod, "fastpay_") || (isFastPayWebhookConfigured() && strings.Contains(strings.ToLower(operation_setting.PayAddress), "fastpay")) {
+	if fastPayMethod, useFastPay := resolveFastPayMethod(req.PaymentMethod); useFastPay {
 		c.Set("parsed_plan_id", req.PlanId)
-		c.Set("parsed_payment_method", req.PaymentMethod)
+		c.Set("parsed_payment_method", fastPayMethod)
 		SubscriptionRequestFastPay(c)
 		return
 	}

--- a/controller/subscription_payment_fastpay.go
+++ b/controller/subscription_payment_fastpay.go
@@ -45,6 +45,11 @@ func SubscriptionRequestFastPay(c *gin.Context) {
 		common.ApiErrorMsg(c, "参数错误")
 		return
 	}
+	req.PaymentMethod = normalizeFastPayMethod(req.PaymentMethod)
+	if !isSupportedFastPayMethod(req.PaymentMethod) {
+		common.ApiErrorMsg(c, "FAST 易支付仅支持支付宝或微信支付")
+		return
+	}
 
 	plan, err := model.GetSubscriptionPlanById(req.PlanId)
 	if err != nil {

--- a/controller/topup.go
+++ b/controller/topup.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -97,7 +96,7 @@ func GetTopUpInfo(c *gin.Context) {
 	}
 
 	data := gin.H{
-		"enable_online_topup":              isEpayTopUpEnabled(),
+		"enable_online_topup":              isEpayTopUpEnabled() || isFastPayTopUpEnabled(),
 		"enable_stripe_topup":              isStripeTopUpEnabled(),
 		"enable_creem_topup":               isCreemTopUpEnabled(),
 		"enable_waffo_topup":               enableWaffo,
@@ -217,9 +216,9 @@ func RequestEpay(c *gin.Context) {
 		return
 	}
 
-	if req.PaymentMethod == "fastpay" || strings.HasPrefix(req.PaymentMethod, "fastpay_") || (isFastPayWebhookConfigured() && strings.Contains(strings.ToLower(operation_setting.PayAddress), "fastpay")) {
+	if fastPayMethod, useFastPay := resolveFastPayMethod(req.PaymentMethod); useFastPay {
 		c.Set("parsed_amount", req.Amount)
-		c.Set("parsed_payment_method", req.PaymentMethod)
+		c.Set("parsed_payment_method", fastPayMethod)
 		RequestFastPay(c)
 		return
 	}

--- a/controller/topup_fastpay.go
+++ b/controller/topup_fastpay.go
@@ -33,6 +33,38 @@ type FastPayConfig struct {
 	ApiSecret  string
 }
 
+func normalizeFastPayMethod(paymentMethod string) string {
+	method := strings.TrimSpace(paymentMethod)
+	if method == "fastpay" {
+		return ""
+	}
+	return strings.TrimPrefix(method, "fastpay_")
+}
+
+// resolveFastPayMethod selects FAST for an explicitly prefixed method, or as
+// the default online gateway when FAST is configured and Epay is not. Plain
+// payment methods remain on Epay when both gateways are configured.
+func resolveFastPayMethod(paymentMethod string) (string, bool) {
+	method := strings.TrimSpace(paymentMethod)
+	normalized := normalizeFastPayMethod(method)
+	if method == "fastpay" || strings.HasPrefix(method, "fastpay_") {
+		return normalized, true
+	}
+
+	if getFastPayConfig() == nil {
+		return normalized, false
+	}
+	if !isEpayWebhookConfigured() || strings.Contains(strings.ToLower(operation_setting.PayAddress), "fastpay") {
+		return normalized, true
+	}
+
+	return normalized, false
+}
+
+func isSupportedFastPayMethod(paymentMethod string) bool {
+	return paymentMethod == "alipay" || paymentMethod == "wxpay"
+}
+
 func getFastPayConfig() *FastPayConfig {
 	addr := strings.TrimSpace(setting.FastPayAddress)
 	merchantNo := strings.TrimSpace(setting.FastPayMerchantNo)
@@ -172,6 +204,11 @@ func RequestFastPay(c *gin.Context) {
 	if err := parsePayRequest(c, &req.Amount, &req.PaymentMethod); err != nil {
 		logger.LogWarn(c.Request.Context(), fmt.Sprintf("FAST易支付 参数解包失败 error=%q", err.Error()))
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": fmt.Sprintf("参数错误: %s", err.Error())})
+		return
+	}
+	req.PaymentMethod = normalizeFastPayMethod(req.PaymentMethod)
+	if !isSupportedFastPayMethod(req.PaymentMethod) {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "FAST 易支付仅支持支付宝或微信支付"})
 		return
 	}
 	int64Amount := int64(req.Amount)

--- a/controller/topup_fastpay_test.go
+++ b/controller/topup_fastpay_test.go
@@ -9,9 +9,88 @@ import (
 	"time"
 
 	"github.com/QuantumNous/new-api/setting"
+	"github.com/QuantumNous/new-api/setting/operation_setting"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func preservePaymentGatewaySettings(t *testing.T) {
+	t.Helper()
+	originalFastPayAddress := setting.FastPayAddress
+	originalFastPayMerchantNo := setting.FastPayMerchantNo
+	originalFastPayAPISecret := setting.FastPayApiSecret
+	originalPayAddress := operation_setting.PayAddress
+	originalEpayID := operation_setting.EpayId
+	originalEpayKey := operation_setting.EpayKey
+	originalPayMethods := operation_setting.PayMethods
+	t.Cleanup(func() {
+		setting.FastPayAddress = originalFastPayAddress
+		setting.FastPayMerchantNo = originalFastPayMerchantNo
+		setting.FastPayApiSecret = originalFastPayAPISecret
+		operation_setting.PayAddress = originalPayAddress
+		operation_setting.EpayId = originalEpayID
+		operation_setting.EpayKey = originalEpayKey
+		operation_setting.PayMethods = originalPayMethods
+	})
+}
+
+func TestResolveFastPayMethod_WhenOnlyFastPayIsConfigured(t *testing.T) {
+	preservePaymentGatewaySettings(t)
+	setting.FastPayAddress = "https://fastpay.example.com/fastpay-server"
+	setting.FastPayMerchantNo = "M123"
+	setting.FastPayApiSecret = "fastpay_secret"
+	operation_setting.PayAddress = "https://pay.example.com"
+	operation_setting.EpayId = "10001"
+	operation_setting.EpayKey = ""
+
+	method, ok := resolveFastPayMethod("alipay")
+	require.True(t, ok)
+	require.Equal(t, "alipay", method)
+}
+
+func TestResolveFastPayMethod_PrefixedMethodWinsWhenBothGatewaysAreConfigured(t *testing.T) {
+	preservePaymentGatewaySettings(t)
+	setting.FastPayAddress = "https://fastpay.example.com/fastpay-server"
+	setting.FastPayMerchantNo = "M123"
+	setting.FastPayApiSecret = "fastpay_secret"
+	operation_setting.PayAddress = "https://epay.example.com"
+	operation_setting.EpayId = "10001"
+	operation_setting.EpayKey = "epay_secret"
+
+	method, ok := resolveFastPayMethod("fastpay_wxpay")
+	require.True(t, ok)
+	require.Equal(t, "wxpay", method)
+
+	method, ok = resolveFastPayMethod("alipay")
+	require.False(t, ok)
+	require.Equal(t, "alipay", method)
+}
+
+func TestGetTopUpInfo_EnablesOnlineTopUpWhenOnlyFastPayIsConfigured(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	confirmPaymentComplianceForTest(t)
+	preservePaymentGatewaySettings(t)
+	setting.FastPayAddress = "https://fastpay.example.com/fastpay-server"
+	setting.FastPayMerchantNo = "M123"
+	setting.FastPayApiSecret = "fastpay_secret"
+	operation_setting.PayAddress = "https://pay.example.com"
+	operation_setting.EpayId = "10001"
+	operation_setting.EpayKey = ""
+	operation_setting.PayMethods = []map[string]string{{"name": "支付宝", "type": "alipay"}}
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	GetTopUpInfo(c)
+
+	var response struct {
+		Data struct {
+			EnableOnlineTopUp bool `json:"enable_online_topup"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	require.True(t, response.Data.EnableOnlineTopUp)
+}
 
 func TestFastPaySignAndVerify(t *testing.T) {
 	secret := "MY_SECRET_KEY_123"


### PR DESCRIPTION
Summary:
- route alipay and wxpay through FAST when Epay is not configured
- normalize explicit fastpay-prefixed methods before signing
- expose online top-up when FAST is configured
- add the FAST server repository as a submodule

Tests:
- go test ./controller -count=1

## Summary by Sourcery

改进支付路由和校验逻辑，以便在配置启用时正确选择并展示 FastPay 作为线上充值选项，同时强制使用受支持的支付方式，并将 FastPay 服务器作为子模块集成。

新功能：
- 当 FastPay 被配置为唯一的线上支付网关时，启用通过 FastPay 进行线上充值

缺陷修复：
- 在合适的情况下，将带有 FastPay 前缀的支付方式通过 FastPay 网关路由，而不是通过 Epay

改进优化：
- 规范 FastPay 支付方式名称，并将 FastPay 限制为仅支持的支付方式（支付宝和微信支付），适用于一次性支付和订阅支付
- 添加逻辑：当未配置 Epay 时，将 FastPay 选为默认线上支付网关；当同时配置了两个网关时，将无前缀的普通支付方式保持在 Epay 上

构建：
- 将 FastPay 服务器仓库作为 git 子模块添加到项目中

测试：
- 添加关于 FastPay 支付方式解析以及在仅配置 FastPay 时启用线上充值的单元测试

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve payment routing and validation so FastPay is correctly selected and exposed as an online top-up option when configured, while enforcing supported payment methods and integrating the FastPay server as a submodule.

New Features:
- Enable online top-up via FastPay when it is configured as the only online gateway

Bug Fixes:
- Route FastPay-prefixed payment methods through the FastPay gateway instead of Epay when appropriate

Enhancements:
- Normalize FastPay payment method names and restrict FastPay to supported methods (Alipay and WeChat Pay) for both one-off and subscription payments
- Add logic to select FastPay as the default online gateway when Epay is not configured while keeping plain methods on Epay when both gateways are available

Build:
- Add the FastPay server repository as a git submodule

Tests:
- Add unit tests for FastPay method resolution and enabling online top-up when only FastPay is configured

</details>