### PR TITLE
feat(home): add interactive gateway artwork

### DIFF
--- a/web/src/features/home/components/hero-art.tsx
+++ b/web/src/features/home/components/hero-art.tsx
@@ -1,0 +1,125 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import {
+  motion,
+  useMotionValue,
+  useReducedMotion,
+  useScroll,
+  useSpring,
+  useTransform,
+} from 'motion/react'
+import { useEffect, useRef, type PointerEvent } from 'react'
+
+import { HeaderLogo } from '@/components/layout/components/header-logo'
+
+import { normalizePointerPosition } from '../lib/hero-parallax'
+
+const POINTER_TRAVEL = 8
+const SPRING = { damping: 27, mass: 1, stiffness: 180 }
+
+interface HeroArtProps {
+  caption: string
+}
+
+export function HeroArt({ caption }: HeroArtProps) {
+  const figureRef = useRef<HTMLElement>(null)
+  const shouldReduceMotion = useReducedMotion()
+  const pointerX = useMotionValue(0)
+  const pointerY = useMotionValue(0)
+  const springX = useSpring(pointerX, SPRING)
+  const springY = useSpring(pointerY, SPRING)
+  const { scrollYProgress } = useScroll({
+    target: figureRef,
+    offset: ['start end', 'end start'],
+  })
+  const scrollY = useTransform(
+    scrollYProgress,
+    [0, 1],
+    shouldReduceMotion ? [0, 0] : [-6, 6]
+  )
+
+  const resetPointer = () => {
+    pointerX.set(0)
+    pointerY.set(0)
+  }
+
+  useEffect(() => {
+    if (shouldReduceMotion) {
+      pointerX.set(0)
+      pointerY.set(0)
+    }
+  }, [pointerX, pointerY, shouldReduceMotion])
+
+  const handlePointerMove = (event: PointerEvent<HTMLElement>) => {
+    if (
+      shouldReduceMotion ||
+      event.pointerType !== 'mouse' ||
+      !window.matchMedia('(pointer: fine)').matches
+    ) {
+      resetPointer()
+      return
+    }
+
+    const bounds = event.currentTarget.getBoundingClientRect()
+    pointerX.set(
+      normalizePointerPosition(event.clientX, bounds.left, bounds.width) *
+        POINTER_TRAVEL
+    )
+    pointerY.set(
+      normalizePointerPosition(event.clientY, bounds.top, bounds.height) *
+        POINTER_TRAVEL
+    )
+  }
+
+  return (
+    <figure
+      ref={figureRef}
+      onPointerMove={handlePointerMove}
+      onPointerLeave={resetPointer}
+      className='landing-animate-fade-up mx-auto w-full max-w-md border-2 border-[#141413] bg-[#D97757] p-5 opacity-0 [animation-delay:240ms] sm:p-7 lg:mr-8 lg:max-w-sm lg:-translate-y-3 lg:justify-self-end lg:rounded-[42%_58%_45%_55%/8%_12%_88%_92%]'
+    >
+      <motion.div style={{ y: shouldReduceMotion ? 0 : scrollY }}>
+        <motion.div
+          style={{
+            x: shouldReduceMotion ? 0 : springX,
+            y: shouldReduceMotion ? 0 : springY,
+          }}
+          className='will-change-transform'
+        >
+          <div className='ml-auto w-[82%] overflow-hidden rounded-[52%_48%_60%_40%/43%_58%_42%_57%] border-2 border-[#141413] bg-[#BCD1CA]'>
+            <HeaderLogo
+              src='/logo.png'
+              width={512}
+              height={512}
+              alt=''
+              loading={false}
+              logoLoaded
+              className='aspect-square size-full rounded-none object-cover transition-none'
+              decoding='async'
+              fetchPriority='high'
+            />
+          </div>
+        </motion.div>
+      </motion.div>
+      <figcaption className='mt-5 max-w-64 border-t border-[#141413] pt-3 text-xs leading-5 font-medium'>
+        {caption}
+      </figcaption>
+    </figure>
+  )
+}

--- a/web/src/features/home/components/sections/hero.tsx
+++ b/web/src/features/home/components/sections/hero.tsx
@@ -20,13 +20,10 @@ import { Link } from '@tanstack/react-router'
 import { ArrowRight, BookOpen } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-import { HeaderLogo } from '@/components/layout/components/header-logo'
 import { Button } from '@/components/ui/button'
 import { useStatus } from '@/hooks/use-status'
-import { toIntlLocale } from '@/i18n/languages'
-import { cn } from '@/lib/utils'
 
-import { isCjkLocale } from '../../lib/cjk-locale'
+import { HeroArt } from '../hero-art'
 
 interface HeroProps {
   isAuthenticated?: boolean
@@ -60,14 +57,10 @@ function DocsLink({ href, label }: { href: string; label: string }) {
 }
 
 export function Hero({ isAuthenticated = false }: HeroProps) {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const { status } = useStatus()
   const docsUrl =
     (status?.docs_link as string | undefined) || 'https://docs.newapi.pro'
-  const language = i18n.resolvedLanguage || i18n.language
-  const isCjk = isCjkLocale(language)
-  const documentLanguage = toIntlLocale(language)
-
   return (
     <section className='overflow-hidden bg-[#FAF9F5] px-5 pt-20 pb-16 text-[#141413] sm:px-8 sm:pt-28 sm:pb-24'>
       <div className='mx-auto grid max-w-6xl items-center gap-14 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.7fr)] lg:gap-20'>
@@ -76,15 +69,10 @@ export function Hero({ isAuthenticated = false }: HeroProps) {
             {t('AI Application Infrastructure Foundation')}
           </p>
           <h1
-            lang={documentLanguage}
-            className={cn(
-              'landing-animate-fade-up font-serif font-medium opacity-0 [animation-delay:60ms]',
-              isCjk
-                ? 'max-w-[11em] text-[clamp(2.5rem,5.2vw,4.25rem)] leading-[1.08] tracking-[-0.035em] [overflow-wrap:normal] [word-break:normal]'
-                : 'max-w-[13ch] text-[clamp(3rem,7vw,5.75rem)] leading-[0.94] tracking-[-0.055em]'
-            )}
+            lang='en'
+            className='landing-animate-fade-up max-w-[13ch] font-serif text-[clamp(3rem,7vw,5.75rem)] leading-[0.94] font-medium tracking-[-0.055em] opacity-0 [animation-delay:60ms]'
           >
-            {t('Unified API Gateway for')} {t('Vast Range of AI Models')}
+            Token Not Included
           </h1>
           <p className='landing-animate-fade-up mt-7 max-w-xl text-base leading-7 text-[#141413]/70 opacity-0 [animation-delay:120ms] sm:text-lg'>
             {t(
@@ -113,24 +101,7 @@ export function Hero({ isAuthenticated = false }: HeroProps) {
           </div>
         </div>
 
-        <figure className='landing-animate-fade-up mx-auto w-full max-w-md border-2 border-[#141413] bg-[#D97757] p-5 opacity-0 [animation-delay:240ms] sm:p-7 lg:mr-8 lg:max-w-sm lg:-translate-y-3 lg:justify-self-end lg:rounded-[42%_58%_45%_55%/8%_12%_88%_92%]'>
-          <div className='ml-auto w-[82%] overflow-hidden rounded-[52%_48%_60%_40%/43%_58%_42%_57%] border-2 border-[#141413] bg-[#BCD1CA]'>
-            <HeaderLogo
-              src='/logo.png'
-              width={512}
-              height={512}
-              alt=''
-              loading={false}
-              logoLoaded
-              className='aspect-square size-full rounded-none object-cover transition-none'
-              decoding='async'
-              fetchPriority='high'
-            />
-          </div>
-          <figcaption className='mt-5 max-w-64 border-t border-[#141413] pt-3 text-xs leading-5 font-medium'>
-            {t('Configure upstream providers and routing.')}
-          </figcaption>
-        </figure>
+        <HeroArt caption={t('Configure upstream providers and routing.')} />
       </div>
     </section>
   )

--- a/web/src/features/home/lib/hero-parallax.test.ts
+++ b/web/src/features/home/lib/hero-parallax.test.ts
@@ -19,28 +19,18 @@ For commercial licensing, please contact support@quantumnous.com
 import assert from 'node:assert/strict'
 import { describe, test } from 'node:test'
 
-import { isCjkLocale } from './cjk-locale'
+import { normalizePointerPosition } from './hero-parallax'
 
-describe('isCjkLocale', () => {
-  test('recognizes project and conventional Chinese/Japanese locale codes', () => {
-    const locales = ['zhCN', 'zhTW', 'zh', 'zh-CN', 'zh-Hant-TW', 'ja', 'ja-JP']
-    for (const locale of locales) {
-      assert.equal(isCjkLocale(locale), true, locale)
-    }
+describe('hero parallax pointer normalization', () => {
+  test('maps the bounds and midpoint to a normalized range', () => {
+    assert.equal(normalizePointerPosition(20, 20, 100), -1)
+    assert.equal(normalizePointerPosition(70, 20, 100), 0)
+    assert.equal(normalizePointerPosition(120, 20, 100), 1)
   })
 
-  test('does not misclassify unrelated or extended locale-like strings', () => {
-    const locales = [
-      'en',
-      'fr',
-      'zhCN-extra',
-      'zhTWfoo',
-      'japanese',
-      'zh-',
-      'ja-',
-    ]
-    for (const locale of locales) {
-      assert.equal(isCjkLocale(locale), false, locale)
-    }
+  test('clamps out-of-bounds positions and handles empty bounds', () => {
+    assert.equal(normalizePointerPosition(-100, 20, 100), -1)
+    assert.equal(normalizePointerPosition(500, 20, 100), 1)
+    assert.equal(normalizePointerPosition(20, 20, 0), 0)
   })
 })

--- a/web/src/features/home/lib/hero-parallax.ts
+++ b/web/src/features/home/lib/hero-parallax.ts
@@ -16,9 +16,12 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-const CJK_LOCALE_PATTERN =
-  /^(?:zh(?:cn|tw|-[a-z0-9]+(?:-[a-z0-9]+)*)?|ja(?:-[a-z0-9]+(?:-[a-z0-9]+)*)?)$/i
-
-export function isCjkLocale(locale: string) {
-  return CJK_LOCALE_PATTERN.test(locale.trim())
+export function normalizePointerPosition(
+  pointer: number,
+  start: number,
+  size: number
+) {
+  if (size <= 0) return 0
+  const normalized = ((pointer - start) / size) * 2 - 1
+  return Math.max(-1, Math.min(1, normalized))
 }


### PR DESCRIPTION
## Summary

- replace the translated hero headline with the exact title `Token Not Included`
- add pointer-driven artwork parallax capped at ±8 px and scroll parallax capped at ±6 px
- keep the artwork static for reduced-motion preferences and touch/coarse-pointer input
- replace the superseded CJK locale helper tests with two focused pointer-normalization tests

## Validation

The implementation worker reported:

- focused parallax tests — PASS (2 tests)
- typecheck — PASS
- production build — PASS
- targeted lint on touched files — PASS
- targeted format check — PASS
- `git diff --check` — PASS
- forbidden home tech-blue/effect token scan — CLEAN

## Residual risk

No local browser screenshot was available. The interaction and motion safeguards were verified at code and test level, but final visual confirmation remains pending deployment.

## Summary by Sourcery

引入一个带有基于运动视差效果的交互式主视觉插画组件，并更新首页主视觉标题文案。

新功能：
- 新增可复用的 `HeroArt` 组件，为首页主视觉插画提供基于滚动和指针的视差动效，并为“减少动态效果”的用户以及非精细指针设备提供优雅降级。

增强改进：
- 将首页主视觉标题简化为固定英文标题，并移除针对中日韩（CJK）语言的特定布局处理。
- 抽取指针位置归一化逻辑到独立工具函数中，并在主视觉插画视差效果中复用。

测试：
- 用更聚焦的单元测试替换旧的 CJK 语言环境辅助工具测试，专门验证用于主视觉视差效果的指针位置归一化逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an interactive hero artwork component with motion-based parallax and update the home hero headline copy.

New Features:
- Add a reusable HeroArt component providing scroll- and pointer-driven parallax motion for the home hero artwork, with graceful fallback for reduced-motion users and non-fine pointers.

Enhancements:
- Simplify the home hero heading to a fixed English title and remove CJK-specific layout handling.
- Extract pointer position normalization into a dedicated utility used by the hero artwork parallax effect.

Tests:
- Replace legacy CJK locale helper tests with focused unit tests for pointer position normalization used by the hero parallax.

</details>