### PR TITLE
feat(deploy): split frontend and standardize valkey

### DIFF
--- a/deploy/check-frontend-split.sh
+++ b/deploy/check-frontend-split.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+config=$repo/deploy/nginx/lmm-api-locations.conf
+release=$repo/deploy/frontend-release.sh
+
+fail() { printf 'split-check: %s\n' "$*" >&2; exit 1; }
+assert_literal() { grep -Fq -- "$1" "$2" || fail "$2 is missing: $1"; }
+
+for route in '/api/' '/v1/' '/v1beta/' '/pg/' '/mj/' '/suno/' '/kling/v1/' '/jimeng' '/dashboard/'; do
+  assert_literal "$route" "$config"
+done
+assert_literal '^/[^/]+/mj(?:/|$)' "$config"
+assert_literal 'location ^~ /oauth/' "$config"
+assert_literal 'location = /terms' "$config"
+assert_literal 'location = /privacy' "$config"
+assert_literal 'return 302 /user-agreement' "$config"
+assert_literal 'return 302 /privacy-policy' "$config"
+assert_literal 'alias /srv/lmm-api-frontend/assets/' "$config"
+assert_literal 'location = /dashboard/billing/subscription' "$config"
+assert_literal 'location = /dashboard/billing/usage' "$config"
+assert_literal 'jpe?g|js|json|map|png|svg|webp|woff2?' "$config"
+assert_literal 'max-age=31536000, immutable' "$config"
+assert_literal 'no-cache, must-revalidate' "$config"
+assert_literal 'proxy_buffering off' "$config"
+assert_literal 'Connection $connection_upgrade' "$config"
+assert_literal 'mv -Tf -- "$temp" "$root/current"' "$release"
+assert_literal 'flock -n 9' "$release"
+assert_literal 'immutable asset collision with different content' "$release"
+assert_literal 'preflight_assets "$stage/static"' "$release"
+if grep -Fq 'location ^~ /dashboard/' "$config"; then
+  fail 'broad /dashboard/ proxy would swallow frontend dashboard routes'
+fi
+
+# Keep the nginx split synchronized with every top-level Gin router family.
+while IFS= read -r route; do
+  case $route in
+    /|/api|/api/*|/v1|/v1/*|/v1beta|/v1beta/*|/pg|/pg/*|/mj|/mj/*|/suno|/suno/*|/kling/v1|/kling/v1/*|jimeng|/jimeng|/jimeng/*|/dashboard|/dashboard/*|/:mode/mj) ;;
+    *) fail "unclassified backend router family: $route" ;;
+  esac
+done < <(sed -nE 's/.*router\.Group\("?([^" ]+)"?\).*/\1/p' "$repo"/router/*.go | sort -u)
+
+bash -n "$release"
+printf 'frontend/backend split checks passed\n'

--- a/deploy/check-frontend-split.sh
+++ b/deploy/check-frontend-split.sh
@@ -15,11 +15,25 @@ assert_literal '^/[^/]+/mj(?:/|$)' "$config"
 assert_literal 'location ^~ /oauth/' "$config"
 assert_literal 'location = /terms' "$config"
 assert_literal 'location = /privacy' "$config"
-assert_literal 'return 302 /user-agreement' "$config"
-assert_literal 'return 302 /privacy-policy' "$config"
+assert_literal 'alias /var/www/api.lmm.best/legal/terms.html;' "$config"
+assert_literal 'alias /var/www/api.lmm.best/legal/privacy.html;' "$config"
+assert_literal 'default_type text/html;' "$config"
+assert_literal 'charset utf-8;' "$config"
+assert_literal 'add_header X-Content-Type-Options nosniff always;' "$config"
+[[ $(grep -Fc 'default_type text/html;' "$config") == 2 ]] ||
+  fail 'each exact legal alias must set the HTML content type'
+[[ $(grep -Fc 'charset utf-8;' "$config") == 2 ]] ||
+  fail 'each exact legal alias must set UTF-8'
+[[ $(grep -Fc 'add_header X-Content-Type-Options nosniff always;' "$config") == 2 ]] ||
+  fail 'each exact legal alias must set nosniff'
+if grep -Eq 'return 30[1278] /(user-agreement|privacy-policy)' "$config"; then
+  fail 'legal aliases must not redirect into the SPA'
+fi
 assert_literal 'alias /srv/lmm-api-frontend/assets/' "$config"
 assert_literal 'location = /dashboard/billing/subscription' "$config"
 assert_literal 'location = /dashboard/billing/usage' "$config"
+assert_literal 'location = /jimeng ' "$config"
+assert_literal 'location ^~ /jimeng/' "$config"
 assert_literal 'jpe?g|js|json|map|png|svg|webp|woff2?' "$config"
 assert_literal 'max-age=31536000, immutable' "$config"
 assert_literal 'no-cache, must-revalidate' "$config"
@@ -31,6 +45,9 @@ assert_literal 'immutable asset collision with different content' "$release"
 assert_literal 'preflight_assets "$stage/static"' "$release"
 if grep -Fq 'location ^~ /dashboard/' "$config"; then
   fail 'broad /dashboard/ proxy would swallow frontend dashboard routes'
+fi
+if grep -Fq 'location ^~ /jimeng {' "$config"; then
+  fail 'broad /jimeng prefix would also proxy /jimengx'
 fi
 
 # Keep the nginx split synchronized with every top-level Gin router family.

--- a/deploy/check-frontend-split.sh
+++ b/deploy/check-frontend-split.sh
@@ -3,7 +3,9 @@ set -Eeuo pipefail
 
 repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
 config=$repo/deploy/nginx/lmm-api-locations.conf
+mime_types=$repo/deploy/nginx/mime.types
 release=$repo/deploy/frontend-release.sh
+nginx_installer=$repo/deploy/nginx/install-nginx-split.sh
 
 fail() { printf 'split-check: %s\n' "$*" >&2; exit 1; }
 assert_literal() { grep -Fq -- "$1" "$2" || fail "$2 is missing: $1"; }
@@ -13,6 +15,16 @@ for route in '/api/' '/v1/' '/v1beta/' '/pg/' '/mj/' '/suno/' '/kling/v1/' '/jim
 done
 assert_literal '^/[^/]+/mj(?:/|$)' "$config"
 assert_literal 'location ^~ /oauth/' "$config"
+assert_literal 'include /etc/nginx/lmm-api-mime.types;' "$config"
+assert_literal 'default_type application/octet-stream;' "$config"
+if grep -Fq 'include /etc/nginx/mime.types;' "$config"; then
+  fail 'site config must not depend on or manage the global nginx MIME map'
+fi
+assert_literal 'application/javascript               js mjs;' "$mime_types"
+assert_literal 'text/css                              css;' "$mime_types"
+assert_literal 'application/json                     json map;' "$mime_types"
+assert_literal 'image/svg+xml                         svg svgz;' "$mime_types"
+assert_literal 'font/woff2                            woff2;' "$mime_types"
 assert_literal 'location = /terms' "$config"
 assert_literal 'location = /privacy' "$config"
 assert_literal 'alias /var/www/api.lmm.best/legal/terms.html;' "$config"
@@ -43,6 +55,12 @@ assert_literal 'mv -Tf -- "$temp" "$root/current"' "$release"
 assert_literal 'flock -n 9' "$release"
 assert_literal 'immutable asset collision with different content' "$release"
 assert_literal 'preflight_assets "$stage/static"' "$release"
+assert_literal 'flock -n 9' "$nginx_installer"
+assert_literal 'mv -Tf -- "$temp" "$target"' "$nginx_installer"
+assert_literal 'nginx -t' "$nginx_installer"
+assert_literal 'systemctl reload nginx' "$nginx_installer"
+assert_literal 'restore_backup "$backup"' "$nginx_installer"
+assert_literal 'MIME_TARGET=$ROOT_PREFIX/etc/nginx/lmm-api-mime.types' "$nginx_installer"
 if grep -Fq 'location ^~ /dashboard/' "$config"; then
   fail 'broad /dashboard/ proxy would swallow frontend dashboard routes'
 fi
@@ -59,4 +77,22 @@ while IFS= read -r route; do
 done < <(sed -nE 's/.*router\.Group\("?([^" ]+)"?\).*/\1/p' "$repo"/router/*.go | sort -u)
 
 bash -n "$release"
+bash -n "$nginx_installer"
+if command -v nginx >/dev/null; then
+  LMM_NGINX_MIME_TYPES="$mime_types" "$repo/deploy/test-nginx-mime.sh"
+else
+  printf 'split-check: nginx not installed; MIME integration test skipped\n' >&2
+fi
+"$repo/deploy/test-nginx-installer.sh"
+
+# The behavioral test must consume the tracked map, not an unrelated system
+# file. Corrupting a copy of that map must make nginx validation fail.
+mime_test_root=$(mktemp -d)
+trap 'rm -rf -- "$mime_test_root"' EXIT
+cp -- "$mime_types" "$mime_test_root/mime.types"
+printf 'this is not nginx syntax\n' >>"$mime_test_root/mime.types"
+if command -v nginx >/dev/null &&
+   LMM_NGINX_MIME_TYPES="$mime_test_root/mime.types" "$repo/deploy/test-nginx-mime.sh" >/dev/null 2>&1; then
+  fail 'corrupted tracked MIME map unexpectedly passed nginx validation'
+fi
 printf 'frontend/backend split checks passed\n'

--- a/deploy/frontend-release.sh
+++ b/deploy/frontend-release.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly DEFAULT_ROOT=/srv/lmm-api-frontend
+readonly DEFAULT_KEEP=3
+
+usage() {
+  cat <<'EOF'
+Usage:
+  frontend-release.sh publish --source DIR --release ID [--root DIR] [--keep N] [--dry-run]
+  frontend-release.sh rollback [--release ID] [--root DIR] [--dry-run]
+
+Publishes a pre-built frontend using a same-filesystem staging directory and an
+atomic `current` symlink replacement. Run as a user allowed to write ROOT.
+EOF
+}
+
+die() { printf 'frontend-release: %s\n' "$*" >&2; exit 1; }
+run() { if (( dry_run )); then printf '+ '; printf '%q ' "$@"; printf '\n'; else "$@"; fi; }
+
+validate_id() {
+  [[ $1 =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] ||
+    die "invalid release id: $1"
+}
+
+validate_tree() {
+  local tree=$1 ref path
+  [[ -f $tree/index.html ]] || die "missing index.html in $tree"
+  if find "$tree" -type l -print -quit | grep -q .; then
+    die 'release trees must not contain symlinks'
+  fi
+  while IFS= read -r ref; do
+    ref=${ref%%\?*}; ref=${ref%%\#*}; ref=${ref#/}
+    [[ -z $ref || $ref == http:* || $ref == https:* || $ref == data:* || $ref == //* ]] && continue
+    path=$tree/$ref
+    [[ -f $path ]] || die "index.html references missing file: $ref"
+    case $(realpath -m -- "$path") in "$tree"/*) ;; *) die "reference escapes release: $ref";; esac
+  done < <(grep -oE "(src|href)=[\"'][^\"']+[\"']" "$tree/index.html" | sed -E "s/^[^=]+=[\"'](.*)[\"']$/\\1/")
+}
+
+root=$DEFAULT_ROOT keep=$DEFAULT_KEEP source= release= dry_run=0
+[[ $# -gt 0 ]] || { usage; exit 2; }
+action=$1; shift
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --source) [[ $# -ge 2 ]] || die '--source needs a value'; source=$2; shift 2 ;;
+    --release) [[ $# -ge 2 ]] || die '--release needs a value'; release=$2; shift 2 ;;
+    --root) [[ $# -ge 2 ]] || die '--root needs a value'; root=$2; shift 2 ;;
+    --keep) [[ $# -ge 2 ]] || die '--keep needs a value'; keep=$2; shift 2 ;;
+    --dry-run) dry_run=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[[ $root = /* && $root != / ]] || die '--root must be an absolute, non-root path'
+[[ $keep =~ ^[1-9][0-9]*$ ]] || die '--keep must be a positive integer'
+
+releases=$root/releases
+staging_root=$root/.staging
+lock_file=$root/.release.lock
+run mkdir -p -- "$releases" "$staging_root"
+if (( dry_run )); then exec 9>/dev/null; else exec 9>"$lock_file"; fi
+flock -n 9 || die 'another frontend release operation is running'
+
+switch_current() {
+  local target=$1 temp=$root/.current.$$
+  run ln -s -- "releases/$target" "$temp"
+  run mv -Tf -- "$temp" "$root/current"
+}
+
+preflight_assets() {
+  local source_static=$1 asset rel destination
+  [[ -d $source_static ]] || return 0
+  while IFS= read -r -d '' asset; do
+    rel=${asset#"$source_static"/}
+    destination=$root/assets/$rel
+    if [[ -e $destination ]]; then
+      cmp -s -- "$asset" "$destination" ||
+        die "immutable asset collision with different content: static/$rel"
+    fi
+  done < <(find "$source_static" -type f -print0)
+}
+
+publish_assets() {
+  local source_static=$1 asset rel destination temp parent probe installed_count=0 i
+  local -a installed=() created_dirs=()
+  rollback_installed_assets() {
+    rm -f -- "${installed[@]}"
+    for ((i=0; i<${#created_dirs[@]}; i++)); do
+      rmdir -- "${created_dirs[i]}" 2>/dev/null || true
+    done
+  }
+  [[ -d $source_static ]] || return 0
+  while IFS= read -r -d '' asset; do
+    rel=${asset#"$source_static"/}
+    destination=$root/assets/$rel
+    [[ -e $destination ]] && continue
+    parent=$(dirname -- "$destination")
+    probe=$parent
+    while [[ ! -d $probe && $probe == "$root/assets"/* ]]; do
+      created_dirs+=("$probe")
+      probe=$(dirname -- "$probe")
+    done
+    if ! run mkdir -p -- "$parent"; then
+      (( dry_run )) || rollback_installed_assets
+      return 1
+    fi
+    temp=$destination.tmp.$$
+    if ! run cp -- "$asset" "$temp" ||
+       ! run chmod a=r -- "$temp" ||
+       ! run mv -T -- "$temp" "$destination"; then
+      if (( ! dry_run )); then rm -f -- "$temp"; rollback_installed_assets; fi
+      return 1
+    fi
+    installed+=("$destination")
+    ((installed_count += 1))
+    if [[ ${LMM_FRONTEND_TEST_FAIL_AFTER_ASSETS:-} == "$installed_count" ]]; then
+      (( dry_run )) || rollback_installed_assets
+      die "injected asset publish failure after $installed_count files"
+    fi
+  done < <(find "$source_static" -type f -print0)
+}
+
+case $action in
+  publish)
+    [[ -n $source && -n $release ]] || die 'publish requires --source and --release'
+    validate_id "$release"
+    source=$(realpath -- "$source")
+    validate_tree "$source"
+    target=$releases/$release
+    [[ ! -e $target ]] || die "release already exists: $release"
+    stage=$staging_root/$release.$$
+    run mkdir -- "$stage"
+    run cp -a -- "$source/." "$stage/"
+    if (( ! dry_run )); then validate_tree "$stage"; fi
+    if (( dry_run )); then
+      preflight_assets "$source/static"
+      publish_assets "$source/static"
+    else
+      preflight_assets "$stage/static"
+      publish_assets "$stage/static"
+    fi
+    run mv -T -- "$stage" "$target"
+    run chmod -R a=rX -- "$target"
+    run find "$target" -type d -exec chmod u+w {} +
+    switch_current "$release"
+    ;;
+  rollback)
+    if [[ -z $release ]]; then
+      current=
+      [[ -L $root/current ]] && current=$(basename -- "$(readlink -- "$root/current")")
+      mapfile -t candidates < <(find "$releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %f\n' | sort -nr | awk -v current="$current" '$2 != current { print $2 }')
+      [[ ${#candidates[@]} -gt 0 ]] || die 'no previous release is available'
+      release=${candidates[0]}
+    fi
+    validate_id "$release"
+    [[ -d $releases/$release ]] || die "unknown release: $release"
+    validate_tree "$releases/$release"
+    switch_current "$release"
+    ;;
+  *) usage; die "unknown action: $action" ;;
+esac
+
+if (( ! dry_run )); then
+  current=$(basename -- "$(readlink -- "$root/current")")
+  mapfile -t stale < <(find "$releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %f\n' | sort -nr | awk -v keep="$keep" -v current="$current" '$2 != current { seen++; if (seen >= keep) print $2 }')
+  for old in "${stale[@]}"; do rm -rf -- "$releases/$old"; done
+  printf 'current=%s\n' "$current"
+fi

--- a/deploy/nginx/http-map.conf
+++ b/deploy/nginx/http-map.conf
@@ -1,0 +1,5 @@
+# Include once in nginx's `http` context (not inside a server block).
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}

--- a/deploy/nginx/install-nginx-split.sh
+++ b/deploy/nginx/install-nginx-split.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_PREFIX=
+if [[ -n ${LMM_NGINX_TEST_ROOT:-} ]]; then
+  [[ ${LMM_NGINX_TEST_MODE:-} == 1 ]] || { printf 'test root requires LMM_NGINX_TEST_MODE=1\n' >&2; exit 2; }
+  [[ $LMM_NGINX_TEST_ROOT = /* && $LMM_NGINX_TEST_ROOT != / && -d $LMM_NGINX_TEST_ROOT ]] || { printf 'unsafe test root\n' >&2; exit 2; }
+  ROOT_PREFIX=${LMM_NGINX_TEST_ROOT%/}
+fi
+readonly ROOT_PREFIX
+readonly LOCK=$ROOT_PREFIX/run/lock/lmm-api-nginx-deploy.lock
+readonly BACKUP_ROOT=$ROOT_PREFIX/var/lib/lmm-api-nginx-deploy/backups
+readonly MIME_TARGET=$ROOT_PREFIX/etc/nginx/lmm-api-mime.types
+readonly MAP_TARGET=$ROOT_PREFIX/etc/nginx/lmm-api-http-map.conf
+readonly LOCATIONS_TARGET=$ROOT_PREFIX/etc/nginx/lmm-api-locations.conf
+readonly SERVER_TARGET=$ROOT_PREFIX/etc/nginx/conf.d/new-api.conf
+INSTALL_OWNER=root
+INSTALL_GROUP=root
+if [[ ${LMM_NGINX_TEST_MODE:-} == 1 ]]; then
+  INSTALL_OWNER=$(id -u)
+  INSTALL_GROUP=$(id -g)
+fi
+readonly INSTALL_OWNER INSTALL_GROUP
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+declare -Ar SOURCES=(
+  [mime]="$SCRIPT_DIR/mime.types"
+  [map]="$SCRIPT_DIR/http-map.conf"
+  [locations]="$SCRIPT_DIR/lmm-api-locations.conf"
+  [server]="$SCRIPT_DIR/new-api.conf"
+)
+declare -Ar TARGETS=(
+  [mime]="$MIME_TARGET"
+  [map]="$MAP_TARGET"
+  [locations]="$LOCATIONS_TARGET"
+  [server]="$SERVER_TARGET"
+)
+readonly -a KEYS=(mime map locations server)
+
+log() { printf '[lmm-api-nginx] %s\n' "$*" >&2; }
+die() { log "$*"; exit 1; }
+
+atomic_install() {
+  local source=$1 target=$2 mode=${3:-0644} owner=${4:-$INSTALL_OWNER} group=${5:-$INSTALL_GROUP} temp status
+  temp=$target.tmp.$$
+  install -o "$owner" -g "$group" -m "$mode" -- "$source" "$temp" || return
+  mv -Tf -- "$temp" "$target" && return 0
+  status=$?
+  rm -f -- "$temp"
+  return "$status"
+}
+
+capture_backup() {
+  local backup=$1 key target mode owner group
+  : >"$backup/manifest.tmp" || return
+  for key in "${KEYS[@]}"; do
+    target=${TARGETS[$key]}
+    if [[ -e $target || -L $target ]]; then
+      [[ -f $target && ! -L $target ]] || { log "unsafe existing target: $target"; return 1; }
+      cp -a -- "$target" "$backup/$key" || return
+      mode=$(stat -c '%a' "$target") || return
+      owner=$(stat -c '%u' "$target") || return
+      group=$(stat -c '%g' "$target") || return
+      printf '%s present %s %s %s\n' "$key" "$mode" "$owner" "$group" >>"$backup/manifest.tmp" || return
+    else
+      printf '%s absent - - -\n' "$key" >>"$backup/manifest.tmp" || return
+    fi
+  done
+  mv -Tf -- "$backup/manifest.tmp" "$backup/manifest" || return
+}
+
+deploy_candidate() {
+  local key
+  for key in "${KEYS[@]}"; do
+    atomic_install "${SOURCES[$key]}" "${TARGETS[$key]}" || return
+  done
+  nginx -t || return
+  systemctl reload nginx || return
+  systemctl is-active --quiet nginx || return
+}
+
+restore_backup() {
+  local backup=$1 key state mode owner group target
+  [[ -f $backup/manifest ]] || return 1
+  while read -r key state mode owner group; do
+    case $key in mime|map|locations|server) ;; *) return 1 ;; esac
+    target=${TARGETS[$key]}
+    case $state in
+      present)
+        [[ -f $backup/$key && $mode =~ ^[0-7]{3,4}$ && $owner =~ ^[0-9]+$ && $group =~ ^[0-9]+$ ]] || return 1
+        atomic_install "$backup/$key" "$target" "$mode" "$owner" "$group" || return
+        ;;
+      absent) rm -f -- "$target" || return ;;
+      *) return 1 ;;
+    esac
+  done <"$backup/manifest"
+  nginx -t || return
+  systemctl reload nginx || return
+  systemctl is-active --quiet nginx || return
+}
+
+[[ ${1:-} == install && $# == 1 ]] || die 'usage: install-nginx-split.sh install'
+[[ $EUID == 0 || ${LMM_NGINX_TEST_MODE:-} == 1 ]] || die 'must run as root'
+for tool in flock install mv cp rm openssl nginx systemctl date mkdir chmod stat; do
+  command -v "$tool" >/dev/null || die "missing required command: $tool"
+done
+for key in "${KEYS[@]}"; do
+  [[ -f ${SOURCES[$key]} && ! -L ${SOURCES[$key]} ]] || die "missing or unsafe source: ${SOURCES[$key]}"
+done
+
+install -d -o "$(id -u)" -g "$(id -g)" -m 0750 "$BACKUP_ROOT" "$(dirname -- "$LOCK")"
+exec 9>"$LOCK"
+flock -n 9 || die 'another nginx deployment is running'
+systemctl is-active --quiet nginx || die 'nginx must be active before deployment'
+
+backup_id=$(date -u +%Y%m%dT%H%M%SZ)-$(date -u +%N)-$(openssl rand -hex 8)
+[[ $backup_id =~ ^[0-9]{8}T[0-9]{6}Z-[0-9]{9}-[0-9a-f]{16}$ ]] || die 'failed to generate safe backup id'
+backup=$BACKUP_ROOT/$backup_id
+mkdir -- "$backup" || die 'failed to reserve unique backup directory'
+chmod 0700 "$backup"
+capture_backup "$backup" || die "failed to capture backup: $backup_id"
+
+deploy_status=0
+deploy_candidate || deploy_status=$?
+if (( deploy_status == 0 )); then
+  log "deployment healthy; backup=$backup_id"
+  exit 0
+fi
+
+log "candidate deployment failed with status $deploy_status; restoring $backup_id"
+restore_status=0
+restore_backup "$backup" || restore_status=$?
+if (( restore_status != 0 )); then
+  die "candidate failed ($deploy_status) and restore verification failed ($restore_status)"
+fi
+die "candidate failed ($deploy_status); previous nginx configuration restored and verified"

--- a/deploy/nginx/lmm-api-locations.conf
+++ b/deploy/nginx/lmm-api-locations.conf
@@ -28,7 +28,8 @@ location ^~ /pg/ { try_files /.__lmm_backend__ @lmm_api_backend; }
 location ^~ /mj/ { try_files /.__lmm_backend__ @lmm_api_backend; }
 location ^~ /suno/ { try_files /.__lmm_backend__ @lmm_api_backend; }
 location ^~ /kling/v1/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /jimeng { try_files /.__lmm_backend__ @lmm_api_backend; }
+location = /jimeng { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /jimeng/ { try_files /.__lmm_backend__ @lmm_api_backend; }
 location = /dashboard/billing/subscription { try_files /.__lmm_backend__ @lmm_api_backend; }
 location = /dashboard/billing/usage { try_files /.__lmm_backend__ @lmm_api_backend; }
 
@@ -54,8 +55,18 @@ location ~ ^/(?:manifest(?:\.webmanifest|\.json)?|service-worker\.js|sw\.js)$ {
 
 # These are client-side routes, including the browser half of OAuth.
 location ^~ /oauth/ { try_files /index.html =404; add_header Cache-Control "no-cache, must-revalidate" always; }
-location = /terms { return 302 /user-agreement; }
-location = /privacy { return 302 /privacy-policy; }
+location = /terms {
+    alias /var/www/api.lmm.best/legal/terms.html;
+    default_type text/html;
+    charset utf-8;
+    add_header X-Content-Type-Options nosniff always;
+}
+location = /privacy {
+    alias /var/www/api.lmm.best/legal/privacy.html;
+    default_type text/html;
+    charset utf-8;
+    add_header X-Content-Type-Options nosniff always;
+}
 
 # Public root assets are not content-addressed and must revalidate. Missing
 # asset-looking URLs are 404s rather than successful responses containing HTML.

--- a/deploy/nginx/lmm-api-locations.conf
+++ b/deploy/nginx/lmm-api-locations.conf
@@ -1,0 +1,71 @@
+# Include inside the production TLS `server` block.
+# The frontend release script atomically updates this root's `current` symlink.
+root /srv/lmm-api-frontend/current;
+
+# All backend traffic reaches one named location so WebSocket upgrades and SSE
+# streaming retain the original request URI and are never served by the SPA.
+location @lmm_api_backend {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+    proxy_buffering off;
+    proxy_read_timeout 3600s;
+}
+
+# Administrative API, OAuth API callbacks, relay APIs, and compatibility APIs.
+location ^~ /api/ { try_files /.__lmm_backend__ @lmm_api_backend; }
+location = /api { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /v1/ { try_files /.__lmm_backend__ @lmm_api_backend; }
+location = /v1 { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /v1beta/ { try_files /.__lmm_backend__ @lmm_api_backend; }
+location = /v1beta { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /pg/ { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /mj/ { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /suno/ { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /kling/v1/ { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ^~ /jimeng { try_files /.__lmm_backend__ @lmm_api_backend; }
+location = /dashboard/billing/subscription { try_files /.__lmm_backend__ @lmm_api_backend; }
+location = /dashboard/billing/usage { try_files /.__lmm_backend__ @lmm_api_backend; }
+
+# Gin's dynamic /:mode/mj group. Restrict mode to one path segment.
+location ~ ^/[^/]+/mj(?:/|$) { try_files /.__lmm_backend__ @lmm_api_backend; }
+
+# Build-generated assets are content-addressed. A missing asset must be a 404,
+# never index.html, otherwise an old page can receive HTML as JS or CSS.
+location ^~ /static/ {
+    alias /srv/lmm-api-frontend/assets/;
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+}
+
+# Entry points and metadata must revalidate across an atomic release switch.
+location = /index.html {
+    try_files /index.html =404;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+}
+location ~ ^/(?:manifest(?:\.webmanifest|\.json)?|service-worker\.js|sw\.js)$ {
+    try_files $uri =404;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+}
+
+# These are client-side routes, including the browser half of OAuth.
+location ^~ /oauth/ { try_files /index.html =404; add_header Cache-Control "no-cache, must-revalidate" always; }
+location = /terms { return 302 /user-agreement; }
+location = /privacy { return 302 /privacy-policy; }
+
+# Public root assets are not content-addressed and must revalidate. Missing
+# asset-looking URLs are 404s rather than successful responses containing HTML.
+location ~* \.(?:avif|css|gif|ico|jpe?g|js|json|map|png|svg|webp|woff2?)$ {
+    try_files $uri =404;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+}
+
+# Serve real public files first; otherwise hand navigation to the SPA.
+location / {
+    try_files $uri $uri/ /index.html;
+    add_header Cache-Control "no-cache, must-revalidate" always;
+}

--- a/deploy/nginx/lmm-api-locations.conf
+++ b/deploy/nginx/lmm-api-locations.conf
@@ -1,5 +1,9 @@
 # Include inside the production TLS `server` block.
 # The frontend release script atomically updates this root's `current` symlink.
+# Load MIME mappings at server scope: production intentionally has no global
+# mime.types include, and ES modules are rejected when served as octet-stream.
+include /etc/nginx/lmm-api-mime.types;
+default_type application/octet-stream;
 root /srv/lmm-api-frontend/current;
 
 # All backend traffic reaches one named location so WebSocket upgrades and SSE

--- a/deploy/nginx/mime.types
+++ b/deploy/nginx/mime.types
@@ -1,0 +1,21 @@
+types {
+    text/html                             html htm;
+    text/css                              css;
+    text/plain                            txt;
+    application/javascript               js mjs;
+    application/json                     json map;
+    application/manifest+json            webmanifest;
+    application/wasm                     wasm;
+    application/xml                      xml;
+    image/avif                            avif;
+    image/gif                             gif;
+    image/jpeg                            jpeg jpg;
+    image/png                             png;
+    image/svg+xml                         svg svgz;
+    image/webp                            webp;
+    image/x-icon                          ico;
+    font/otf                              otf;
+    font/ttf                              ttf;
+    font/woff                             woff;
+    font/woff2                            woff2;
+}

--- a/deploy/nginx/new-api.conf
+++ b/deploy/nginx/new-api.conf
@@ -1,0 +1,18 @@
+include /etc/nginx/lmm-api-http-map.conf;
+
+server {
+    listen 443 ssl;
+    listen 9000 ssl;
+    http2 on;
+    server_name api.lmm.best;
+
+    ssl_certificate /etc/letsencrypt/live/api.lmm.best/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.lmm.best/privkey.pem;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:NewApiSSL:10m;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    client_max_body_size 64m;
+
+    include /etc/nginx/lmm-api-locations.conf;
+}

--- a/deploy/test-frontend-release.sh
+++ b/deploy/test-frontend-release.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+work=$(mktemp -d)
+trap 'rm -rf -- "$work"' EXIT
+
+make_build() {
+  local name=$1 asset=$2 body=$3
+  mkdir -p -- "$work/$name/static/js"
+  printf '<script src="/static/js/%s"></script>\n' "$asset" >"$work/$name/index.html"
+  printf '%s\n' "$body" >"$work/$name/static/js/$asset"
+}
+
+snapshot_store() {
+  find "$work/root/assets" -printf '%y %P\n'
+  find "$work/root/assets" -type f -exec sha256sum {} +
+}
+
+make_build first old.111.js old
+make_build second new.222.js new
+
+"$repo/deploy/frontend-release.sh" publish --root "$work/root" --source "$work/first" --release first --keep 2
+"$repo/deploy/frontend-release.sh" publish --root "$work/root" --source "$work/second" --release second --keep 2
+
+[[ $(readlink -- "$work/root/current") == releases/second ]]
+[[ $(<"$work/root/assets/js/old.111.js") == old ]]
+[[ $(<"$work/root/assets/js/new.222.js") == new ]]
+
+# A browser holding the old index can still lazy-load its old hashed chunk.
+grep -Fq '/static/js/old.111.js' "$work/root/releases/first/index.html"
+
+"$repo/deploy/frontend-release.sh" rollback --root "$work/root" --release first --keep 2
+[[ $(readlink -- "$work/root/current") == releases/first ]]
+
+make_build collision old.111.js changed
+printf 'new-before-conflict\n' >"$work/collision/static/js/aaa.000.js"
+before_collision=$(snapshot_store | sort)
+if "$repo/deploy/frontend-release.sh" publish --root "$work/root" --source "$work/collision" --release collision --keep 2 >"$work/out" 2>"$work/err"; then
+  printf 'expected immutable asset collision to fail\n' >&2
+  exit 1
+fi
+grep -Fq 'immutable asset collision with different content' "$work/err"
+[[ $(readlink -- "$work/root/current") == releases/first ]]
+[[ ! -e $work/root/releases/collision ]]
+after_collision=$(snapshot_store | sort)
+[[ $before_collision == "$after_collision" ]]
+
+# A failure after one successful asset installation rolls back the whole batch.
+make_build injected injected.333.js injected
+mkdir -p "$work/injected/static/lazy/deep"
+printf 'another\n' >"$work/injected/static/lazy/deep/another.444.js"
+before_injected=$(snapshot_store | sort)
+if LMM_FRONTEND_TEST_FAIL_AFTER_ASSETS=2 \
+  "$repo/deploy/frontend-release.sh" publish --root "$work/root" --source "$work/injected" --release injected --keep 2 >"$work/out" 2>"$work/err"; then
+  printf 'expected injected asset failure\n' >&2
+  exit 1
+fi
+grep -Fq 'injected asset publish failure' "$work/err"
+after_injected=$(snapshot_store | sort)
+[[ $before_injected == "$after_injected" ]]
+[[ $(readlink -- "$work/root/current") == releases/first ]]
+[[ ! -e $work/root/releases/injected ]]
+
+printf 'frontend release integration tests passed\n'

--- a/deploy/test-nginx-installer.sh
+++ b/deploy/test-nginx-installer.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+installer=$repo/deploy/nginx/install-nginx-split.sh
+work=$(mktemp -d)
+trap 'rm -rf -- "$work"' EXIT
+
+make_mocks() {
+  local root=$1
+  mkdir -p "$root/mock-bin" "$root/state"
+  cat >"$root/mock-bin/nginx" <<'EOF'
+#!/usr/bin/env bash
+count_file=$MOCK_STATE/nginx-count
+count=$(($(cat "$count_file" 2>/dev/null || echo 0) + 1))
+printf '%s\n' "$count" >"$count_file"
+case ",${MOCK_NGINX_FAIL_COUNTS:-}," in *,"$count",*) exit 42 ;; esac
+exit 0
+EOF
+  cat >"$root/mock-bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+if [[ $1 == reload ]]; then
+  count_file=$MOCK_STATE/reload-count
+  count=$(($(cat "$count_file" 2>/dev/null || echo 0) + 1))
+  printf '%s\n' "$count" >"$count_file"
+  case ",${MOCK_RELOAD_FAIL_COUNTS:-}," in *,"$count",*) exit 43 ;; esac
+fi
+exit 0
+EOF
+  cat >"$root/mock-bin/mv" <<'EOF'
+#!/usr/bin/env bash
+count_file=$MOCK_STATE/mv-count
+count=$(($(cat "$count_file" 2>/dev/null || echo 0) + 1))
+printf '%s\n' "$count" >"$count_file"
+case ",${MOCK_MV_FAIL_COUNTS:-}," in *,"$count",*) exit 44 ;; esac
+exec /usr/bin/mv "$@"
+EOF
+  chmod +x "$root/mock-bin"/*
+}
+
+setup_case() {
+  local name=$1 root
+  root=$work/$name
+  mkdir -p "$root/etc/nginx/conf.d" "$root/run/lock" "$root/var/lib"
+  printf 'old locations\n' >"$root/etc/nginx/lmm-api-locations.conf"
+  printf 'old server\n' >"$root/etc/nginx/conf.d/new-api.conf"
+  chmod 0640 "$root/etc/nginx/lmm-api-locations.conf"
+  chmod 0600 "$root/etc/nginx/conf.d/new-api.conf"
+  make_mocks "$root"
+  printf '%s\n' "$root"
+}
+
+snapshot() {
+  local root=$1 target
+  for target in \
+    etc/nginx/lmm-api-mime.types \
+    etc/nginx/lmm-api-http-map.conf \
+    etc/nginx/lmm-api-locations.conf \
+    etc/nginx/conf.d/new-api.conf; do
+    if [[ -e $root/$target || -L $root/$target ]]; then
+      stat -c "$target %F %a %u %g" "$root/$target"
+      [[ -f $root/$target && ! -L $root/$target ]] && sha256sum "$root/$target"
+    else
+      printf '%s absent\n' "$target"
+    fi
+  done
+}
+
+run_failure() {
+  local root=$1 output=$2
+  shift 2
+  if env PATH="$root/mock-bin:$PATH" MOCK_STATE="$root/state" \
+    LMM_NGINX_TEST_MODE=1 LMM_NGINX_TEST_ROOT="$root" "$@" \
+    "$installer" install >"$output" 2>&1; then
+    printf 'expected installer failure\n' >&2
+    return 1
+  fi
+}
+
+# Failure during the second candidate rename restores content, modes, and
+# targets which were originally absent.
+root=$(setup_case mid-move)
+before=$(snapshot "$root")
+run_failure "$root" "$root/output" env MOCK_MV_FAIL_COUNTS=3
+after=$(snapshot "$root")
+[[ $before == "$after" ]]
+grep -Fq 'candidate failed (44); previous nginx configuration restored and verified' "$root/output"
+
+# Candidate syntax validation and reload failures both restore exactly.
+for scenario in nginx-t reload; do
+  root=$(setup_case "$scenario")
+  before=$(snapshot "$root")
+  if [[ $scenario == nginx-t ]]; then
+    run_failure "$root" "$root/output" env MOCK_NGINX_FAIL_COUNTS=1
+    grep -Fq 'candidate failed (42)' "$root/output"
+  else
+    run_failure "$root" "$root/output" env MOCK_RELOAD_FAIL_COUNTS=1
+    grep -Fq 'candidate failed (43)' "$root/output"
+  fi
+  after=$(snapshot "$root")
+  [[ $before == "$after" ]]
+done
+
+# A dangling symlink is unsafe existing state, never "absent".
+root=$(setup_case dangling)
+rm "$root/etc/nginx/lmm-api-locations.conf"
+ln -s /missing/target "$root/etc/nginx/lmm-api-locations.conf"
+before=$(snapshot "$root")
+run_failure "$root" "$root/output" env
+after=$(snapshot "$root")
+[[ $before == "$after" ]]
+grep -Fq 'unsafe existing target' "$root/output"
+
+# Preserve the candidate's first error even if restoration independently fails.
+root=$(setup_case double-failure)
+run_failure "$root" "$root/output" env MOCK_RELOAD_FAIL_COUNTS=1 MOCK_NGINX_FAIL_COUNTS=2
+grep -Fq 'candidate failed (43) and restore verification failed (42)' "$root/output"
+
+printf 'nginx installer failure-injection tests passed\n'

--- a/deploy/test-nginx-mime.sh
+++ b/deploy/test-nginx-mime.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+command -v nginx >/dev/null || { printf 'test-nginx-mime: nginx is required\n' >&2; exit 1; }
+command -v curl >/dev/null || { printf 'test-nginx-mime: curl is required\n' >&2; exit 1; }
+
+work=$(mktemp -d)
+port=${LMM_NGINX_TEST_PORT:-49184}
+mime_types=${LMM_NGINX_MIME_TYPES:-/etc/nginx/lmm-api-mime.types}
+[[ -r $mime_types ]] || { printf 'test-nginx-mime: unreadable MIME map: %s\n' "$mime_types" >&2; exit 1; }
+nginx_pid=
+cleanup() {
+  if [[ -n $nginx_pid ]] && kill -0 "$nginx_pid" 2>/dev/null; then
+    kill "$nginx_pid" 2>/dev/null || true
+    wait "$nginx_pid" 2>/dev/null || true
+  fi
+  rm -rf -- "$work"
+}
+trap cleanup EXIT
+
+mkdir -p -- "$work/assets"
+printf 'export const ready = true\n' >"$work/assets/app.js"
+printf 'body { color: black; }\n' >"$work/assets/app.css"
+printf '{"ready":true}\n' >"$work/assets/app.json"
+printf '<svg xmlns="http://www.w3.org/2000/svg"/>\n' >"$work/assets/app.svg"
+printf 'synthetic-font\n' >"$work/assets/app.woff2"
+chmod a+rx "$work" "$work/assets"
+chmod a+r "$work/assets"/*
+
+cat >"$work/nginx.conf" <<EOF
+pid $work/nginx.pid;
+error_log $work/error.log notice;
+events { worker_connections 16; }
+http {
+    # Match production: no global mime.types include.
+    default_type application/octet-stream;
+    server {
+        listen 127.0.0.1:$port;
+        include $mime_types;
+        default_type application/octet-stream;
+        location ^~ /static/ {
+            alias $work/assets/;
+        }
+    }
+}
+EOF
+
+nginx -t -c "$work/nginx.conf"
+nginx -c "$work/nginx.conf" -g 'daemon off;' &
+nginx_pid=$!
+
+for _ in {1..50}; do
+  curl -fsS "http://127.0.0.1:$port/static/app.js" >/dev/null 2>&1 && break
+  sleep 0.02
+done
+
+content_type() {
+  curl -fsSI "http://127.0.0.1:$port/static/$1" |
+    awk -F ': *' 'tolower($1) == "content-type" { sub("\\r$", "", $2); print tolower($2) }'
+}
+
+[[ $(content_type app.js) == application/javascript ]]
+[[ $(content_type app.css) == text/css ]]
+[[ $(content_type app.json) == application/json ]]
+[[ $(content_type app.svg) == image/svg+xml ]]
+[[ $(content_type app.woff2) == font/woff2 ]]
+[[ $(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:$port/static/missing.hash.js") == 404 ]]
+
+printf 'nginx MIME integration tests passed\n'

--- a/deploy/valkey/70-valkey-lmm-api.conf
+++ b/deploy/valkey/70-valkey-lmm-api.conf
@@ -1,0 +1,2 @@
+# Valkey requires memory overcommit for reliable background persistence.
+vm.overcommit_memory = 1

--- a/deploy/valkey/check-valkey-deployment.sh
+++ b/deploy/valkey/check-valkey-deployment.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOYER="$SCRIPT_DIR/deploy-valkey-lmm-api.sh"
+CONFIG="$SCRIPT_DIR/lmm-api.conf"
+UNIT="$SCRIPT_DIR/valkey-lmm-api.service"
+SYSCTL_CONFIG="$SCRIPT_DIR/70-valkey-lmm-api.conf"
+TMPFILES_CONFIG="$SCRIPT_DIR/valkey-lmm-api.tmpfiles.conf"
+
+fail() { printf 'check-valkey-deployment: %s\n' "$*" >&2; exit 1; }
+expect_line() { grep -Fxq -- "$1" "$2" || fail "missing '$1' in $(basename "$2")"; }
+
+bash -n "$DEPLOYER" "$0"
+if command -v shellcheck >/dev/null; then
+  shellcheck "$DEPLOYER" "$0" "$SCRIPT_DIR/test-restore-behavior.sh"
+fi
+if command -v systemd-analyze >/dev/null; then
+  systemd-analyze verify "$UNIT"
+fi
+
+expect_line 'bind 127.0.0.1 -::1' "$CONFIG"
+expect_line 'protected-mode yes' "$CONFIG"
+expect_line 'port 6380' "$CONFIG"
+expect_line 'maxmemory 64mb' "$CONFIG"
+expect_line 'maxmemory-policy allkeys-lru' "$CONFIG"
+expect_line 'appendonly yes' "$CONFIG"
+expect_line 'appendfsync everysec' "$CONFIG"
+expect_line 'MemoryMax=112M' "$UNIT"
+expect_line 'MemorySwapMax=32M' "$UNIT"
+expect_line 'vm.overcommit_memory = 1' "$SYSCTL_CONFIG"
+expect_line 'w /sys/kernel/mm/transparent_hugepage/enabled - - - - madvise' "$TMPFILES_CONFIG"
+
+grep -Fq "ss -ltnH 'sport = :6379'" "$DEPLOYER" || fail 'protected 6379 invariant is absent'
+grep -Fq "restore_transaction \"\$RESTORE_ON_EXIT\"" "$DEPLOYER" || fail 'automatic restore is absent'
+grep -Fq "systemctl stop \"\$SERVICE\"" "$DEPLOYER" || fail 'rollback does not stop before restore'
+grep -Fq "restore_kernel_state \"\$backup_dir\"" "$DEPLOYER" || fail 'rollback does not restore runtime kernel state'
+grep -Fq 'valkey-server --check-system' "$DEPLOYER" || fail 'Valkey system preflight is absent'
+grep -Fq "if ! overcommit=\"\$(sysctl -n vm.overcommit_memory)\"" "$DEPLOYER" || fail 'overcommit capture does not check command failure'
+grep -Fq "if ! thp=\"\$(current_thp_mode)\"" "$DEPLOYER" || fail 'THP capture does not check command failure'
+grep -Fq "mv -fT -- \"\$kernel_state_tmp\" \"\$backup_dir/kernel-state\"" "$DEPLOYER" || fail 'kernel metadata is not atomically published'
+grep -Fq "mv -fT -- \"\$manifest_tmp\" \"\$backup_dir/manifest\"" "$DEPLOYER" || fail 'backup manifest is not published last and atomically'
+restore_body="$(sed -n '/^restore_transaction()/,/^}/p' "$DEPLOYER")"
+grep -Fq ') || restore_status=$?' <<<"$restore_body" || fail 'restore failure is not captured independently'
+grep -Fq '(assert_existing_untouched) || invariant_status=$?' <<<"$restore_body" || fail '6379 invariant is not checked independently after restore'
+grep -Fq "return \"\$restore_status\"" <<<"$restore_body" || fail 'primary restore failure is not preserved'
+"$SCRIPT_DIR/test-restore-behavior.sh"
+install_branch="$(sed -n '/^[[:space:]]*install)$/,/^[[:space:]]*;;$/p' "$DEPLOYER")"
+rollback_branch="$(sed -n '/^[[:space:]]*rollback)/p' "$DEPLOYER")"
+grep -Fq 'capture_dedicated_state' <<<"$install_branch" || fail 'install does not validate the current dedicated-unit state'
+if grep -Fq 'capture_dedicated_state' <<<"$rollback_branch"; then
+  fail 'rollback incorrectly depends on the current dedicated-unit state'
+fi
+grep -Fq 'rollback_instance' <<<"$rollback_branch" || fail 'rollback dispatch is missing'
+if grep -Fq 'enable --now' "$DEPLOYER"; then
+  fail 'redundant enable --now remains'
+fi
+
+valid_id='20260801T010203Z-123456789-a1b2c3d4e5f60708'
+invalid_ids=(
+  '20260801T010203Z'
+  '../20260801T010203Z-123456789-a1b2c3d4e5f60708'
+  '20260801T010203Z-12345678-a1b2c3d4e5f60708'
+  '20260801T010203Z-123456789-A1B2C3D4E5F60708'
+)
+regex='^[0-9]{8}T[0-9]{6}Z-[0-9]{9}-[0-9a-f]{16}$'
+[[ "$valid_id" =~ $regex ]] || fail 'valid backup ID rejected by test regex'
+for invalid_id in "${invalid_ids[@]}"; do
+  [[ ! "$invalid_id" =~ $regex ]] || fail "unsafe backup ID accepted: $invalid_id"
+done
+
+printf 'check-valkey-deployment: OK\n'

--- a/deploy/valkey/deploy-valkey-lmm-api.sh
+++ b/deploy/valkey/deploy-valkey-lmm-api.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly SERVICE='valkey-lmm-api.service'
+readonly EXISTING_SERVICE='valkey.service'
+readonly CONFIG='/etc/valkey/lmm-api.conf'
+readonly ACL='/etc/valkey/lmm-api.acl'
+readonly APP_ENV='/etc/lmm-api/valkey.env'
+readonly UNIT='/etc/systemd/system/valkey-lmm-api.service'
+readonly SYSCTL_CONFIG='/etc/sysctl.d/70-valkey-lmm-api.conf'
+readonly TMPFILES_CONFIG='/etc/tmpfiles.d/valkey-lmm-api.conf'
+readonly THP_SYSFS='/sys/kernel/mm/transparent_hugepage/enabled'
+readonly STATE_DIR='/var/lib/valkey-lmm-api'
+readonly BACKUP_ROOT='/var/lib/valkey-lmm-api-deploy/backups'
+readonly LOCK='/run/lock/valkey-lmm-api-deploy.lock'
+readonly PORT='6380'
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ACTION="${1:-install}"
+BACKUP_ID="${2:-}"
+STAGE=''
+RESTORE_ON_EXIT=''
+PREVIOUS_DEDICATED_ACTIVE=''
+PREVIOUS_DEDICATED_ENABLED=''
+
+log() { printf '[valkey-lmm-api] %s\n' "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+cleanup() {
+  local exit_status=$?
+  local restore_status=0
+  if ((exit_status != 0)) && [[ -n "$RESTORE_ON_EXIT" ]]; then
+    set +e
+    log "install failed; restoring managed files from $(basename "$RESTORE_ON_EXIT")"
+    (restore_transaction "$RESTORE_ON_EXIT")
+    restore_status=$?
+    if ((restore_status != 0)); then
+      log "ROLLBACK ERROR: automatic restoration failed with status $restore_status (original status $exit_status)"
+    else
+      log "automatic restoration succeeded (original status $exit_status)"
+    fi
+    set -e
+  fi
+  [[ -z "$STAGE" ]] || rm -rf -- "$STAGE"
+  return "$exit_status"
+}
+trap cleanup EXIT
+
+require_root() { [[ $EUID -eq 0 ]] || die 'run as root'; }
+require_tools() {
+  local tool
+  for tool in flock install mv cp rm mktemp systemctl systemd-tmpfiles sysctl valkey-server valkey-cli ss openssl sha256sum; do
+    command -v "$tool" >/dev/null || die "missing command: $tool"
+  done
+  getent passwd valkey >/dev/null || die 'system user valkey is missing'
+}
+
+capture_existing_instance() {
+  EXISTING_ACTIVE="$(systemctl is-active "$EXISTING_SERVICE" 2>/dev/null || true)"
+  EXISTING_PID="$(systemctl show "$EXISTING_SERVICE" -p MainPID --value 2>/dev/null || true)"
+  ss -ltnH 'sport = :6379' | grep -q . || die 'protected Valkey listener on port 6379 is missing'
+}
+
+capture_dedicated_state() {
+  PREVIOUS_DEDICATED_ACTIVE="$(systemctl is-active "$SERVICE" 2>/dev/null || true)"
+  PREVIOUS_DEDICATED_ENABLED="$(systemctl is-enabled "$SERVICE" 2>/dev/null || true)"
+  [[ -n "$PREVIOUS_DEDICATED_ACTIVE" ]] || PREVIOUS_DEDICATED_ACTIVE='inactive'
+  [[ -n "$PREVIOUS_DEDICATED_ENABLED" ]] || PREVIOUS_DEDICATED_ENABLED='not-found'
+  case "$PREVIOUS_DEDICATED_ACTIVE" in active|inactive) ;; *) die "dedicated unit is not in a deployable active state: $PREVIOUS_DEDICATED_ACTIVE" ;; esac
+  case "$PREVIOUS_DEDICATED_ENABLED" in enabled|disabled|not-found) ;; *) die "dedicated unit is not in a deployable enabled state: $PREVIOUS_DEDICATED_ENABLED" ;; esac
+}
+
+assert_existing_untouched() {
+  local active pid
+  active="$(systemctl is-active "$EXISTING_SERVICE" 2>/dev/null || true)"
+  pid="$(systemctl show "$EXISTING_SERVICE" -p MainPID --value 2>/dev/null || true)"
+  [[ "$active" == "$EXISTING_ACTIVE" && "$pid" == "$EXISTING_PID" ]] ||
+    die 'protected valkey.service changed state or PID; manual investigation required'
+  ss -ltnH 'sport = :6379' | grep -q . || die 'protected listener on port 6379 disappeared'
+}
+
+atomic_install() {
+  local source="$1" target="$2" mode="$3" owner="$4" group="$5" temporary
+  temporary="${target}.new.$$"
+  install -o "$owner" -g "$group" -m "$mode" -- "$source" "$temporary"
+  mv -fT -- "$temporary" "$target"
+}
+
+backup_managed_files() {
+  local backup_dir="$1" path overcommit thp kernel_state_tmp unit_state_tmp manifest_tmp
+  [[ -d "$backup_dir" ]] || die "backup directory was not reserved: $backup_dir"
+  [[ ! -e "$backup_dir/manifest" ]] || die "backup manifest already exists: $backup_dir"
+  if ! overcommit="$(sysctl -n vm.overcommit_memory)"; then
+    die 'could not capture vm.overcommit_memory'
+  fi
+  [[ "$overcommit" =~ ^[012]$ ]] || die "invalid current overcommit state: $overcommit"
+  if ! thp="$(current_thp_mode)"; then
+    die 'could not capture current THP mode'
+  fi
+  case "$thp" in always|madvise|never) ;; *) die "invalid current THP state: $thp" ;; esac
+  unit_state_tmp="$backup_dir/.unit-state.new.$$"
+  printf 'active %s\nenabled %s\n' "$PREVIOUS_DEDICATED_ACTIVE" "$PREVIOUS_DEDICATED_ENABLED" \
+    >"$unit_state_tmp"
+  chmod 0600 "$unit_state_tmp"
+  mv -fT -- "$unit_state_tmp" "$backup_dir/unit-state"
+  kernel_state_tmp="$backup_dir/.kernel-state.new.$$"
+  printf 'overcommit %s\nthp %s\n' "$overcommit" "$thp" >"$kernel_state_tmp"
+  chmod 0600 "$kernel_state_tmp"
+  mv -fT -- "$kernel_state_tmp" "$backup_dir/kernel-state"
+  manifest_tmp="$backup_dir/.manifest.new.$$"
+  : >"$manifest_tmp"
+  chmod 0600 "$manifest_tmp"
+  for path in "$CONFIG" "$ACL" "$APP_ENV" "$UNIT" "$SYSCTL_CONFIG" "$TMPFILES_CONFIG"; do
+    if [[ -e "$path" ]]; then
+      cp -a -- "$path" "$backup_dir/$(basename "$path")"
+      printf 'present %s\n' "$path" >>"$manifest_tmp"
+    else
+      printf 'absent %s\n' "$path" >>"$manifest_tmp"
+    fi
+  done
+  mv -fT -- "$manifest_tmp" "$backup_dir/manifest"
+}
+
+current_thp_mode() {
+  local state
+  [[ -r "$THP_SYSFS" ]] || die "THP state is unavailable: $THP_SYSFS"
+  state="$(<"$THP_SYSFS")"
+  if [[ "$state" =~ \[([a-z]+)\] ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+  else
+    die 'could not parse current THP mode'
+  fi
+}
+
+apply_kernel_tuning() {
+  sysctl -q -w vm.overcommit_memory=1
+  systemd-tmpfiles --create "$TMPFILES_CONFIG"
+  [[ "$(sysctl -n vm.overcommit_memory)" == 1 ]] || die 'vm.overcommit_memory did not become 1'
+  [[ "$(current_thp_mode)" == madvise ]] || die 'THP mode did not become madvise'
+}
+
+restore_kernel_state() {
+  local backup_dir="$1" key value overcommit='' thp='' observed step_status
+  [[ -r "$backup_dir/kernel-state" ]] || die "kernel state metadata missing: $backup_dir"
+  while read -r key value; do
+    case "$key" in
+      overcommit) overcommit="$value" ;;
+      thp) thp="$value" ;;
+      *) die 'invalid kernel state metadata' ;;
+    esac
+  done <"$backup_dir/kernel-state"
+  [[ "$overcommit" =~ ^[012]$ ]] || die 'invalid saved overcommit state'
+  case "$thp" in always|madvise|never) ;; *) die 'invalid saved THP state' ;; esac
+  if sysctl -q -w "vm.overcommit_memory=$overcommit"; then :; else step_status=$?; return "$step_status"; fi
+  if printf '%s\n' "$thp" >"$THP_SYSFS"; then :; else step_status=$?; return "$step_status"; fi
+  if observed="$(sysctl -n vm.overcommit_memory)"; then :; else step_status=$?; return "$step_status"; fi
+  [[ "$observed" == "$overcommit" ]] || { log 'overcommit runtime state was not restored'; return 1; }
+  if observed="$(current_thp_mode)"; then :; else step_status=$?; return "$step_status"; fi
+  [[ "$observed" == "$thp" ]] || { log 'THP runtime state was not restored'; return 1; }
+}
+
+reserve_backup_dir() {
+  local candidate random
+  install -d -o root -g root -m 0700 -- "$BACKUP_ROOT"
+  for _ in {1..10}; do
+    random="$(openssl rand -hex 8)"
+    candidate="$BACKUP_ROOT/$(date -u +%Y%m%dT%H%M%SZ)-$(date -u +%N)-$random"
+    if mkdir -m 0700 -- "$candidate" 2>/dev/null; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+  die 'could not reserve a unique backup directory'
+}
+
+restore_managed_files() {
+  local backup_dir="$1" status path stored step_status
+  [[ -r "$backup_dir/manifest" ]] || die "backup manifest missing: $backup_dir"
+  while read -r status path; do
+    case "$path" in "$CONFIG"|"$ACL"|"$APP_ENV"|"$UNIT"|"$SYSCTL_CONFIG"|"$TMPFILES_CONFIG") ;; *) die 'unsafe backup manifest' ;; esac
+    stored="$backup_dir/$(basename "$path")"
+    if [[ "$status" == present ]]; then
+      [[ -e "$stored" ]] || die "backup payload missing for $path"
+      if cp -a -- "$stored" "${path}.rollback.$$"; then :; else step_status=$?; return "$step_status"; fi
+      if mv -fT -- "${path}.rollback.$$" "$path"; then :; else step_status=$?; return "$step_status"; fi
+    elif [[ "$status" == absent ]]; then
+      if rm -f -- "$path"; then :; else step_status=$?; return "$step_status"; fi
+    else
+      die 'invalid backup manifest'
+    fi
+  done <"$backup_dir/manifest"
+}
+
+read_unit_state() {
+  local backup_dir="$1" key value
+  RESTORE_ACTIVE=''
+  RESTORE_ENABLED=''
+  [[ -r "$backup_dir/unit-state" ]] || die "unit state metadata missing: $backup_dir"
+  while read -r key value; do
+    case "$key" in
+      active) RESTORE_ACTIVE="$value" ;;
+      enabled) RESTORE_ENABLED="$value" ;;
+      *) die 'invalid unit state metadata' ;;
+    esac
+  done <"$backup_dir/unit-state"
+  case "$RESTORE_ACTIVE" in active|inactive) ;; *) die 'invalid saved active state' ;; esac
+  case "$RESTORE_ENABLED" in enabled|disabled|not-found) ;; *) die 'invalid saved enabled state' ;; esac
+}
+
+restore_unit_state() {
+  local active_now enabled_now step_status
+  case "$RESTORE_ENABLED" in
+    enabled)
+      if systemctl enable "$SERVICE"; then :; else step_status=$?; return "$step_status"; fi
+      ;;
+    not-found|disabled) ;;
+  esac
+
+  if [[ "$RESTORE_ACTIVE" == active ]]; then
+    if systemctl restart "$SERVICE"; then :; else step_status=$?; return "$step_status"; fi
+    if health_check; then :; else step_status=$?; return "$step_status"; fi
+  fi
+
+  active_now="$(systemctl is-active "$SERVICE" 2>/dev/null || true)"
+  enabled_now="$(systemctl is-enabled "$SERVICE" 2>/dev/null || true)"
+  [[ "$active_now" == "$RESTORE_ACTIVE" ]] || die "dedicated unit active state was not restored ($active_now != $RESTORE_ACTIVE)"
+  [[ "$enabled_now" == "$RESTORE_ENABLED" ]] || die "dedicated unit enabled state was not restored ($enabled_now != $RESTORE_ENABLED)"
+}
+
+restore_steps() {
+  local backup_dir="$1" step_status current_active
+  if read_unit_state "$backup_dir"; then :; else step_status=$?; return "$step_status"; fi
+  if systemctl stop "$SERVICE" >/dev/null 2>&1; then
+    :
+  else
+    step_status=$?
+    current_active="$(systemctl is-active "$SERVICE" 2>/dev/null || true)"
+    case "$current_active" in
+      inactive|failed|unknown) ;;
+      *) return "$step_status" ;;
+    esac
+  fi
+  case "$RESTORE_ENABLED" in
+    disabled|not-found)
+      if systemctl disable "$SERVICE" >/dev/null 2>&1; then
+        :
+      else
+        step_status=$?
+        current_active="$(systemctl is-enabled "$SERVICE" 2>/dev/null || true)"
+        case "$current_active" in
+          disabled|not-found) ;;
+          *) return "$step_status" ;;
+        esac
+      fi
+      ;;
+  esac
+  if restore_managed_files "$backup_dir"; then :; else step_status=$?; return "$step_status"; fi
+  if restore_kernel_state "$backup_dir"; then :; else step_status=$?; return "$step_status"; fi
+  if systemctl daemon-reload; then :; else step_status=$?; return "$step_status"; fi
+  if restore_unit_state; then :; else step_status=$?; return "$step_status"; fi
+}
+
+restore_transaction() {
+  local backup_dir="$1" restore_status=0 invariant_status=0
+  (restore_steps "$backup_dir") || restore_status=$?
+
+  (assert_existing_untouched) || invariant_status=$?
+  if ((restore_status != 0)); then
+    log "restore steps failed with status $restore_status"
+  fi
+  if ((invariant_status != 0)); then
+    log "protected 6379 invariant check failed with status $invariant_status"
+  fi
+  if ((restore_status != 0)); then
+    return "$restore_status"
+  fi
+  return "$invariant_status"
+}
+
+health_check() {
+  local password denied_output
+  password="$(sed -n 's/^user lmm-api on >\([[:xdigit:]]\{64\}\) .*/\1/p' "$ACL")"
+  [[ ${#password} -eq 64 ]] || die 'managed ACL is malformed'
+  VALKEYCLI_AUTH="$password" valkey-cli --no-auth-warning -h 127.0.0.1 -p "$PORT" \
+    --user lmm-api ping 2>/dev/null | grep -qx PONG || die 'authenticated PING failed'
+  denied_output="$(VALKEYCLI_AUTH="$password" valkey-cli --no-auth-warning --raw \
+    -h 127.0.0.1 -p "$PORT" --user lmm-api CONFIG GET '*' 2>&1 || true)"
+  grep -qiE 'NOPERM|no permissions' <<<"$denied_output" ||
+    die 'application user unexpectedly has dangerous CONFIG permission'
+  systemctl is-active --quiet "$SERVICE" || die "$SERVICE is not active"
+  ss -ltnH 'sport = :6380' | grep -q '127.0.0.1:6380' || die 'loopback listener is missing'
+  if ss -ltnH 'sport = :6380' | grep -Eq '(^|[[:space:]])(0\.0\.0\.0|\*|\[::\]):6380'; then
+    die 'Valkey is exposed beyond IPv4 loopback'
+  fi
+}
+
+install_instance() {
+  local backup_dir password
+  [[ -r "$SCRIPT_DIR/lmm-api.conf" && -r "$SCRIPT_DIR/valkey-lmm-api.service" &&
+    -r "$SCRIPT_DIR/70-valkey-lmm-api.conf" && -r "$SCRIPT_DIR/valkey-lmm-api.tmpfiles.conf" ]] ||
+    die 'deployment templates are missing'
+  [[ "$(grep -Ec '^port 6380$' "$SCRIPT_DIR/lmm-api.conf")" == 1 ]] || die 'template port check failed'
+  [[ "$(grep -Ec '^bind 127\.0\.0\.1 -::1$' "$SCRIPT_DIR/lmm-api.conf")" == 1 ]] || die 'template bind check failed'
+
+  backup_dir="$(reserve_backup_dir)"
+  backup_managed_files "$backup_dir"
+  RESTORE_ON_EXIT="$backup_dir"
+  log "backup retained at $backup_dir"
+
+  install -d -o root -g valkey -m 0750 /etc/valkey
+  install -d -o root -g root -m 0700 /etc/lmm-api "$BACKUP_ROOT"
+  install -d -o valkey -g valkey -m 0750 "$STATE_DIR"
+
+  if [[ -s "$ACL" && -s "$APP_ENV" ]]; then
+    cp -a -- "$ACL" "$STAGE/acl"
+    cp -a -- "$APP_ENV" "$STAGE/env"
+  else
+    password="$(openssl rand -hex 32)"
+    printf 'user default off\nuser lmm-api on >%s ~* &* +@all -@dangerous\n' "$password" >"$STAGE/acl"
+    printf 'REDIS_CONN_STRING=redis://lmm-api:%s@127.0.0.1:6380/0\n' "$password" >"$STAGE/env"
+  fi
+
+  atomic_install "$SCRIPT_DIR/lmm-api.conf" "$CONFIG" 0640 root valkey
+  atomic_install "$STAGE/acl" "$ACL" 0640 root valkey
+  atomic_install "$STAGE/env" "$APP_ENV" 0600 root root
+  atomic_install "$SCRIPT_DIR/valkey-lmm-api.service" "$UNIT" 0644 root root
+  atomic_install "$SCRIPT_DIR/70-valkey-lmm-api.conf" "$SYSCTL_CONFIG" 0644 root root
+  atomic_install "$SCRIPT_DIR/valkey-lmm-api.tmpfiles.conf" "$TMPFILES_CONFIG" 0644 root root
+  apply_kernel_tuning
+  valkey-server --check-system >/dev/null || die 'valkey-server --check-system failed after kernel tuning'
+  systemctl daemon-reload
+  systemctl enable "$SERVICE"
+  systemctl restart "$SERVICE"
+  health_check
+  assert_existing_untouched
+  sha256sum "$CONFIG" "$UNIT" "$SYSCTL_CONFIG" "$TMPFILES_CONFIG" >"$backup_dir/installed.sha256"
+  RESTORE_ON_EXIT=''
+  log 'installation healthy; application credential is in /etc/lmm-api/valkey.env (mode 0600)'
+}
+
+rollback_instance() {
+  local backup_dir
+  [[ -n "$BACKUP_ID" && "$BACKUP_ID" =~ ^[0-9]{8}T[0-9]{6}Z-[0-9]{9}-[0-9a-f]{16}$ ]] ||
+    die 'usage: deploy-valkey-lmm-api.sh rollback <backup-id>'
+  backup_dir="$BACKUP_ROOT/$BACKUP_ID"
+  [[ -r "$backup_dir/manifest" ]] || die "backup not found: $BACKUP_ID"
+  restore_transaction "$backup_dir"
+  log "rollback to $BACKUP_ID completed"
+}
+
+main() {
+  require_root
+  require_tools
+  exec 9>"$LOCK"
+  flock -n 9 || die 'another Valkey deployment is running'
+  STAGE="$(mktemp -d /tmp/valkey-lmm-api.XXXXXX)"
+  chmod 0700 "$STAGE"
+  capture_existing_instance
+  case "$ACTION" in
+    install)
+      [[ -z "$BACKUP_ID" ]] || die 'install takes no positional argument'
+      capture_dedicated_state
+      install_instance
+      ;;
+    health) [[ -z "$BACKUP_ID" ]] || die 'health takes no positional argument'; health_check; assert_existing_untouched ;;
+    rollback) rollback_instance ;;
+    *) die 'usage: deploy-valkey-lmm-api.sh {install|health|rollback <backup-id>}' ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/deploy/valkey/lmm-api.conf
+++ b/deploy/valkey/lmm-api.conf
@@ -1,0 +1,32 @@
+# Dedicated lmm-api cache. Credentials live in the separately protected ACL file.
+bind 127.0.0.1 -::1
+protected-mode yes
+port 6380
+tcp-backlog 128
+timeout 0
+tcp-keepalive 300
+
+supervised systemd
+daemonize no
+pidfile /run/valkey-lmm-api/valkey-lmm-api.pid
+loglevel notice
+logfile ""
+
+databases 1
+dir /var/lib/valkey-lmm-api
+dbfilename dump.rdb
+aclfile /etc/valkey/lmm-api.acl
+
+# Cache data may be evicted; PostgreSQL remains authoritative.
+maxmemory 64mb
+maxmemory-policy allkeys-lru
+maxmemory-samples 5
+
+# Retain useful warm state across a restart without treating it as authoritative.
+save ""
+appendonly yes
+appendfilename "appendonly.aof"
+appenddirname "appendonlydir"
+appendfsync everysec
+no-appendfsync-on-rewrite yes
+aof-use-rdb-preamble yes

--- a/deploy/valkey/test-restore-behavior.sh
+++ b/deploy/valkey/test-restore-behavior.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2034,SC2329
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy-valkey-lmm-api.sh
+source "$SCRIPT_DIR/deploy-valkey-lmm-api.sh"
+
+fail() { printf 'test-restore-behavior: %s\n' "$*" >&2; exit 1; }
+
+test_early_failure_preserves_status() (
+  local kernel_called=0 unit_called=0 status
+  read_unit_state() { RESTORE_ACTIVE='inactive'; RESTORE_ENABLED='enabled'; return 0; }
+  systemctl() { return 0; }
+  restore_managed_files() { return 23; }
+  restore_kernel_state() { kernel_called=1; return 0; }
+  restore_unit_state() { unit_called=1; return 0; }
+
+  if restore_steps '/unused/mock-backup'; then
+    fail 'early restore failure was reported as success'
+  else
+    status=$?
+  fi
+  [[ "$status" == 23 ]] || fail "first restore error was not preserved: $status"
+  [[ "$kernel_called" == 0 ]] || fail 'unsafe later kernel restore ran after file restore failure'
+  [[ "$unit_called" == 0 ]] || fail 'unsafe unit restore ran after file restore failure'
+)
+
+test_invariant_runs_after_restore_failure() (
+  local marker status
+  marker="$(mktemp)"
+  rm -f -- "$marker"
+  trap 'rm -f -- "$marker"' EXIT
+  restore_steps() { return 29; }
+  assert_existing_untouched() { : >"$marker"; return 0; }
+
+  if restore_transaction '/unused/mock-backup'; then
+    fail 'restore transaction hid the primary failure'
+  else
+    status=$?
+  fi
+  [[ "$status" == 29 ]] || fail "restore transaction lost the primary error: $status"
+  [[ -e "$marker" ]] || fail '6379 invariant was skipped after restore failure'
+)
+
+test_internal_copy_failure_is_not_masked() (
+  local backup marker status
+  backup="$(mktemp -d)"
+  marker="$backup/mv-called"
+  trap 'rm -rf -- "$backup"' EXIT
+  printf 'present %s\n' "$CONFIG" >"$backup/manifest"
+  : >"$backup/$(basename "$CONFIG")"
+  cp() { return 23; }
+  mv() { : >"$marker"; return 0; }
+
+  if restore_managed_files "$backup"; then
+    fail 'internal cp failure was hidden by a later successful command'
+  else
+    status=$?
+  fi
+  [[ "$status" == 23 ]] || fail "internal cp error was not preserved: $status"
+  [[ ! -e "$marker" ]] || fail 'mv ran after cp failed'
+)
+
+test_early_failure_preserves_status
+test_invariant_runs_after_restore_failure
+test_internal_copy_failure_is_not_masked
+printf 'test-restore-behavior: OK\n'

--- a/deploy/valkey/valkey-lmm-api.service
+++ b/deploy/valkey/valkey-lmm-api.service
@@ -1,0 +1,54 @@
+[Unit]
+Description=Dedicated Valkey cache for lmm-api
+Documentation=https://valkey.io/
+After=network.target
+Before=lmm-api.service
+
+[Service]
+Type=notify
+User=valkey
+Group=valkey
+ExecStart=/usr/bin/valkey-server /etc/valkey/lmm-api.conf --supervised systemd
+ExecStartPre=/usr/bin/test -r /etc/valkey/lmm-api.conf
+ExecStartPre=/usr/bin/test -r /etc/valkey/lmm-api.acl
+TimeoutStartSec=60
+TimeoutStopSec=60
+Restart=on-failure
+RestartSec=2s
+
+RuntimeDirectory=valkey-lmm-api
+RuntimeDirectoryMode=0750
+StateDirectory=valkey-lmm-api
+StateDirectoryMode=0750
+UMask=0027
+
+CapabilityBoundingSet=
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectSystem=strict
+ReadWritePaths=/var/lib/valkey-lmm-api
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+LimitNOFILE=10032
+MemoryHigh=80M
+MemoryMax=112M
+MemorySwapMax=32M
+TasksMax=128
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/valkey/valkey-lmm-api.tmpfiles.conf
+++ b/deploy/valkey/valkey-lmm-api.tmpfiles.conf
@@ -1,0 +1,2 @@
+# Keep THP available to other workloads while avoiding unconditional huge pages for Valkey.
+w /sys/kernel/mm/transparent_hugepage/enabled - - - - madvise

--- a/docs/seamless-upgrades.md
+++ b/docs/seamless-upgrades.md
@@ -22,7 +22,7 @@ sudo deploy/frontend-release.sh rollback
 sudo deploy/frontend-release.sh rollback --release <git-sha>
 ```
 
-Install `deploy/nginx/http-map.conf` in nginx's `http` context and include `deploy/nginx/lmm-api-locations.conf` inside the existing TLS server. Validate with `nginx -t` before reloading nginx. The template sends every known backend route family to port 3000, preserves WebSocket/SSE behavior, serves the shared `/static` asset store with immutable caching, and makes entry points revalidate. Missing static or root-public assets return 404 instead of SPA HTML. `/terms` and `/privacy` redirect to the frontend's current `/user-agreement` and `/privacy-policy` routes.
+Install `deploy/nginx/http-map.conf` in nginx's `http` context and include `deploy/nginx/lmm-api-locations.conf` inside the existing TLS server. Validate with `nginx -t` before reloading nginx. The template sends every known backend route family to port 3000, preserves WebSocket/SSE behavior, serves the shared `/static` asset store with immutable caching, and makes entry points revalidate. Missing static or root-public assets return 404 instead of SPA HTML. The production `/terms` and `/privacy` semantics are preserved as exact aliases to `/var/www/api.lmm.best/legal/terms.html` and `privacy.html`; nginx serves both as UTF-8 HTML with `X-Content-Type-Options: nosniff`, independently of a frontend release.
 
 Run `make check-frontend-split` whenever routers or deployment files change. Adding a new top-level backend router family requires updating the nginx split and its check in the same change.
 

--- a/docs/seamless-upgrades.md
+++ b/docs/seamless-upgrades.md
@@ -22,7 +22,15 @@ sudo deploy/frontend-release.sh rollback
 sudo deploy/frontend-release.sh rollback --release <git-sha>
 ```
 
-Install `deploy/nginx/http-map.conf` in nginx's `http` context and include `deploy/nginx/lmm-api-locations.conf` inside the existing TLS server. Validate with `nginx -t` before reloading nginx. The template sends every known backend route family to port 3000, preserves WebSocket/SSE behavior, serves the shared `/static` asset store with immutable caching, and makes entry points revalidate. Missing static or root-public assets return 404 instead of SPA HTML. The production `/terms` and `/privacy` semantics are preserved as exact aliases to `/var/www/api.lmm.best/legal/terms.html` and `privacy.html`; nginx serves both as UTF-8 HTML with `X-Content-Type-Options: nosniff`, independently of a frontend release.
+The site uses its own `/etc/nginx/lmm-api-mime.types`; it never creates or overwrites nginx's global `/etc/nginx/mime.types`. Publish all nginx inputs with the controlled transaction rather than copying them individually:
+
+```bash
+sudo deploy/nginx/install-nginx-split.sh install
+```
+
+The installer serializes with `flock`, reserves a unique non-overwritable backup, and manages `/etc/nginx/lmm-api-mime.types`, the HTTP `map`, the server locations, and `/etc/nginx/conf.d/new-api.conf`. Each candidate is installed as a root-owned `0644` same-directory temporary file and published with `mv -T`. Only after every file is in place does it run `nginx -t`, reload nginx, and verify the unit remains active. Any candidate failure restores the previous presence or exact content of every managed file with the same atomic replacement, then repeats syntax validation, reload, and service verification. Backups remain under `/var/lib/lmm-api-nginx-deploy/backups` for audit and manual recovery; never overwrite an existing backup. Existing symlinks, including dangling symlinks, are rejected before mutation.
+
+The server-scoped template explicitly includes `/etc/nginx/lmm-api-mime.types`; do not remove it or rely on a global include, because production's `http` context otherwise defaults to `application/octet-stream` and browsers reject JavaScript modules served with that MIME type. The template sends every known backend route family to port 3000, preserves WebSocket/SSE behavior, serves the shared `/static` asset store with immutable caching, and makes entry points revalidate. Missing static or root-public assets return 404 instead of SPA HTML. The production `/terms` and `/privacy` semantics are preserved as exact aliases to `/var/www/api.lmm.best/legal/terms.html` and `privacy.html`; nginx serves both as UTF-8 HTML with `X-Content-Type-Options: nosniff`, independently of a frontend release.
 
 Run `make check-frontend-split` whenever routers or deployment files change. Adding a new top-level backend router family requires updating the nginx split and its check in the same change.
 

--- a/docs/seamless-upgrades.md
+++ b/docs/seamless-upgrades.md
@@ -1,0 +1,39 @@
+# Frontend and backend upgrades
+
+The frontend and backend have different safety boundaries and are released independently.
+
+## Frontend: zero-downtime static releases
+
+Build `web/dist` in CI or a build workspace, then copy that immutable directory to the server. Publishing does not restart the Go service or nginx:
+
+```bash
+sudo deploy/frontend-release.sh publish \
+  --source /path/to/dist \
+  --release <git-sha>
+```
+
+The publisher validates `index.html` and its local asset references, copies into a same-filesystem staging directory, and atomically replaces `/srv/lmm-api-frontend/current`. Before switching, it copies `/static` files into the cumulative immutable store at `/srv/lmm-api-frontend/assets`, rejecting a same-name/different-content collision, then makes the versioned release read-only. This lets a browser holding the previous `index.html` continue lazy-loading its hashed chunks after a switch. It uses `flock` to serialize publishers and retains `N` HTML releases in total, always including the current release. Static assets are intentionally not garbage-collected in this phase; a future GC must preserve every asset referenced by every retained release. Preview actions with `--dry-run`; change HTML retention with `--keep N`.
+
+Rollback is another atomic symlink replacement:
+
+```bash
+sudo deploy/frontend-release.sh rollback
+# or select an exact retained release
+sudo deploy/frontend-release.sh rollback --release <git-sha>
+```
+
+Install `deploy/nginx/http-map.conf` in nginx's `http` context and include `deploy/nginx/lmm-api-locations.conf` inside the existing TLS server. Validate with `nginx -t` before reloading nginx. The template sends every known backend route family to port 3000, preserves WebSocket/SSE behavior, serves the shared `/static` asset store with immutable caching, and makes entry points revalidate. Missing static or root-public assets return 404 instead of SPA HTML. `/terms` and `/privacy` redirect to the frontend's current `/user-agreement` and `/privacy-policy` routes.
+
+Run `make check-frontend-split` whenever routers or deployment files change. Adding a new top-level backend router family requires updating the nginx split and its check in the same change.
+
+## Backend today: autonomous, bounded interruption
+
+Production currently uses one Go process and SQLite. A backend package upgrade must remain a single-instance, autonomous systemd transaction with a deployment lock, offline database backup, health validation, persistent audit output, and complete package rollback. The transaction continues without the initiating shell or API connection, but restarting the only process creates a bounded interruption. It is not a zero-downtime or blue/green deployment.
+
+Do not run old and new backend binaries concurrently against the SQLite database. Two writers, startup migrations, and background jobs make that unsafe; copying SQLite for each process would instead create divergent state.
+
+## PostgreSQL migration prerequisite
+
+True backend blue/green deployment is a later phase and requires a reviewed migration from SQLite to PostgreSQL first. The migration plan must cover backup and restore, row/count and application-level validation, maintenance boundaries, rollback criteria, and production-specific configuration. No generic migration command should be run against production without that plan.
+
+After PostgreSQL is established, backend blue/green still requires explicit liveness/readiness endpoints, expand/contract migrations compatible with N and N-1, singleton ownership for background jobs, shared runtime state, authenticated canaries, atomic nginx upstream switching, and graceful draining/reconnection of SSE and WebSocket clients. nginx must not automatically retry non-idempotent requests.

--- a/docs/valkey-lmm-api.md
+++ b/docs/valkey-lmm-api.md
@@ -1,0 +1,65 @@
+# Dedicated Valkey for lmm-api
+
+Production uses a dedicated native Valkey instance for lmm-api. It is deliberately separate from the pre-existing `valkey.service` on `127.0.0.1:6379`; the deployment script refuses to proceed unless that listener exists and verifies that its unit state and PID did not change.
+
+## Layout and resource policy
+
+| Resource | Value |
+| --- | --- |
+| Unit | `valkey-lmm-api.service` |
+| Listener | `127.0.0.1:6380` only |
+| Configuration | `/etc/valkey/lmm-api.conf` (`0640 root:valkey`) |
+| ACL | `/etc/valkey/lmm-api.acl` (`0640 root:valkey`) |
+| Application environment | `/etc/lmm-api/valkey.env` (`0600 root:root`) |
+| Persistent state | `/var/lib/valkey-lmm-api` |
+| Cache memory | `64 MiB`, `allkeys-lru` |
+| Unit memory ceiling | `MemoryHigh=80M`, `MemoryMax=112M`, `MemorySwapMax=32M` |
+| Persistence | AOF, `appendfsync everysec` |
+| Kernel tuning | `vm.overcommit_memory=1`; THP `madvise` |
+
+PostgreSQL is authoritative. Valkey accelerates shared sessions, revocation propagation, and rate limiting; its AOF improves warm restarts but is not a database backup. The default user is disabled. The `lmm-api` ACL user may access keys and scripting but is denied Valkey's `@dangerous` command category. Protected mode and loopback binding provide independent network containment.
+
+The project uses go-redis v8 and accepts the generated URL without modification:
+
+```text
+redis://lmm-api:<password>@127.0.0.1:6380/0
+```
+
+The password is a 256-bit random hexadecimal value. It is never printed by the deployer and exists only in the protected ACL and application environment files. Do not paste either file into logs or issue reports.
+
+## Install and validate
+
+Install the Arch `valkey` package first, then run from a reviewed repository checkout:
+
+```bash
+deploy/valkey/check-valkey-deployment.sh
+sudo deploy/valkey/deploy-valkey-lmm-api.sh install
+sudo deploy/valkey/deploy-valkey-lmm-api.sh health
+```
+
+The install is idempotent: an existing generated credential is preserved, managed files are written via same-directory atomic rename, publishers are serialized with `flock`, systemd state directories are declarative, and every run atomically reserves a non-overwritable backup directory using a UTC timestamp, nanoseconds, and 64 bits of secure randomness. A failed install automatically restores those managed files, the exact prior active/enabled state of the dedicated unit, and the prior runtime kernel values. Restoration failures are reported separately from the original deployment failure; they are never silently swallowed. If the restored instance was active, the deployer repeats its authenticated health check. The script applies the checked-in sysctl/tmpfiles policy, requires `valkey-server --check-system` to pass, validates fixed security directives, starts the isolated unit, performs an authenticated PING, proves the application user cannot run `CONFIG`, and verifies both listener isolation and the untouched 6379 instance.
+
+Valkey 9.1 does not expose a config-only parser. A configuration error therefore fails the isolated unit start; the existing 6379 service remains untouched and the retained backup provides recovery.
+
+The kernel policy is global: `/etc/sysctl.d/70-valkey-lmm-api.conf` persists memory overcommit, while `/etc/tmpfiles.d/valkey-lmm-api.conf` writes `madvise` to the THP sysfs selector at boot. `madvise` avoids unconditional THP for Valkey without disabling THP for applications that explicitly request it. The transaction captures both previous runtime values with independently checked reads, validates their accepted domains, and atomically publishes the metadata before changing them. Rollback restores the previous files and writes the recorded runtime values back directly; it does not run `sysctl --system`, so unrelated sysctl configuration is never reapplied. Restore steps propagate status explicitly and stop at the first unsafe failure rather than relying on Bash `errexit`; a later successful command cannot hide an earlier error. Neither tuning operation restarts the existing instance on port 6379. Its PID, unit state, and listener are checked in an independent best-effort phase even when an earlier restore step fails; a primary restore error remains the transaction's reported status while any separate 6379 invariant failure is also logged.
+
+## Connect lmm-api
+
+Add this line to the lmm-api unit without copying the secret into the unit itself:
+
+```ini
+EnvironmentFile=/etc/lmm-api/valkey.env
+```
+
+Apply this only as part of the reviewed backend blue/green deployment. Restarting lmm-api merely to attach Valkey would violate the seamless-upgrade boundary. All concurrently active backend slots must use the same Valkey URL and `CRYPTO_SECRET`.
+
+## Rollback
+
+List retained backup identifiers, review the selected manifest, then restore it:
+
+```bash
+sudo ls -1 /var/lib/valkey-lmm-api-deploy/backups
+sudo deploy/valkey/deploy-valkey-lmm-api.sh rollback 20260801T010203Z-123456789-a1b2c3d4e5f60708
+```
+
+Rollback stops the dedicated instance before atomically restoring each managed file and kernel-policy file to its previous presence or absence, restores the recorded runtime kernel values, reloads systemd, and restores the recorded active/enabled state exactly. Its recovery path intentionally does not require the current unit to be active or inactive, so a `failed`, `activating`, or otherwise unhealthy current instance cannot block rollback. Only the target backup's strictly validated state is restored. If the selected backup predates the dedicated unit, rollback stops it before removing the unit and its enablement link. It never changes or restarts `valkey.service`.

--- a/makefile
+++ b/makefile
@@ -8,7 +8,7 @@ DEV_POSTGRES_DB = new-api
 DEV_POSTGRES_USER = root
 DEV_SQLITE_PATH ?= one-api.db
 
-.PHONY: all build-web build-all-web start-api dev dev-api dev-api-rebuild dev-web reset-setup test
+.PHONY: all build-web build-all-web check-frontend-split start-api dev dev-api dev-api-rebuild dev-web reset-setup test
 
 all: build-all-web start-api
 
@@ -18,6 +18,10 @@ build-web:
 	@cd $(WEB_DIR) && DISABLE_ESLINT_PLUGIN='true' VITE_REACT_APP_VERSION=$$(cat ../VERSION) bun run build
 
 build-all-web: build-web
+
+check-frontend-split:
+	@./deploy/check-frontend-split.sh
+	@./deploy/test-frontend-release.sh
 
 start-api:
 	@echo "Starting api dev server..."


### PR DESCRIPTION
## Summary

- add independently deployable frontend releases with same-filesystem staging, serialized publishing, atomic symlink switching, retained rollback targets, and a cumulative immutable asset store for old lazy-loaded chunks
- add nginx route and cache boundaries for the SPA, OAuth, WebSocket/SSE, relay APIs, exact legacy billing endpoints, legal-route redirects, and missing-asset 404 behavior
- add route/cache regression checks and integration coverage for publish, rollback, collisions, and injected asset failures
- standardize a dedicated native Valkey instance with isolated configuration, systemd hardening, atomic managed-file updates, health checks, backup/rollback behavior, and protection for the existing port 6379 instance
- document that the SQLite backend still uses an autonomous bounded-interruption transaction; true backend blue/green remains gated on a reviewed PostgreSQL migration and compatible readiness/migration/job semantics

## Tests

- `make check-frontend-split`
- `./deploy/valkey/check-valkey-deployment.sh`
- `./deploy/valkey/test-restore-behavior.sh`
- `git diff --check`
- isolated nginx 1.30.4 validation on an ArchDmit loopback high port: valid shared static asset returned 200 with immutable caching; missing hashed asset returned 404
- production Valkey deployment and isolation validation completed separately

## Summary by Sourcery

引入独立的前端部署方案，配合 nginx 路由和标准化的专用 Valkey 实例，并提供验证脚本和文档以支持安全的升级与回滚。

Enhancements:
- 新增前端发布脚本，支持原子发布/回滚、累积且不可变的静态资源存储，以及基于符号链接的版本切换。
- 配置 nginx 的 location 和缓存策略，将 SPA 流量与后端 API、WebSocket/SSE、OAuth 以及历史计费端点分离。
- 新增用于 lmm-api 的专用 Valkey 实例部署脚本，包含隔离的配置、内核调优、健康检查，以及具备事务性的备份/回滚行为。

Build:
- 扩展 makefile，增加 `check-frontend-split` 目标，用于运行前端/后端拆分验证和集成测试。

Deployment:
- 新增 nginx 的 HTTP map 和 location 配置，以支持新的前端发布根目录以及后端路由。
- 为专用的 Valkey lmm-api 服务添加 systemd 单元、sysctl 和 tmpfiles 配置。

Documentation:
- 编写专用 Valkey 的部署文档，说明其设置方式、部署/回滚语义，以及 lmm-api 如何连接到该实例。
- 编写前后端升级模型文档，包括零停机的静态前端发布流程以及当前后端部署的限制条件。

Tests:
- 新增基于 shell 的前端发布行为测试（资源冲突、回滚、注入故障）以及 nginx/前端拆分一致性测试。
- 新增 Valkey 部署验证和恢复行为测试，以确保回滚安全，并保护现有的 `6379` 实例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce independent frontend deployment with nginx routing and standardized dedicated Valkey instance, along with validation scripts and documentation for safe upgrades and rollback.

Enhancements:
- Add frontend release script supporting atomic publish/rollback, cumulative immutable asset store, and symlink-based switching.
- Configure nginx locations and cache policies to split SPA traffic from backend APIs, WebSocket/SSE, OAuth, and legacy billing endpoints.
- Add deployment script for a dedicated Valkey instance for lmm-api with isolated config, kernel tuning, health checks, and transactional backup/rollback behavior.

Build:
- Extend makefile with a check-frontend-split target to run frontend/backend split validation and integration tests.

Deployment:
- Add nginx HTTP map and location configs to support the new frontend release root and backend routing.
- Add systemd unit, sysctl, and tmpfiles configuration for the dedicated Valkey lmm-api service.

Documentation:
- Document the dedicated Valkey setup, its deployment/rollback semantics, and how lmm-api should connect to it.
- Document the frontend/backend upgrade model, including zero-downtime static frontend releases and current backend deployment constraints.

Tests:
- Add shell-based tests for frontend release behavior (asset collisions, rollback, injected failures) and nginx/frontend split consistency.
- Add Valkey deployment validation and restore-behavior tests to ensure safe rollback and protection of the existing 6379 instance.

</details>