### PR TITLE
fix(wallet): consolidate payment notes

### DIFF
--- a/web/src/features/wallet/components/recharge-form-card.tsx
+++ b/web/src/features/wallet/components/recharge-form-card.tsx
@@ -199,6 +199,18 @@ export function RechargeFormCard({
       ? formatSettlementAmount(amount, settlementUnit.label)
       : formatPaymentAmount(amount)
   const pancakeCurrencySupported = isWaffoPancakeCurrencySupported()
+  const selectedPresetPricing = (() => {
+    if (selectedPreset === null) return null
+    const preset = presetAmounts.find((item) => item.value === selectedPreset)
+    if (!preset) return null
+    const discount =
+      preset.discount || topupInfo?.discount?.[preset.value] || 1.0
+    return calculatePresetPricing(
+      preset.value,
+      (settlementUnit?.unitPrice ?? priceRatio) * topupGroupRatio,
+      discount
+    )
+  })()
 
   if (loading) {
     return (
@@ -365,30 +377,47 @@ export function RechargeFormCard({
                                 </Badge>
                               )}
                             </div>
-                            <div className='text-muted-foreground mt-1.5 flex w-full min-w-0 flex-col gap-0.5 text-xs sm:mt-2'>
-                              <span>
-                                {t(
-                                  'Estimated actual payment via {{method}}: {{amount}} (original payment {{original}})',
-                                  {
-                                    method: selectedPaymentMethodName,
-                                    amount: payment,
-                                    original: originalPayment,
-                                  }
-                                )}
-                              </span>
-                              {hasDiscount && savedAmount > 0 && (
-                                <span>
-                                  {t('Discount applied {{amount}}', {
-                                    amount:
-                                      formatPresetPaymentAmount(savedAmount),
-                                  })}
-                                </span>
-                              )}
-                            </div>
                           </Button>
                         )
                       })}
                     </div>
+                    <Card className='bg-muted/30 border-dashed shadow-none'>
+                      <CardContent className='space-y-1.5 p-3 text-xs sm:p-4'>
+                        <div className='font-medium'>{t('Payment notes')}</div>
+                        <p className='text-muted-foreground'>
+                          {t(
+                            'The amount shown on each card is the platform credit. The actual payment and any discount are calculated for the selected payment method.'
+                          )}
+                        </p>
+                        {selectedPreset !== null && (
+                          <>
+                            <p className='text-muted-foreground'>
+                              {t(
+                                'Selected method: {{method}} · Estimated payment: {{amount}} (original {{original}})',
+                                {
+                                  method: selectedPaymentMethodName,
+                                  amount: formatPresetPaymentAmount(
+                                    selectedPresetPricing?.actualPrice ?? 0
+                                  ),
+                                  original: formatPresetPaymentAmount(
+                                    selectedPresetPricing?.originalPrice ?? 0
+                                  ),
+                                }
+                              )}
+                            </p>
+                            {selectedPresetPricing?.hasDiscount && (
+                              <p className='text-muted-foreground'>
+                                {t('Discount applied {{amount}}', {
+                                  amount: formatPresetPaymentAmount(
+                                    selectedPresetPricing.savedAmount
+                                  ),
+                                })}
+                              </p>
+                            )}
+                          </>
+                        )}
+                      </CardContent>
+                    </Card>
                   </Field>
                 </FieldGroup>
               )}

--- a/web/src/features/wallet/components/wallet-payment-clarity.test.tsx
+++ b/web/src/features/wallet/components/wallet-payment-clarity.test.tsx
@@ -180,10 +180,8 @@ describe('wallet payment clarity', () => {
       true
     )
     assert.equal(
-      noDiscountPreset?.textContent?.includes(
-        'Estimated actual payment via Alipay: ¥540 CNY (original payment ¥540 CNY)'
-      ),
-      true
+      noDiscountPreset?.textContent?.includes('Estimated actual payment'),
+      false
     )
 
     const discountPreset = rendered.container.querySelector(
@@ -195,10 +193,8 @@ describe('wallet payment clarity', () => {
       true
     )
     assert.equal(
-      discountPreset?.textContent?.includes(
-        'Estimated actual payment via Alipay: ¥864 CNY (original payment ¥1,080 CNY)'
-      ),
-      true
+      discountPreset?.textContent?.includes('Estimated actual payment'),
+      false
     )
 
     const customAmount = rendered.container.querySelector('#topup-amount')
@@ -258,7 +254,7 @@ describe('wallet payment clarity', () => {
     assert.equal(text.includes('100(Platform amount, unit: USD)'), true)
     assert.equal(
       text.includes(
-        'Estimated actual payment via Alipay: ¥80 CNY (original payment ¥100 CNY)'
+        'Selected method: Alipay · Estimated payment: ¥80 CNY (original ¥100 CNY)'
       ),
       true
     )
@@ -355,7 +351,7 @@ describe('wallet payment clarity', () => {
 
     assert.equal(
       recharge.container.textContent?.includes(
-        'Estimated actual payment via LINUX DO Credit: 1.12 LDC (original payment 1.4 LDC)'
+        'Selected method: LINUX DO Credit · Estimated payment: 1.12 LDC (original 1.4 LDC)'
       ),
       true
     )
@@ -414,7 +410,7 @@ describe('wallet payment clarity', () => {
 
     assert.equal(
       rendered.container.textContent?.includes(
-        'Estimated actual payment via Alipay: $0.14 USD (original payment $0.14 USD)'
+        'Selected method: Alipay · Estimated payment: $0.14 USD (original $0.14 USD)'
       ),
       true
     )
@@ -500,7 +496,13 @@ describe('wallet payment clarity', () => {
     )
     assert.equal(
       rendered.container.textContent?.includes(
-        '通过 Alipay 预计实付：¥80 CNY（原价需付款 ¥100 CNY）'
+        '卡片中的金额是平台到账金额，实际支付金额和优惠会根据所选支付方式计算。'
+      ),
+      true
+    )
+    assert.equal(
+      rendered.container.textContent?.includes(
+        '所选方式：Alipay · 预计支付：¥80 CNY（原价 ¥100 CNY）'
       ),
       true
     )
@@ -563,6 +565,10 @@ describe('wallet payment clarity', () => {
     const text = rendered.container.textContent ?? ''
     assert.equal(
       text.includes('通过 Alipay 预计实付：$80 USD（原价需付款 $100 USD）'),
+      false
+    )
+    assert.equal(
+      text.includes('所选方式：Alipay · 预计支付：$80 USD（原价 $100 USD）'),
       true
     )
     assert.equal(text.includes('人民币'), false)

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -5313,6 +5313,9 @@
     "Zero retention": "Zero retention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Payment notes": "Payment notes",
+    "The amount shown on each card is the platform credit. The actual payment and any discount are calculated for the selected payment method.": "The amount shown on each card is the platform credit. The actual payment and any discount are calculated for the selected payment method.",
+    "Selected method: {{method}} · Estimated payment: {{amount}} (original {{original}})": "Selected method: {{method}} · Estimated payment: {{amount}} (original {{original}})"
   }
 }

--- a/web/src/i18n/locales/zh.json
+++ b/web/src/i18n/locales/zh.json
@@ -5313,6 +5313,9 @@
     "Zero retention": "零数据保留",
     "Zhipu": "智谱",
     "Zhipu V4": "智谱 V4",
-    "Zoom": "缩放"
+    "Zoom": "缩放",
+    "Payment notes": "支付说明",
+    "The amount shown on each card is the platform credit. The actual payment and any discount are calculated for the selected payment method.": "卡片中的金额是平台到账金额，实际支付金额和优惠会根据所选支付方式计算。",
+    "Selected method: {{method}} · Estimated payment: {{amount}} (original {{original}})": "所选方式：{{method}} · 预计支付：{{amount}}（原价 {{original}}）"
   }
 }


### PR DESCRIPTION
## Summary

- remove repeated payment breakdown text from each preset card
- add a shared payment-notes card with selected preset details
- update English/Chinese copy and wallet clarity tests

## Verification

- `cd web && bun test src/features/wallet/components/wallet-payment-clarity.test.tsx`
- `cd web && bun run typecheck`
- `cd web && bunx oxfmt --check src/features/wallet/components/recharge-form-card.tsx src/features/wallet/components/wallet-payment-clarity.test.tsx src/i18n/locales/en.json src/i18n/locales/zh.json`

## Summary by Sourcery

将钱包支付信息整合到共享的支付备注区域，并使测试和文案与新的用户体验保持一致。

Enhancements:
- 添加一个共享的支付备注卡片，用于展示所选预设的预估支付金额、原始金额以及所选支付方式的任何优惠。
- 从充值预设按钮中移除每个预设的预估支付文案，以减少重复，并更清晰地区分平台金额与实际支付金额的含义。
- 更新英文和中文的钱包支付文案，以说明平台余额金额以及所选支付方式的支付细节。

Tests:
- 调整钱包支付清晰度相关测试，使其断言新的共享支付备注文案和翻译字符串，而不是针对每个预设的标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate wallet payment information into a shared payment notes section and align tests and translations with the new UX.

Enhancements:
- Add a shared payment-notes card that shows the selected preset’s estimated payment, original amount, and any discount for the chosen payment method.
- Remove per-preset estimated payment text from recharge preset buttons to reduce repetition and clarify the meaning of platform vs actual payment amounts.
- Update English and Chinese wallet payment copy to explain platform credit amounts and selected-method payment details.

Tests:
- Adjust wallet payment clarity tests to assert against the new shared payment notes messaging and translation strings rather than per-preset labels.

</details>