### PR TITLE
fix(docker): require fork-owned image repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,19 @@ jobs:
             echo "::error::Retired Electron npm packaging unexpectedly succeeded"
             exit 1
           fi
+
+  docker-publish-config:
+    name: Docker publish namespace guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: deploy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Validate fork-owned Docker publish namespace
+        run: |
+          bash check-docker-image-namespace.sh
+          bash test-docker-image-namespace.sh

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,8 +13,37 @@ on:
         type: string
 
 jobs:
+  validate:
+    name: Validate fork-owned Docker repository
+    runs-on: ubuntu-latest
+    outputs:
+      repository: ${{ steps.validate.outputs.repository }}
+    steps:
+      - name: Require fork-owned Docker repository
+        id: validate
+        env:
+          IMAGE_REPOSITORY: ${{ vars.DOCKER_IMAGE_REPOSITORY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${IMAGE_REPOSITORY}" ]]; then
+            echo "::error::DOCKER_IMAGE_REPOSITORY is not configured. Set it to this fork's own Docker Hub repository; it must not be calciumion/new-api."
+            exit 1
+          fi
+          if [[ "${IMAGE_REPOSITORY}" == "calciumion/new-api" ]]; then
+            echo "::error::DOCKER_IMAGE_REPOSITORY must not target the upstream calciumion/new-api repository."
+            exit 1
+          fi
+          case "${IMAGE_REPOSITORY}" in
+            *[!A-Za-z0-9._/-]*|[[:space:]]*)
+              echo "::error::DOCKER_IMAGE_REPOSITORY must be a valid Docker repository name."
+              exit 1
+              ;;
+          esac
+          echo "repository=${IMAGE_REPOSITORY}" >> "$GITHUB_OUTPUT"
+
   build_single_arch:
     name: Build & push (${{ matrix.arch }})
+    needs: [validate]
     strategy:
       fail-fast: false
       matrix:
@@ -133,7 +162,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
-          images: calciumion/new-api
+          images: ${{ needs.validate.outputs.repository }}
 
       - name: Build & push
         id: build
@@ -145,8 +174,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            calciumion/new-api:${{ env.TAG }}-${{ matrix.arch }}
-            calciumion/new-api:latest-${{ matrix.arch }}
+            ${{ needs.validate.outputs.repository }}:${{ env.TAG }}-${{ matrix.arch }}
+            ${{ needs.validate.outputs.repository }}:latest-${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -157,19 +186,19 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with cosign
-        run: cosign sign --yes calciumion/new-api@${{ steps.build.outputs.digest }}
+        run: cosign sign --yes ${{ needs.validate.outputs.repository }}@${{ steps.build.outputs.digest }}
 
       - name: Image summary
         run: |
           echo "### Docker Image Digest (${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "calciumion/new-api:${TAG}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.validate.outputs.repository }}:${TAG}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
   create_manifests:
     name: Create multi-arch manifests
-    needs: [build_single_arch]
+    needs: [build_single_arch, validate]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
 
@@ -189,28 +218,28 @@ jobs:
       - name: Create & push manifest (version)
         run: |
           docker buildx imagetools create \
-            -t calciumion/new-api:${TAG} \
-            calciumion/new-api:${TAG}-amd64 \
-            calciumion/new-api:${TAG}-arm64
+            -t ${{ needs.validate.outputs.repository }}:${TAG} \
+            ${{ needs.validate.outputs.repository }}:${TAG}-amd64 \
+            ${{ needs.validate.outputs.repository }}:${TAG}-arm64
 
       - name: Create & push manifest (latest)
         run: |
           docker buildx imagetools create \
-            -t calciumion/new-api:latest \
-            calciumion/new-api:latest-amd64 \
-            calciumion/new-api:latest-arm64
+            -t ${{ needs.validate.outputs.repository }}:latest \
+            ${{ needs.validate.outputs.repository }}:latest-amd64 \
+            ${{ needs.validate.outputs.repository }}:latest-arm64
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign manifests with cosign
         run: |
-          cosign sign --yes calciumion/new-api:${TAG}
-          cosign sign --yes calciumion/new-api:latest
+          cosign sign --yes ${{ needs.validate.outputs.repository }}:${TAG}
+          cosign sign --yes ${{ needs.validate.outputs.repository }}:latest
 
       - name: Manifest summary
         run: |
           echo "### Multi-arch Manifest" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          docker buildx imagetools inspect calciumion/new-api:${TAG} >> $GITHUB_STEP_SUMMARY
+          docker buildx imagetools inspect ${{ needs.validate.outputs.repository }}:${TAG} >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-image-branch.yml
+++ b/.github/workflows/docker-image-branch.yml
@@ -17,6 +17,7 @@ jobs:
       sha: ${{ steps.version.outputs.sha }}
       tag_prefix: ${{ steps.version.outputs.tag_prefix }}
       version: ${{ steps.version.outputs.version }}
+      repository: ${{ steps.validate.outputs.repository }}
     permissions:
       contents: read
     steps:
@@ -25,6 +26,28 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch }}
+
+      - name: Require fork-owned Docker repository
+        id: validate
+        env:
+          IMAGE_REPOSITORY: ${{ vars.DOCKER_IMAGE_REPOSITORY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${IMAGE_REPOSITORY}" ]]; then
+            echo "::error::DOCKER_IMAGE_REPOSITORY is not configured. Set it to this fork's own Docker Hub repository; it must not be calciumion/new-api."
+            exit 1
+          fi
+          if [[ "${IMAGE_REPOSITORY}" == "calciumion/new-api" ]]; then
+            echo "::error::DOCKER_IMAGE_REPOSITORY must not target the upstream calciumion/new-api repository."
+            exit 1
+          fi
+          case "${IMAGE_REPOSITORY}" in
+            *[!A-Za-z0-9._/-]*|[[:space:]]*)
+              echo "::error::DOCKER_IMAGE_REPOSITORY must be a valid Docker repository name."
+              exit 1
+              ;;
+          esac
+          echo "repository=${IMAGE_REPOSITORY}" >> "$GITHUB_OUTPUT"
 
       - name: Require complete Rust production parity
         run: |
@@ -152,7 +175,7 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
-            calciumion/new-api
+            ${{ needs.prepare.outputs.repository }}
 
       - name: Build & push single-arch
         id: build
@@ -164,8 +187,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           push: true
           tags: |
-            calciumion/new-api:${{ needs.prepare.outputs.tag_prefix }}-${{ matrix.arch }}
-            calciumion/new-api:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}
+            ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.tag_prefix }}-${{ matrix.arch }}
+            ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -176,14 +199,14 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign image with cosign
-        run: cosign sign --yes calciumion/new-api@${{ steps.build.outputs.digest }}
+        run: cosign sign --yes ${{ needs.prepare.outputs.repository }}@${{ steps.build.outputs.digest }}
 
       - name: Output digest
         run: |
           echo "### Docker Image Digest (${{ matrix.arch }})" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "calciumion/new-api:${{ needs.prepare.outputs.tag_prefix }}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
-          echo "calciumion/new-api:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.tag_prefix }}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.version }}-${{ matrix.arch }}" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
@@ -203,30 +226,30 @@ jobs:
       - name: Create & push manifest (Docker Hub - branch)
         run: |
           docker buildx imagetools create \
-            -t calciumion/new-api:${{ needs.prepare.outputs.tag_prefix }} \
-            calciumion/new-api:${{ needs.prepare.outputs.tag_prefix }}-amd64 \
-            calciumion/new-api:${{ needs.prepare.outputs.tag_prefix }}-arm64
+            -t ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.tag_prefix }} \
+            ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.tag_prefix }}-amd64 \
+            ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.tag_prefix }}-arm64
 
       - name: Create & push manifest (Docker Hub - versioned)
         run: |
           docker buildx imagetools create \
-            -t calciumion/new-api:${{ needs.prepare.outputs.version }} \
-            calciumion/new-api:${{ needs.prepare.outputs.version }}-amd64 \
-            calciumion/new-api:${{ needs.prepare.outputs.version }}-arm64
+            -t ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.version }} \
+            ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.version }}-amd64 \
+            ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.version }}-arm64
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Sign manifests with cosign
         run: |
-          cosign sign --yes calciumion/new-api:${{ needs.prepare.outputs.tag_prefix }}
-          cosign sign --yes calciumion/new-api:${{ needs.prepare.outputs.version }}
+          cosign sign --yes ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.tag_prefix }}
+          cosign sign --yes ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.version }}
 
       - name: Output manifest digest
         run: |
           echo "### Multi-arch Manifest Digests" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          docker buildx imagetools inspect calciumion/new-api:${{ needs.prepare.outputs.tag_prefix }} >> $GITHUB_STEP_SUMMARY
+          docker buildx imagetools inspect ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.tag_prefix }} >> $GITHUB_STEP_SUMMARY
           echo "---" >> $GITHUB_STEP_SUMMARY
-          docker buildx imagetools inspect calciumion/new-api:${{ needs.prepare.outputs.version }} >> $GITHUB_STEP_SUMMARY
+          docker buildx imagetools inspect ${{ needs.prepare.outputs.repository }}:${{ needs.prepare.outputs.version }} >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY

--- a/deploy/check-docker-image-namespace.sh
+++ b/deploy/check-docker-image-namespace.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflows=("$@")
+if ((${#workflows[@]} == 0)); then
+  workflows=(
+    "$repo_root/.github/workflows/docker-build.yml"
+    "$repo_root/.github/workflows/docker-image-branch.yml"
+  )
+fi
+
+for workflow in "${workflows[@]}"; do
+  [[ -f "$workflow" ]] || { echo "missing workflow: $workflow" >&2; exit 1; }
+  if grep -Eq '(^|[[:space:]])calciumion/new-api([:@]|$)' "$workflow"; then
+    echo "workflow still targets the upstream Docker repository: $workflow" >&2
+    exit 1
+  fi
+  if ! grep -Fq 'DOCKER_IMAGE_REPOSITORY' "$workflow"; then
+    echo "workflow does not require DOCKER_IMAGE_REPOSITORY: $workflow" >&2
+    exit 1
+  fi
+done
+
+echo "docker publish workflows use a fork-owned Docker repository"

--- a/deploy/test-docker-image-namespace.sh
+++ b/deploy/test-docker-image-namespace.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+checker="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/deploy/check-docker-image-namespace.sh"
+runtime="$(mktemp -d "${TMPDIR:-/tmp}/lmm-docker-namespace.XXXXXX")"
+cleanup() { rm -rf -- "$runtime"; }
+trap cleanup EXIT
+
+printf 'push: true\ntags:\n  - calciumion/new-api:latest\n' >"$runtime/upstream.yml"
+if "$checker" "$runtime/upstream.yml" >/dev/null 2>&1; then
+  echo "upstream Docker repository fixture unexpectedly passed" >&2
+  exit 1
+fi
+
+printf 'push: true\ntags:\n  - lightjunction/lmm-api:latest\n' >"$runtime/no-variable.yml"
+if "$checker" "$runtime/no-variable.yml" >/dev/null 2>&1; then
+  echo "missing DOCKER_IMAGE_REPOSITORY fixture unexpectedly passed" >&2
+  exit 1
+fi
+
+cat >"$runtime/fork-owned.yml" <<'YAML'
+push: true
+tags:
+  - ${{ vars.DOCKER_IMAGE_REPOSITORY }}:latest
+YAML
+"$checker" "$runtime/fork-owned.yml" >/dev/null
+
+echo "docker image namespace check passes"


### PR DESCRIPTION
# ⚠️ 提交说明 / PR Notice

> 本次变更为人工整理并核验的发布配置修复，描述基于对工作流文件与 README 的实际核对，非未经整理的 AI 输出。

## 📝 变更描述 / Description

**问题：** 两个 Docker 发布工作流把镜像目标硬编码为上游 `calciumion/new-api`。tag 推送或手动 branch 发布会把本 fork 构建的 `lmm-api-rs` 镜像 push 到上游命名空间（包括 `latest`），与 README 中“上游镜像仅作兼容基线、fork 应自行发布”的说明相悖。

**修复：**
- 将硬编码的 `calciumion/new-api` 替换为仓库变量 `DOCKER_IMAGE_REPOSITORY`：
  - `.github/workflows/docker-build.yml` 新增 `validate` job，输出校验后的仓库名，`build_single_arch` 与 `create_manifests` 全部引用该输出。
  - `.github/workflows/docker-image-branch.yml` 在 `prepare` job 中完成同样校验，并输出 `repository`。
- 校验 fail closed：变量未配置、含非法字符、或等于上游 `calciumion/new-api` 时，工作流在 Docker 登录/构建前直接失败。
- 新增 `deploy/check-docker-image-namespace.sh` 与 `deploy/test-docker-image-namespace.sh`，并在 `ci.yml` 增加 `docker-publish-config` 任务，防止未来重新引入硬编码上游命名空间。

**运维说明：** 仓库需要在 Settings → Variables 中设置 `DOCKER_IMAGE_REPOSITORY` 为本 fork 自己的 Docker Hub 仓库名（例如 `lightjunction/lmm-api`），发布工作流才会继续执行。

## 🚀 变更类型 / Type of change

- [x] 🐛 Bug 修复 (Bug fix) - 已关联对应 Issue #18
- [ ] ✨ 新功能 (New feature)
- [ ] ⚡ 性能优化 / 重构 (Refactor)
- [ ] 📝 文档更新 (Documentation)

## 🔗 关联任务 / Related Issue

- Closes #18

## ✅ 提交前检查项 / Checklist

- [x] **人工确认:** 我已亲自整理并撰写此描述，没有直接粘贴未经处理的 AI 输出。
- [x] **非重复提交:** 我已搜索现有 Issues 与 PRs，确认不是重复提交。
- [x] **Bug fix 说明:** 此 PR 标记为 `Bug fix`，已关联对应 Issue #18，且属于真实发布配置缺陷。
- [x] **变更理解:** 我已理解这些更改的工作原理及可能影响。
- [x] **范围聚焦:** 本 PR 仅包含与 Docker 发布目标相关的 5 个文件改动。
- [x] **本地验证:** 已在本地运行并通过验证（见下方运行证明）。
- [x] **安全合规:** 代码中无敏感凭据，且符合项目代码规范。

## 📸 运行证明 / Proof of Work

```text
$ bash deploy/test-docker-image-namespace.sh
docker image namespace check passes

$ bash deploy/check-docker-image-namespace.sh
docker publish workflows use a fork-owned Docker repository

# 三个 YAML 文件均可被 python yaml.safe_load 解析
# bash -n 与 git show --check 均通过
```

## Summary by Sourcery

强制 Docker 发布工作流将镜像推送到由 fork 所拥有的仓库，而不是上游命名空间；使用带有校验的可配置仓库变量实现这一点。

Bug Fixes:
- 防止 Docker 构建和分支发布工作流将镜像仓库硬编码并推送到上游的 `calciumion/new-api` 仓库。

Enhancements:
- 在 Docker 构建和分支镜像工作流中添加校验步骤，要求配置一个由 fork 拥有的 `DOCKER_IMAGE_REPOSITORY`，并在值无效或指向上游时尽早失败。
- 引入脚本，用于验证 Docker 工作流是否使用 `DOCKER_IMAGE_REPOSITORY` 变量，并新增一个 CI 任务，防止重新引入硬编码的上游镜像命名空间。

CI:
- 新增一个 CI 任务，运行 Docker 发布命名空间检查，以确保工作流始终配置为使用 fork 所拥有的仓库。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce that Docker publish workflows push images to a fork-owned repository rather than the upstream namespace, using a configurable repository variable with validation.

Bug Fixes:
- Prevent Docker build and branch-publish workflows from hardcoding and pushing images to the upstream calciumion/new-api repository.

Enhancements:
- Add validation steps in Docker build and branch image workflows that require a configured, fork-owned DOCKER_IMAGE_REPOSITORY and fail early on invalid or upstream values.
- Introduce scripts to verify Docker workflows use the DOCKER_IMAGE_REPOSITORY variable and add a CI job to guard against reintroducing hardcoded upstream image namespaces.

CI:
- Add a CI job that runs Docker publish namespace checks to ensure workflows remain configured for fork-owned repositories.

</details>