### PR TITLE
fix(bounties): repair PostgreSQL and MCP production paths

### DIFF
--- a/apps/api-go/controller/open_source_bounty_mcp_server.go
+++ b/apps/api-go/controller/open_source_bounty_mcp_server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-const openSourceBountyMCPProtocolVersion = "2026-07-28"
+const openSourceBountyMCPProtocolVersion = "2025-11-25"
 
 type bountyMCPOutput struct {
 	Message        string `json:"message"`

--- a/apps/api-go/controller/open_source_bounty_mcp_token.go
+++ b/apps/api-go/controller/open_source_bounty_mcp_token.go
@@ -13,7 +13,7 @@ func GetOpenSourceBountyMCPToken(c *gin.Context) {
 		return
 	}
 	common.ApiSuccess(c, gin.H{
-		"status": status, "endpoint": "/mcp", "protocol_version": "2026-07-28",
+		"status": status, "endpoint": "/mcp", "protocol_version": openSourceBountyMCPProtocolVersion,
 	})
 }
 
@@ -24,7 +24,7 @@ func RotateOpenSourceBountyMCPToken(c *gin.Context) {
 		return
 	}
 	common.ApiSuccess(c, gin.H{
-		"token": token, "status": status, "endpoint": "/mcp", "protocol_version": "2026-07-28",
+		"token": token, "status": status, "endpoint": "/mcp", "protocol_version": openSourceBountyMCPProtocolVersion,
 	})
 }
 

--- a/apps/api-go/model/open_source_bounty.go
+++ b/apps/api-go/model/open_source_bounty.go
@@ -148,7 +148,7 @@ type OpenSourceBountyProjectView struct {
 	ApprovedChallengeCount int64                      `json:"approved_challenge_count"`
 	OwnerRatingAverage     float64                    `json:"owner_rating_average"`
 	OwnerRatingCount       int64                      `json:"owner_rating_count"`
-	ViewerChallenge        *OpenSourceBountyChallenge `json:"viewer_challenge,omitempty"`
+	ViewerChallenge        *OpenSourceBountyChallenge `json:"viewer_challenge,omitempty" gorm:"-"`
 }
 
 type OpenSourceBountyChallengeView struct {

--- a/apps/api-go/model/open_source_bounty_mcp.go
+++ b/apps/api-go/model/open_source_bounty_mcp.go
@@ -160,7 +160,7 @@ func VerifyOpenSourceBountyMCPToken(rawToken string) (int, error) {
 	var token OpenSourceBountyMCPToken
 	err := DB.Table("open_source_bounty_mcp_tokens AS token").
 		Select("token.*").
-		Joins("JOIN users user ON user.id = token.user_id AND user.deleted_at IS NULL AND user.status = ?", common.UserStatusEnabled).
+		Joins("JOIN users AS token_user ON token_user.id = token.user_id AND token_user.deleted_at IS NULL AND token_user.status = ?", common.UserStatusEnabled).
 		Where("token.token_hash = ?", openSourceBountyMCPTokenHash(rawToken)).
 		First(&token).Error
 	if err != nil {

--- a/apps/api-go/model/open_source_bounty_test.go
+++ b/apps/api-go/model/open_source_bounty_test.go
@@ -185,6 +185,14 @@ func TestOpenSourceBountyTipsAndMutualRatings(t *testing.T) {
 	assert.Equal(t, float64(5), accepted[0].OwnerRatingAverage)
 	assert.Equal(t, int64(1), accepted[0].OwnerRatingCount)
 
+	detail, err := GetOpenSourceBountyDetail(owner.Id, project.Id)
+	require.NoError(t, err)
+	require.Len(t, detail.Challenges, 1)
+	assert.Equal(t, float64(4), detail.Challenges[0].ParticipantRatingAverage)
+	assert.Equal(t, int64(1), detail.Challenges[0].ParticipantRatingCount)
+	assert.Equal(t, float64(5), detail.Challenges[0].OwnerRatingAverage)
+	assert.Equal(t, int64(1), detail.Challenges[0].OwnerRatingCount)
+
 	var tipLedger OpenSourceBountyLedger
 	require.NoError(t, db.Where("challenge_id = ? AND kind = ?", challenge.Id, OpenSourceBountyLedgerTipTransfer).First(&tipLedger).Error)
 	assert.Equal(t, 250, tipLedger.Quota)

--- a/apps/web/src/features/open-source-bounties/index.tsx
+++ b/apps/web/src/features/open-source-bounties/index.tsx
@@ -2620,7 +2620,7 @@ function McpSettingsPanel() {
     typeof window === 'undefined'
       ? '/mcp'
       : `${window.location.origin}${connectionQuery.data?.endpoint ?? '/mcp'}`
-  const protocolVersion = connectionQuery.data?.protocol_version ?? '2026-07-28'
+  const protocolVersion = connectionQuery.data?.protocol_version ?? '2025-11-25'
   const prompt = useMemo(
     () => `Connect to the api.lmm.best Open-source bounties MCP server.
 


### PR DESCRIPTION
# LMM API Pull Request

> LMM API 是 New API 的衍生版本。请说明本次变更与上游的关系，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

修复开源悬赏功能在 PostgreSQL 和 MCP 生产路径上的三个问题：项目详情查询不再让 GORM 映射仅用于响应的 `ViewerChallenge` 字段；个人 MCP Token 查询不再使用 PostgreSQL 保留字 `user` 作为表别名；MCP 服务端、Token API 和网页端统一报告 SDK 当前支持的最新稳定协议版本 `2025-11-25`。

同时补充项目详情中的双向评分回归断言，覆盖验收者与接单者互相可见的评分聚合。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A，开源悬赏与 `/mcp` 为 LMM API 独有功能。

## 关联 Issue / Related issue

N/A

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [x] 前端或交互 / Frontend or UX
- [x] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
command: cd apps/api-go && go test ./model ./controller
result: ok (model 13.259s, controller 4.639s)

command: cd apps/web && bun test src/features/open-source-bounties src/features/support-ticket
result: 5 pass, 0 fail

command: isolated Arch Linux PostgreSQL + Valkey lifecycle E2E
result: pass; 21 MCP tools, 2.5% admin fee, no default projects,
        publish/accept/submit/tip/rate/approve/pay/dispute/admin settlement,
        personal MCP token authentication, and restart persistence verified
```

## 截图或日志 / Screenshots or logs

```text
E2E PASS
users,99980575,17500,0
projects,2,425,1500
ledgers,9,36425
disputes,1,1
mcp_tools=21 fee_rate=2.5 default_projects=0 normal_transfer=10000 tip_transfer=500 dispute_transfer=7000
```

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更与上游 New API 的关系，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；无破坏性迁移。
- [x] 我已补充相关测试，并在上方记录实际验证结果。
- [x] 文档与多语言文案不受影响；未修改 i18n 文件。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Summary by Sourcery

修复开源悬赏流程中的 PostgreSQL 和 MCP 生产环境问题，并在 API 和 Web 之间统一 MCP 协议版本报告方式。

Bug Fixes:
- 防止 GORM 在开源悬赏项目视图中持久化仅面向当前查看者的 `ViewerChallenge` 字段。
- 在验证 MCP token 时，避免使用 PostgreSQL 保留字 `user` 作为表别名。
- 在 MCP 服务器、token API 和 Web UI 之间，将 MCP 协议版本报告统一到受支持的稳定版本 `2025-11-25`。

Tests:
- 扩展开源悬赏的双向互评测试，用于断言双向评分汇总在项目详情中被正确暴露。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix PostgreSQL and MCP production issues in the open-source bounties flow and align MCP protocol version reporting across API and web.

Bug Fixes:
- Prevent GORM from persisting the viewer-specific ViewerChallenge field in open-source bounty project views.
- Avoid using the PostgreSQL reserved word user as a table alias when verifying MCP tokens.
- Align MCP protocol version reporting between the MCP server, token APIs, and web UI to the supported stable version 2025-11-25.

Tests:
- Extend open-source bounty mutual ratings tests to assert bidirectional rating aggregates are correctly exposed in project details.

</details>