### PR TITLE
fix(bounties): normalize empty list responses

### DIFF
--- a/apps/api-go/model/open_source_bounty.go
+++ b/apps/api-go/model/open_source_bounty.go
@@ -658,7 +658,7 @@ func ListOpenSourceBounties(viewerUserId int, page int, pageSize int) ([]OpenSou
 	if err := DB.Model(&OpenSourceBountyProject{}).Where("status IN ?", statuses).Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
-	var views []OpenSourceBountyProjectView
+	views := make([]OpenSourceBountyProjectView, 0)
 	err := openSourceBountyProjectQuery().Where("p.status IN ?", statuses).
 		Order("p.promotion_quota DESC, p.published_at DESC, p.id DESC").
 		Offset((page - 1) * pageSize).Limit(pageSize).Scan(&views).Error
@@ -672,7 +672,7 @@ func ListOpenSourceBounties(viewerUserId int, page int, pageSize int) ([]OpenSou
 }
 
 func ListOwnedOpenSourceBounties(ownerUserId int) ([]OpenSourceBountyProjectView, error) {
-	var views []OpenSourceBountyProjectView
+	views := make([]OpenSourceBountyProjectView, 0)
 	if err := openSourceBountyProjectQuery().Where("p.owner_user_id = ?", ownerUserId).
 		Order("p.created_at DESC, p.id DESC").Scan(&views).Error; err != nil {
 		return nil, err
@@ -750,7 +750,7 @@ func openSourceBountyChallengeViewQuery() *gorm.DB {
 }
 
 func ListAcceptedOpenSourceBounties(participantUserId int) ([]OpenSourceBountyChallengeView, error) {
-	var views []OpenSourceBountyChallengeView
+	views := make([]OpenSourceBountyChallengeView, 0)
 	if err := openSourceBountyChallengeViewQuery().Where("c.participant_user_id = ?", participantUserId).
 		Order("c.updated_at DESC, c.id DESC").Scan(&views).Error; err != nil {
 		return nil, err

--- a/apps/api-go/model/open_source_bounty_dispute.go
+++ b/apps/api-go/model/open_source_bounty_dispute.go
@@ -256,7 +256,7 @@ func ListOpenSourceBountyDisputesFiltered(userId int, admin bool, status string,
 	if limit > 100 {
 		limit = 100
 	}
-	var views []OpenSourceBountyDisputeView
+	views := make([]OpenSourceBountyDisputeView, 0)
 	query := openSourceBountyDisputeViewQuery()
 	if admin {
 		var user User

--- a/apps/api-go/model/open_source_bounty_test.go
+++ b/apps/api-go/model/open_source_bounty_test.go
@@ -80,6 +80,32 @@ func openSourceBountyInput(repository string, promotion int, reward int, slots i
 	}
 }
 
+func TestOpenSourceBountyEmptyListQueriesReturnNonNilSlices(t *testing.T) {
+	db := setupOpenSourceBountyTestDB(t)
+	user := createOpenSourceBountyUser(t, db, "empty-list-user", 0, common.RoleCommonUser)
+
+	projects, total, err := ListOpenSourceBounties(user.Id, 1, 20)
+	require.NoError(t, err)
+	assert.Zero(t, total)
+	assert.NotNil(t, projects)
+	assert.Empty(t, projects)
+
+	owned, err := ListOwnedOpenSourceBounties(user.Id)
+	require.NoError(t, err)
+	assert.NotNil(t, owned)
+	assert.Empty(t, owned)
+
+	accepted, err := ListAcceptedOpenSourceBounties(user.Id)
+	require.NoError(t, err)
+	assert.NotNil(t, accepted)
+	assert.Empty(t, accepted)
+
+	disputes, err := ListOpenSourceBountyDisputes(user.Id, false)
+	require.NoError(t, err)
+	assert.NotNil(t, disputes)
+	assert.Empty(t, disputes)
+}
+
 func TestOpenSourceBountyLifecycleChargesOwnerAndTransfersEscrow(t *testing.T) {
 	db := setupOpenSourceBountyTestDB(t)
 	owner := createOpenSourceBountyUser(t, db, "root-owner", 10_000, common.RoleRootUser)

--- a/apps/web/src/features/open-source-bounties/api.test.ts
+++ b/apps/web/src/features/open-source-bounties/api.test.ts
@@ -21,12 +21,29 @@ import { afterEach, describe, test } from 'node:test'
 
 import { api } from '@/lib/api'
 
-import { tipChallenge } from './api'
+import { listBounties, tipChallenge } from './api'
 
+const originalGet = api.get
 const originalPost = api.post
 
 afterEach(() => {
+  api.get = originalGet
   api.post = originalPost
+})
+
+describe('open-source bounty lists', () => {
+  test('normalizes a null project list from an empty database to an array', async () => {
+    api.get = (async () => ({
+      data: {
+        success: true,
+        data: { items: null, total: 0 },
+      },
+    })) as typeof api.get
+
+    const result = await listBounties()
+
+    assert.deepEqual(result, { items: [], total: 0 })
+  })
 })
 
 describe('open-source bounty tips', () => {

--- a/apps/web/src/features/open-source-bounties/api.ts
+++ b/apps/web/src/features/open-source-bounties/api.ts
@@ -48,10 +48,11 @@ async function unwrap<T>(request: Promise<{ data: ApiEnvelope<T> }>) {
   return response.data.data
 }
 
-export function listBounties() {
-  return unwrap<{ items: BountyProject[]; total: number }>(
+export async function listBounties() {
+  const result = await unwrap<{ items: BountyProject[] | null; total: number }>(
     api.get('/api/open-source-bounties?page=1&page_size=50')
   )
+  return { ...result, items: result.items ?? [] }
 }
 
 export function getBountyConfig() {


### PR DESCRIPTION
# LMM API Pull Request

> LMM API 是 New API 的衍生版本。请说明本次变更与上游的关系，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

Fix the production Open-source bounties error boundary triggered by an empty database. Go list queries now return non-nil empty slices so REST and MCP serialize empty collections as `[]`, and the web API boundary normalizes a legacy `items: null` response before rendering.

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A; Open-source bounties is an LMM API feature.

## 关联 Issue / Related issue

N/A; production regression found during deployment verification.

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [x] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
command: go test ./model -run '^TestOpenSourceBountyEmptyListQueriesReturnNonNilSlices$' -count=1
result: pass

command: go test ./model ./controller
result: pass

command: bun test src/features/open-source-bounties
result: 4 pass, 0 fail

command: bun run typecheck
result: pass

command: bunx oxlint -c .oxlintrc.json src/features/open-source-bounties/api.ts src/features/open-source-bounties/api.test.ts
result: pass

command: bunx oxfmt --check src/features/open-source-bounties/api.ts src/features/open-source-bounties/api.test.ts
result: pass

command: just build-web
result: pass
```

Production verification after the atomic frontend hotfix: `/open-source-bounties` returned 200, `/api/status` returned 200, unauthenticated `POST /mcp` returned 401, and Go, nginx, PostgreSQL, and Valkey remained active.

## 截图或日志 / Screenshots or logs

The production failure was reproduced by an empty `open_source_bounty_projects` table and a `data.items: null` response. The pre-fix web regression test failed with `actual.items: null`; the same test passes with `items: []` after this change.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更与上游 New API 的关系，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。本修复没有新增或修改文案。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Summary by Sourcery

规范开源悬赏列表的响应，避免返回空（null）集合，并在整个 API 和 Web 客户端中确保一致的空数组处理行为。

Bug Fixes:
- 确保 Go 开源悬赏列表和争议查询在无记录时返回非 nil 的空切片。
- 在 Web API 客户端中，将悬赏项目列表中的 null 值在渲染前规范化为空数组。
- 添加回归测试，验证在 Go 模型逻辑和 Web 悬赏 API 客户端中对空列表的处理行为。

Tests:
- 添加 Go 测试，断言开源悬赏列表和争议查询函数在数据库为空时返回非 nil 的空集合。
- 添加 Web API 测试，验证在开源悬赏功能中，悬赏项目列表中的 null 值被规范化为空数组。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize open-source bounty list responses to avoid null collections and ensure consistent empty-array handling across the API and web client.

Bug Fixes:
- Ensure Go open-source bounty list and dispute queries return non-nil empty slices when no records exist.
- Normalize null bounty project lists in the web API client to empty arrays before rendering.
- Add regression tests verifying empty-list behavior in both Go model logic and the web bounty API client.

Tests:
- Add Go tests asserting open-source bounty list and dispute query functions return non-nil, empty collections for empty databases.
- Add web API tests verifying null bounty project lists are normalized to empty arrays in the open-source bounties feature.

</details>