### PR TITLE
fix(bounty): allow manual numeric entry

### DIFF
--- a/apps/web/src/features/open-source-bounties/__tests__/validation.test.ts
+++ b/apps/web/src/features/open-source-bounties/__tests__/validation.test.ts
@@ -22,6 +22,7 @@ import { describe, test } from 'node:test'
 import {
   type BountyDraftValidationInput,
   calculateBountyCharge,
+  parseBountyNumericInput,
   validateBountyDraft,
   validateBountySubmissionLinks,
 } from '../validation'
@@ -40,6 +41,56 @@ const VALID_DRAFT: BountyDraftValidationInput = {
 describe('bounty draft validation', () => {
   test('accepts a complete draft with a canonical GitHub repository URL', () => {
     assert.deepEqual(validateBountyDraft(VALID_DRAFT), {})
+  })
+
+  test('accepts manually entered numeric text while keeping empty inputs invalid', () => {
+    assert.deepEqual(
+      validateBountyDraft({
+        ...VALID_DRAFT,
+        rewardAmount: '0.25',
+        rewardSlots: '2',
+      }),
+      {}
+    )
+
+    const emptyNumericErrors = validateBountyDraft({
+      ...VALID_DRAFT,
+      rewardAmount: '',
+      rewardSlots: '',
+    })
+    assert.equal(
+      emptyNumericErrors.rewardAmount,
+      'Reward per fix must be greater than zero.'
+    )
+    assert.equal(
+      emptyNumericErrors.rewardSlots,
+      'Reward slots must be a whole number between 1 and 100.'
+    )
+
+    assert.deepEqual(
+      validateBountyDraft({
+        ...VALID_DRAFT,
+        rewardAmount: ' 0.25 ',
+        rewardSlots: ' 2 ',
+      }),
+      {}
+    )
+
+    for (const value of ['   ', 'not-a-number']) {
+      const malformedNumericErrors = validateBountyDraft({
+        ...VALID_DRAFT,
+        rewardAmount: value,
+        rewardSlots: value,
+      })
+      assert.equal(
+        malformedNumericErrors.rewardAmount,
+        'Reward per fix must be greater than zero.'
+      )
+      assert.equal(
+        malformedNumericErrors.rewardSlots,
+        'Reward slots must be a whole number between 1 and 100.'
+      )
+    }
   })
 
   test('reports every invalid field with a specific message', () => {
@@ -83,6 +134,20 @@ describe('bounty draft validation', () => {
 })
 
 describe('bounty publication charge', () => {
+  test('keeps invalid in-progress numeric inputs out of the charge preview', () => {
+    const reward = parseBountyNumericInput(' ')
+    const slots = parseBountyNumericInput('not-a-number')
+
+    assert.deepEqual(calculateBountyCharge(reward, slots, 250), {
+      gross: 0,
+      netReward: 0,
+      escrow: 0,
+      platformFee: 0,
+      feeRatePercent: 2.5,
+      total: 0,
+    })
+  })
+
   test('deducts the public fee from each listed reward instead of adding it', () => {
     assert.deepEqual(calculateBountyCharge(5_000_000, 20, 100), {
       gross: 100_000_000,

--- a/apps/web/src/features/open-source-bounties/index.tsx
+++ b/apps/web/src/features/open-source-bounties/index.tsx
@@ -116,6 +116,7 @@ import {
   type BountyCharge,
   type BountyDraftErrors,
   calculateBountyCharge,
+  parseBountyNumericInput,
   validateBountyDraft,
   validateBountySubmissionLinks,
 } from './validation'
@@ -178,8 +179,8 @@ type DraftForm = {
   title: string
   description: string
   rules: string
-  rewardAmount: number
-  rewardSlots: number
+  rewardAmount: string
+  rewardSlots: string
 }
 
 const EMPTY_DRAFT: DraftForm = {
@@ -187,8 +188,8 @@ const EMPTY_DRAFT: DraftForm = {
   title: '',
   description: '',
   rules: '',
-  rewardAmount: 0,
-  rewardSlots: 1,
+  rewardAmount: '',
+  rewardSlots: '1',
 }
 
 function projectToDraft(project: BountyProject): DraftForm {
@@ -197,8 +198,8 @@ function projectToDraft(project: BountyProject): DraftForm {
     title: project.title,
     description: project.description,
     rules: project.rules,
-    rewardAmount: quotaUnitsToDollars(project.reward_quota),
-    rewardSlots: project.reward_slots,
+    rewardAmount: String(quotaUnitsToDollars(project.reward_quota)),
+    rewardSlots: String(project.reward_slots),
   }
 }
 
@@ -292,9 +293,15 @@ export function OpenSourceBounties() {
   })
 
   const draftCharge = useMemo(() => {
-    const reward = parseQuotaFromDollars(draft.rewardAmount)
+    const reward = parseQuotaFromDollars(
+      parseBountyNumericInput(draft.rewardAmount)
+    )
     const feeRateBps = configQuery.data?.rate_basis_points ?? 0
-    return calculateBountyCharge(reward, draft.rewardSlots, feeRateBps)
+    return calculateBountyCharge(
+      reward,
+      parseBountyNumericInput(draft.rewardSlots),
+      feeRateBps
+    )
   }, [
     configQuery.data?.rate_basis_points,
     draft.rewardAmount,
@@ -368,8 +375,10 @@ export function OpenSourceBounties() {
       title: draft.title.trim(),
       description: draft.description.trim(),
       rules: draft.rules.trim(),
-      reward_quota: parseQuotaFromDollars(draft.rewardAmount),
-      reward_slots: draft.rewardSlots,
+      reward_quota: parseQuotaFromDollars(
+        parseBountyNumericInput(draft.rewardAmount)
+      ),
+      reward_slots: parseBountyNumericInput(draft.rewardSlots),
     }
     const success = await runAction(
       'save-draft',
@@ -1739,8 +1748,9 @@ function DraftDialog(props: {
             id='bounty-reward'
             type='number'
             min={0}
+            step='any'
             value={props.draft.rewardAmount}
-            onChange={(e) => update('rewardAmount', Number(e.target.value))}
+            onChange={(e) => update('rewardAmount', e.target.value)}
             aria-invalid={Boolean(props.errors.rewardAmount)}
             aria-describedby={
               props.errors.rewardAmount ? 'bounty-reward-error' : undefined
@@ -1759,7 +1769,7 @@ function DraftDialog(props: {
             max={100}
             step={1}
             value={props.draft.rewardSlots}
-            onChange={(e) => update('rewardSlots', Number(e.target.value))}
+            onChange={(e) => update('rewardSlots', e.target.value)}
             aria-invalid={Boolean(props.errors.rewardSlots)}
             aria-describedby={
               props.errors.rewardSlots ? 'bounty-slots-error' : undefined

--- a/apps/web/src/features/open-source-bounties/validation.ts
+++ b/apps/web/src/features/open-source-bounties/validation.ts
@@ -23,8 +23,8 @@ export type BountyDraftValidationInput = {
   title: string
   description: string
   rules: string
-  rewardAmount: number
-  rewardSlots: number
+  rewardAmount: number | string
+  rewardSlots: number | string
 }
 
 export type BountyDraftErrors = Partial<
@@ -45,15 +45,21 @@ export type BountySubmissionLinks = {
   pullRequestUrl: string
 }
 
+export function parseBountyNumericInput(value: number | string): number {
+  if (typeof value === 'string' && value.trim() === '') return Number.NaN
+  return Number(value)
+}
+
 export function calculateBountyCharge(
   rewardQuota: number,
   rewardSlots: number,
   feeRateBasisPoints: number
 ): BountyCharge {
-  const slots = Math.max(0, rewardSlots)
-  const feePerSlot = Math.ceil((rewardQuota * feeRateBasisPoints) / 10_000)
-  const netReward = Math.max(0, rewardQuota - feePerSlot)
-  const gross = rewardQuota * slots
+  const reward = Number.isFinite(rewardQuota) ? Math.max(0, rewardQuota) : 0
+  const slots = Number.isFinite(rewardSlots) ? Math.max(0, rewardSlots) : 0
+  const feePerSlot = Math.ceil((reward * feeRateBasisPoints) / 10_000)
+  const netReward = Math.max(0, reward - feePerSlot)
+  const gross = reward * slots
   const platformFee = feePerSlot * slots
   return {
     gross,
@@ -91,6 +97,8 @@ export function validateBountyDraft(
   draft: BountyDraftValidationInput
 ): BountyDraftErrors {
   const errors: BountyDraftErrors = {}
+  const rewardAmount = parseBountyNumericInput(draft.rewardAmount)
+  const rewardSlots = parseBountyNumericInput(draft.rewardSlots)
   const titleLength = draft.title.trim().length
   const descriptionLength = draft.description.trim().length
   const rulesLength = draft.rules.trim().length
@@ -110,14 +118,10 @@ export function validateBountyDraft(
     errors.rules =
       'Acceptance and verification rules must contain 20 to 5000 characters.'
   }
-  if (!Number.isFinite(draft.rewardAmount) || draft.rewardAmount <= 0) {
+  if (!Number.isFinite(rewardAmount) || rewardAmount <= 0) {
     errors.rewardAmount = 'Reward per fix must be greater than zero.'
   }
-  if (
-    !Number.isInteger(draft.rewardSlots) ||
-    draft.rewardSlots < 1 ||
-    draft.rewardSlots > 100
-  ) {
+  if (!Number.isInteger(rewardSlots) || rewardSlots < 1 || rewardSlots > 100) {
     errors.rewardSlots =
       'Reward slots must be a whole number between 1 and 100.'
   }


### PR DESCRIPTION
# LMM API Pull Request

> LMM API 是 New API 的衍生版本。请说明本次变更与上游的关系，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

修复创建悬赏时金额与名额无法稳定手动填写的问题。数值输入在编辑过程中保留文本状态，校验及提交时再转换为数字；金额输入允许合法小数，名额仍限制为 1–100 的整数。补充回归测试，覆盖手动输入数字文本和空值校验。

本变更由 AI 辅助完成，并由仓库维护者执行验证、签名提交和发布。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A，开源悬赏是 LMM API 独有功能。

## 关联 Issue / Related issue

Closes #

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [x] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
command: bun test src/features/open-source-bounties/__tests__/validation.test.ts
result: 8 pass, 0 fail

command: bun run typecheck
result: passed

command: bun run format:check
result: passed

command: bunx oxlint -c .oxlintrc.json src/features/open-source-bounties/index.tsx src/features/open-source-bounties/validation.ts src/features/open-source-bounties/__tests__/validation.test.ts
result: passed
```

## 截图或日志 / Screenshots or logs

N/A；回归由输入状态与校验测试覆盖。

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更与上游 New API 的关系，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Summary by Sourcery

允许赏金奖励金额和名额数量以文本形式输入和存储，将数值转换延后到校验和提交阶段，以改善手动输入的处理体验。

Bug Fixes:
- 修复在手动输入奖励金额和名额值时的稳定性问题，支持数值文本输入，包括金额的小数，同时对名额强制限制为 1–100 的整数。
- 确保空的奖励金额和名额输入保持为无效状态，并提供清晰的校验错误信息。

Enhancements:
- 调整草稿费用计算和草稿保存逻辑，仅在计算和提交时将基于文本的奖励字段转换为数字。
- 更新表单字段配置，以支持奖励金额的任意小数步长，同时保持名额输入限制为整数。

Tests:
- 添加回归测试，覆盖奖励字段的手动数值文本输入，以及对空输入的校验行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow bounty reward amount and slot count to be entered and stored as text, with numeric conversion deferred to validation and submission to improve manual input handling.

Bug Fixes:
- Fix instability when manually entering reward amount and slot values by accepting numeric text input, including decimals for amounts and enforcing 1–100 integers for slots.
- Ensure empty reward amount and slot inputs remain invalid and surface clear validation errors.

Enhancements:
- Adjust draft charge calculation and draft saving logic to convert text-based reward fields to numbers only at computation and submission time.
- Update form field configuration to support arbitrary decimal steps for reward amounts while keeping slot input constrained to whole numbers.

Tests:
- Add regression tests covering manual numeric text entry for reward fields and validation behavior for empty inputs.

</details>