### PR TITLE
fix: protect Midjourney image relay URLs from cross-user access

### DIFF
--- a/apps/api-go/controller/midjourney.go
+++ b/apps/api-go/controller/midjourney.go
@@ -12,6 +12,7 @@ import (
 	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/logger"
 	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/relay"
 	"github.com/QuantumNous/new-api/service"
 	"github.com/QuantumNous/new-api/setting"
 	"github.com/QuantumNous/new-api/setting/system_setting"
@@ -309,7 +310,7 @@ func GetAllMidjourney(c *gin.Context) {
 
 	if setting.MjForwardUrlEnabled {
 		for i, midjourney := range items {
-			midjourney.ImageUrl = system_setting.ServerAddress + "/mj/image/" + midjourney.MjId
+			midjourney.ImageUrl = relay.BuildMidjourneyImageURL(system_setting.ServerAddress, midjourney.UserId, midjourney.MjId)
 			items[i] = midjourney
 		}
 	}
@@ -334,7 +335,7 @@ func GetUserMidjourney(c *gin.Context) {
 
 	if setting.MjForwardUrlEnabled {
 		for i, midjourney := range items {
-			midjourney.ImageUrl = system_setting.ServerAddress + "/mj/image/" + midjourney.MjId
+			midjourney.ImageUrl = relay.BuildMidjourneyImageURL(system_setting.ServerAddress, midjourney.UserId, midjourney.MjId)
 			items[i] = midjourney
 		}
 	}

--- a/apps/api-go/relay/mjproxy_handler.go
+++ b/apps/api-go/relay/mjproxy_handler.go
@@ -2,11 +2,15 @@ package relay
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -28,9 +32,17 @@ import (
 
 func RelayMidjourneyImage(c *gin.Context) {
 	taskId := c.Param("id")
-	midjourneyTask := model.GetByOnlyMJId(taskId)
+	signature := c.Query("sig")
+	userID, err := strconv.Atoi(c.Query("uid"))
+	if err != nil || userID <= 0 || !verifyMidjourneyImageSignature(userID, taskId, signature) {
+		c.JSON(http.StatusUnauthorized, gin.H{
+			"error": "midjourney_image_signature_invalid",
+		})
+		return
+	}
+	midjourneyTask := model.GetByMJId(userID, taskId)
 	if midjourneyTask == nil {
-		c.JSON(400, gin.H{
+		c.JSON(http.StatusNotFound, gin.H{
 			"error": "midjourney_task_not_found",
 		})
 		return
@@ -97,6 +109,33 @@ func RelayMidjourneyImage(c *gin.Context) {
 	return
 }
 
+func midjourneyImageSignature(userID int, taskID string) string {
+	mac := hmac.New(sha256.New, []byte(common.SessionSecret))
+	_, _ = mac.Write([]byte(fmt.Sprintf("midjourney-image-v1:%d:%s", userID, taskID)))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func verifyMidjourneyImageSignature(userID int, taskID, signature string) bool {
+	if userID <= 0 || taskID == "" || signature == "" {
+		return false
+	}
+	expected := midjourneyImageSignature(userID, taskID)
+	provided, err := hex.DecodeString(signature)
+	if err != nil {
+		return false
+	}
+	want, err := hex.DecodeString(expected)
+	return err == nil && hmac.Equal(provided, want)
+}
+
+// BuildMidjourneyImageURL returns a bearer URL bound to one user's task.
+func BuildMidjourneyImageURL(baseURL string, userID int, taskID string) string {
+	query := url.Values{}
+	query.Set("uid", strconv.Itoa(userID))
+	query.Set("sig", midjourneyImageSignature(userID, taskID))
+	return strings.TrimRight(baseURL, "/") + "/mj/image/" + url.PathEscape(taskID) + "?" + query.Encode()
+}
+
 func RelayMidjourneyNotify(c *gin.Context) *dto.MidjourneyResponse {
 	var midjRequest dto.MidjourneyDto
 	err := common.UnmarshalBodyReusable(c, &midjRequest)
@@ -150,9 +189,15 @@ func coverMidjourneyTaskDto(c *gin.Context, originTask *model.Midjourney) (midjo
 	midjourneyTask.FinishTime = originTask.FinishTime
 	midjourneyTask.ImageUrl = ""
 	if originTask.ImageUrl != "" && setting.MjForwardUrlEnabled {
-		midjourneyTask.ImageUrl = system_setting.ServerAddress + "/mj/image/" + originTask.MjId
+		midjourneyTask.ImageUrl = BuildMidjourneyImageURL(system_setting.ServerAddress, originTask.UserId, originTask.MjId)
 		if originTask.Status != "SUCCESS" {
-			midjourneyTask.ImageUrl += "?rand=" + strconv.FormatInt(time.Now().UnixNano(), 10)
+			imageURL, err := url.Parse(midjourneyTask.ImageUrl)
+			if err == nil {
+				query := imageURL.Query()
+				query.Set("rand", strconv.FormatInt(time.Now().UnixNano(), 10))
+				imageURL.RawQuery = query.Encode()
+				midjourneyTask.ImageUrl = imageURL.String()
+			}
 		}
 	} else {
 		midjourneyTask.ImageUrl = originTask.ImageUrl

--- a/apps/api-go/relay/mjproxy_handler_test.go
+++ b/apps/api-go/relay/mjproxy_handler_test.go
@@ -1,0 +1,40 @@
+package relay
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/setting"
+	"github.com/QuantumNous/new-api/setting/system_setting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCoverMidjourneyTaskDtoPreservesSignatureWithCacheBuster(t *testing.T) {
+	previousForwardURL := setting.MjForwardUrlEnabled
+	previousServerAddress := system_setting.ServerAddress
+	setting.MjForwardUrlEnabled = true
+	system_setting.ServerAddress = "https://example.com"
+	t.Cleanup(func() {
+		setting.MjForwardUrlEnabled = previousForwardURL
+		system_setting.ServerAddress = previousServerAddress
+	})
+
+	task := &model.Midjourney{
+		UserId:   101,
+		MjId:     "unfinished-task",
+		ImageUrl: "https://upstream.example/image.png",
+		Status:   "IN_PROGRESS",
+	}
+	dto := coverMidjourneyTaskDto(nil, task)
+	imageURL, err := url.Parse(dto.ImageUrl)
+	require.NoError(t, err)
+	signedURL, err := url.Parse(BuildMidjourneyImageURL(system_setting.ServerAddress, task.UserId, task.MjId))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/mj/image/unfinished-task", imageURL.Path)
+	assert.Equal(t, "101", imageURL.Query().Get("uid"))
+	assert.Equal(t, signedURL.Query().Get("sig"), imageURL.Query().Get("sig"))
+	assert.NotEmpty(t, imageURL.Query().Get("rand"))
+}

--- a/apps/api-go/router/relay_image_security_test.go
+++ b/apps/api-go/router/relay_image_security_test.go
@@ -1,0 +1,167 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/relay"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/QuantumNous/new-api/setting/system_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupRelayImageSecurityTest(t *testing.T) {
+	t.Helper()
+	previousDB := model.DB
+	previousDatabaseType := common.MainDatabaseType()
+	previousMemoryCache := common.MemoryCacheEnabled
+	previousFetchSetting := *system_setting.GetFetchSetting()
+
+	db, err := gorm.Open(sqlite.Open(t.TempDir()+"/relay-image.db"), &gorm.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	model.DB = db
+	common.SetMainDatabaseType(common.DatabaseTypeSQLite)
+	common.MemoryCacheEnabled = false
+	fetchSetting := system_setting.GetFetchSetting()
+	fetchSetting.EnableSSRFProtection = false
+
+	require.NoError(t, db.AutoMigrate(&model.Midjourney{}, &model.Channel{}))
+	service.InitHttpClient()
+	t.Cleanup(func() {
+		model.DB = previousDB
+		common.SetMainDatabaseType(previousDatabaseType)
+		common.MemoryCacheEnabled = previousMemoryCache
+		*system_setting.GetFetchSetting() = previousFetchSetting
+	})
+}
+
+func TestRelayMidjourneyImageIsNotPubliclyReadable(t *testing.T) {
+	setupRelayImageSecurityTest(t)
+
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("user-a-image"))
+	}))
+	t.Cleanup(imageServer.Close)
+	require.NoError(t, model.DB.Create(&model.Midjourney{
+		UserId:    101,
+		MjId:      "task-owned-by-a",
+		ImageUrl:  imageServer.URL,
+		ChannelId: 999,
+	}).Error)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	SetRelayRouter(engine)
+	for _, path := range []string{
+		"/mj/image/task-owned-by-a",
+		"/openai/mj/image/task-owned-by-a",
+	} {
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		response := httptest.NewRecorder()
+
+		engine.ServeHTTP(response, request)
+
+		require.Equal(t, http.StatusUnauthorized, response.Code, path)
+		require.Contains(t, response.Body.String(), "midjourney_image_signature_invalid", path)
+	}
+}
+
+func TestRelayMidjourneyImageRequiresTaskOwnerAndValidSignature(t *testing.T) {
+	setupRelayImageSecurityTest(t)
+
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("user-a-image"))
+	}))
+	t.Cleanup(imageServer.Close)
+	require.NoError(t, model.DB.Create(&model.Midjourney{
+		UserId:    101,
+		MjId:      "task-owned-by-a",
+		ImageUrl:  imageServer.URL,
+		ChannelId: 999,
+	}).Error)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	SetRelayRouter(engine)
+	imageURL := relay.BuildMidjourneyImageURL("http://fixture", 202, "task-owned-by-a")
+	parsedURL, err := url.Parse(imageURL)
+	require.NoError(t, err)
+	request := httptest.NewRequest(http.MethodGet, parsedURL.RequestURI(), nil)
+	response := httptest.NewRecorder()
+
+	engine.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusNotFound, response.Code)
+	require.Contains(t, response.Body.String(), "midjourney_task_not_found")
+}
+
+func TestRelayMidjourneyImageAllowsSignedTaskURL(t *testing.T) {
+	setupRelayImageSecurityTest(t)
+
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("user-a-image"))
+	}))
+	t.Cleanup(imageServer.Close)
+	require.NoError(t, model.DB.Create(&model.Midjourney{
+		UserId:    101,
+		MjId:      "task-owned-by-a",
+		ImageUrl:  imageServer.URL,
+		ChannelId: 999,
+	}).Error)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	SetRelayRouter(engine)
+	imageURL := relay.BuildMidjourneyImageURL("http://fixture", 101, "task-owned-by-a")
+	parsedURL, err := url.Parse(imageURL)
+	require.NoError(t, err)
+	request := httptest.NewRequest(http.MethodGet, parsedURL.RequestURI(), nil)
+	response := httptest.NewRecorder()
+
+	engine.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, "image/png", response.Header().Get("Content-Type"))
+	require.Equal(t, "user-a-image", response.Body.String())
+}
+
+func TestRelayMidjourneyImageRejectsTamperedOwner(t *testing.T) {
+	setupRelayImageSecurityTest(t)
+	require.NoError(t, model.DB.Create(&model.Midjourney{
+		UserId:    101,
+		MjId:      "task-owned-by-a",
+		ImageUrl:  "https://example.com/image.png",
+		ChannelId: 999,
+	}).Error)
+
+	gin.SetMode(gin.TestMode)
+	engine := gin.New()
+	SetRelayRouter(engine)
+	imageURL := relay.BuildMidjourneyImageURL("http://fixture", 101, "task-owned-by-a")
+	parsedURL, err := url.Parse(imageURL)
+	require.NoError(t, err)
+	query := parsedURL.Query()
+	query.Set("uid", "202")
+	parsedURL.RawQuery = query.Encode()
+	request := httptest.NewRequest(http.MethodGet, parsedURL.RequestURI(), nil)
+	response := httptest.NewRecorder()
+
+	engine.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusUnauthorized, response.Code)
+	require.Contains(t, response.Body.String(), "midjourney_image_signature_invalid")
+}

--- a/apps/api-go/router/relay_image_security_test.go
+++ b/apps/api-go/router/relay_image_security_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/QuantumNous/new-api/setting/system_setting"
 	"github.com/gin-gonic/gin"
 	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
@@ -74,8 +75,8 @@ func TestRelayMidjourneyImageIsNotPubliclyReadable(t *testing.T) {
 
 		engine.ServeHTTP(response, request)
 
-		require.Equal(t, http.StatusUnauthorized, response.Code, path)
-		require.Contains(t, response.Body.String(), "midjourney_image_signature_invalid", path)
+		assert.Equal(t, http.StatusUnauthorized, response.Code, path)
+		assert.Contains(t, response.Body.String(), "midjourney_image_signature_invalid", path)
 	}
 }
 
@@ -104,8 +105,8 @@ func TestRelayMidjourneyImageRequiresTaskOwnerAndValidSignature(t *testing.T) {
 
 	engine.ServeHTTP(response, request)
 
-	require.Equal(t, http.StatusNotFound, response.Code)
-	require.Contains(t, response.Body.String(), "midjourney_task_not_found")
+	assert.Equal(t, http.StatusNotFound, response.Code)
+	assert.Contains(t, response.Body.String(), "midjourney_task_not_found")
 }
 
 func TestRelayMidjourneyImageAllowsSignedTaskURL(t *testing.T) {
@@ -129,14 +130,19 @@ func TestRelayMidjourneyImageAllowsSignedTaskURL(t *testing.T) {
 	imageURL := relay.BuildMidjourneyImageURL("http://fixture", 101, "task-owned-by-a")
 	parsedURL, err := url.Parse(imageURL)
 	require.NoError(t, err)
-	request := httptest.NewRequest(http.MethodGet, parsedURL.RequestURI(), nil)
-	response := httptest.NewRecorder()
+	for _, path := range []string{
+		parsedURL.RequestURI(),
+		"/openai" + parsedURL.RequestURI(),
+	} {
+		request := httptest.NewRequest(http.MethodGet, path, nil)
+		response := httptest.NewRecorder()
 
-	engine.ServeHTTP(response, request)
+		engine.ServeHTTP(response, request)
 
-	require.Equal(t, http.StatusOK, response.Code)
-	require.Equal(t, "image/png", response.Header().Get("Content-Type"))
-	require.Equal(t, "user-a-image", response.Body.String())
+		assert.Equal(t, http.StatusOK, response.Code, path)
+		assert.Equal(t, "image/png", response.Header().Get("Content-Type"), path)
+		assert.Equal(t, "user-a-image", response.Body.String(), path)
+	}
 }
 
 func TestRelayMidjourneyImageRejectsTamperedOwner(t *testing.T) {
@@ -162,6 +168,6 @@ func TestRelayMidjourneyImageRejectsTamperedOwner(t *testing.T) {
 
 	engine.ServeHTTP(response, request)
 
-	require.Equal(t, http.StatusUnauthorized, response.Code)
-	require.Contains(t, response.Body.String(), "midjourney_image_signature_invalid")
+	assert.Equal(t, http.StatusUnauthorized, response.Code)
+	assert.Contains(t, response.Body.String(), "midjourney_image_signature_invalid")
 }


### PR DESCRIPTION
# LMM API Pull Request

## 变更说明 / Summary

修复 Midjourney 图片中继端点的未认证跨用户对象引用问题：`/mj/image/:id` 和 `/:mode/mj/image/:id` 在共享 `TokenAuth` 之后注册图片路由，handler 原先使用仅按 `mj_id` 查询的 `GetByOnlyMJId`，导致知道任务 ID 的未认证调用方可以读取其他用户的图片。

本 PR 使用 `common.SessionSecret` 生成 HMAC-SHA256 bearer URL，签名绑定 `user_id` 与 `mj_id`，在数据库查询前验证签名，并使用 `GetByMJId(userID, taskID)` 强制所有权约束。所有生成的图片 URL 已更新，未完成任务的 `rand` 缓存参数也会与签名参数共存。

本次代码与回归测试为 AI-assisted；当前 Git 作者 `TimShitPig` 不是仓库历史核心作者。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A；本变更针对 `LIghtJUNction/api.lmm.best` 的悬赏安全缺陷。

## 关联 Issue / Related issue

Closes #33

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor / performance
- [ ] 前端或交互 / Frontend / UX
- [ ] 部署、CI 或构建 / Deployment / CI / build
- [ ] 文档或仓库维护 / Documentation / maintenance

## 验证 / Verification

```text
Baseline reproduction:
cd C:\Users\17818\AppData\Local\Temp\api-lmm-baseline\apps\api-go
 go test ./router -run TestBaselineRelayMidjourneyImageIsPublic -count=1 -v
result: exit=0; unauthenticated GET /mj/image/task-owned-by-a returned status=200 and body=user-a-image.

Focused regression:
cd C:\Users\17818\Desktop\API站点任务\apps\api-go
 go test ./router -run TestRelayMidjourneyImage -count=1 -v
result: exit=0; both image route aliases reject anonymous access with 401, wrong-owner signed URL returns 404, valid owner URL returns 200 with image/png and body=user-a-image, and tampered uid returns 401.

Package regression suite:
 go test ./router ./relay ./controller ./model -count=1
result: exit=0

Static checks:
 go vet ./router ./relay ./controller ./model
 git diff --check
result: exit=0 for both commands.

Rollback:
git apply --check fix.patch; git apply fix.patch; git apply --check rollback.patch; git apply rollback.patch
result: all exit=0; baseline tracked worktree clean after rollback.

Full repository:
go test ./...
result: pre-existing repository failures remain outside this change: missing web/dist embed path in the root package and two unrelated service channel-affinity assertions.
```

## 截图或日志 / Screenshots or logs

N/A; this is a backend authorization fix. Exact response assertions and command results are recorded above.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更与上游 New API 的关系，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；签名 URL 保留直接 `<img src>` 使用方式，并保留缓存破坏参数。
- [x] 我已补充相关回归测试，并在上方记录实际验证结果；完整仓库测试的预存缺口已注明。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）；本后端安全修复不需要文案变更。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Summary by Sourcery

通过使用带有 HMAC 签名参数的方式，将图像 URL 绑定到发起请求的用户，并强制执行任务归属校验，从而保护 Midjourney 图像中继端点；同时相应更新 URL 生成逻辑和测试。

New Features:
- 引入绑定到特定用户和任务的、带签名的 Midjourney 图像中继 URL，通过基于 HMAC 的查询参数实现。

Bug Fixes:
- 在提供 Midjourney 图像时要求有效的按用户签名和归属校验，防止跨用户访问图像中继端点。

Enhancements:
- 更新所有 Midjourney 图像 URL 生成辅助方法以使用带签名的中继 URL，同时为进行中的任务保留防缓存机制支持。

Tests:
- 为 Midjourney 图像中继端点添加类集成测试，用于覆盖匿名访问、错误归属请求、有效签名 URL 以及被篡改签名等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Secure Midjourney image relay endpoints by binding image URLs to the requesting user with HMAC-signed parameters and enforcing task ownership checks, and update URL generation and tests accordingly.

New Features:
- Introduce signed Midjourney image relay URLs bound to a specific user and task via HMAC-based query parameters.

Bug Fixes:
- Require a valid per-user signature and ownership check when serving Midjourney images, preventing cross-user access to image relay endpoints.

Enhancements:
- Update all Midjourney image URL generation helpers to use the signed relay URL while preserving cache-busting support for in-progress tasks.

Tests:
- Add integration-style tests for Midjourney image relay endpoints covering anonymous access, wrong-owner requests, valid signed URLs, and tampered signatures.

</details>