### PR TITLE
fix: prevent cross-user access to Rust Midjourney images

### DIFF
--- a/apps/api-rust/apps/lmm-api-rs/src/main.rs
+++ b/apps/api-rust/apps/lmm-api-rs/src/main.rs
@@ -132,7 +132,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         );
         let candidates = http::migration_candidate_test_surface(
             &app_state,
-            test_instance::safe_candidate_surface(pg.clone(), valkey.clone(), Arc::clone(&auth)),
+            test_instance::safe_candidate_surface(
+                pg.clone(),
+                valkey.clone(),
+                Arc::clone(&auth),
+                config.auth_session_secret.expose_secret(),
+            ),
         );
         http::router_with_web_and_api_token_and_extra(
             app_state,

--- a/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_midjourney.rs
+++ b/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_midjourney.rs
@@ -17,12 +17,14 @@ use axum::{
     Extension, Json, Router,
     body::{Body, Bytes, to_bytes},
     extract::{Path, State},
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{HeaderMap, HeaderValue, StatusCode, Uri, header},
     response::{IntoResponse, Response},
     routing::{get, post},
 };
+use hmac::{Hmac, Mac};
 use serde::Deserialize;
 use serde_json::{Value, json};
+use sha2::Sha256;
 use sqlx::{PgPool, Row};
 
 use crate::RequestContext;
@@ -66,7 +68,7 @@ pub struct BufferedJsonReply {
     pub body: Value,
 }
 
-/// A persisted public image reference, looked up exclusively by Midjourney id.
+/// A persisted image reference selected after the signed URL user scope is checked.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct StoredImage {
     /// URL saved in PostgreSQL by the task lifecycle.
@@ -152,6 +154,82 @@ pub enum MidjourneyFailure {
     BlockedImage,
 }
 
+type HmacSha256 = Hmac<Sha256>;
+
+const IMAGE_SIGNATURE_PREFIX: &str = "midjourney-image-v1";
+
+/// Creates the bearer signature used by the legacy image URL contract.
+///
+/// The task id and user id are both authenticated so a leaked URL for one
+/// user's task cannot be rewritten to address another task or account.
+#[must_use]
+pub fn midjourney_image_signature(secret: &[u8], user_id: i64, task_id: &str) -> Option<String> {
+    if secret.is_empty() || user_id <= 0 || task_id.is_empty() {
+        return None;
+    }
+    let mut mac = HmacSha256::new_from_slice(secret).ok()?;
+    mac.update(format!("{IMAGE_SIGNATURE_PREFIX}:{user_id}:{task_id}").as_bytes());
+    Some(hex::encode(mac.finalize().into_bytes()))
+}
+
+/// Verifies a legacy image URL signature using constant-time HMAC comparison.
+#[must_use]
+pub fn verify_midjourney_image_signature(
+    secret: &[u8],
+    user_id: i64,
+    task_id: &str,
+    signature: &str,
+) -> bool {
+    if secret.is_empty() || user_id <= 0 || task_id.is_empty() || signature.is_empty() {
+        return false;
+    }
+    let Ok(provided) = hex::decode(signature) else {
+        return false;
+    };
+    let Ok(mut mac) = HmacSha256::new_from_slice(secret) else {
+        return false;
+    };
+    mac.update(format!("{IMAGE_SIGNATURE_PREFIX}:{user_id}:{task_id}").as_bytes());
+    mac.verify_slice(&provided).is_ok()
+}
+
+/// Extracts and verifies `uid`/`sig` from a bearer image URL query string.
+#[must_use]
+pub fn signed_image_user_id(secret: &[u8], task_id: &str, query: Option<&str>) -> Option<i64> {
+    let mut user_id = None;
+    let mut signature = None;
+    for (key, value) in form_urlencoded::parse(query.unwrap_or_default().as_bytes()) {
+        if key == "uid" && user_id.is_none() {
+            user_id = value.parse::<i64>().ok();
+        } else if key == "sig" && signature.is_none() {
+            signature = Some(value.into_owned());
+        }
+    }
+    let user_id = user_id.filter(|user_id| *user_id > 0)?;
+    let signature = signature?;
+    verify_midjourney_image_signature(secret, user_id, task_id, &signature).then_some(user_id)
+}
+
+/// Builds a signed image URL while preserving any path prefix in `base_url`.
+#[must_use]
+pub fn build_midjourney_image_url(
+    base_url: &str,
+    secret: &[u8],
+    user_id: i64,
+    task_id: &str,
+) -> Option<String> {
+    let signature = midjourney_image_signature(secret, user_id, task_id)?;
+    let mut url = reqwest::Url::parse(base_url).ok()?;
+    {
+        let mut segments = url.path_segments_mut().ok()?;
+        segments.push("mj").push("image").push(task_id);
+    }
+    url.query_pairs_mut()
+        .append_pair("uid", &user_id.to_string())
+        .append_pair("sig", &signature);
+    Some(url.to_string())
+}
+
 /// Boundary for authentication, relational task persistence, accounting, and upstream I/O.
 ///
 /// Implementations must insert/charge only from [`Self::record_submit`] after a 200
@@ -190,8 +268,12 @@ pub trait MidjourneyBackend: Send + Sync {
         headers: &HeaderMap,
         body: Option<Value>,
     ) -> Result<BufferedJsonReply, MidjourneyFailure>;
-    /// Finds a public image reference without authenticating the requester.
-    async fn image_for(&self, task_id: &str) -> Result<StoredImage, MidjourneyFailure>;
+    /// Finds an image reference scoped to the user authenticated by the signed URL.
+    async fn image_for(
+        &self,
+        user_id: i64,
+        task_id: &str,
+    ) -> Result<StoredImage, MidjourneyFailure>;
     /// Fetches a previously validated image URL.
     async fn fetch_image(&self, url: &str) -> Result<ImageReply, MidjourneyFailure>;
 }
@@ -200,13 +282,24 @@ pub trait MidjourneyBackend: Send + Sync {
 #[derive(Clone)]
 pub struct MidjourneyHttpState {
     backend: Arc<dyn MidjourneyBackend>,
+    image_signing_secret: Arc<[u8]>,
 }
 
 impl MidjourneyHttpState {
     /// Creates state from an application-owned backend.
     #[must_use]
     pub fn new(backend: Arc<dyn MidjourneyBackend>) -> Self {
-        Self { backend }
+        Self {
+            backend,
+            image_signing_secret: Arc::from([]),
+        }
+    }
+
+    /// Supplies the deployment-wide `SESSION_SECRET` used for image URLs.
+    #[must_use]
+    pub fn with_image_signing_secret(mut self, secret: impl AsRef<[u8]>) -> Self {
+        self.image_signing_secret = Arc::from(secret.as_ref());
+        self
     }
 }
 
@@ -399,8 +492,16 @@ async fn task_read(
 async fn image(
     State(state): State<MidjourneyHttpState>,
     Path((_, id)): Path<(String, String)>,
+    uri: Uri,
 ) -> Response {
-    let stored = match state.backend.image_for(&id).await {
+    let Some(user_id) = signed_image_user_id(&state.image_signing_secret, &id, uri.query()) else {
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(json!({"error":"midjourney_image_signature_invalid"})),
+        )
+            .into_response();
+    };
+    let stored = match state.backend.image_for(user_id, &id).await {
         Ok(stored) => stored,
         Err(MidjourneyFailure::NotFound) => {
             return (
@@ -1351,10 +1452,15 @@ impl MidjourneyBackend for PgMidjourneyBackend {
         .await
     }
 
-    async fn image_for(&self, task_id: &str) -> Result<StoredImage, MidjourneyFailure> {
+    async fn image_for(
+        &self,
+        user_id: i64,
+        task_id: &str,
+    ) -> Result<StoredImage, MidjourneyFailure> {
         let url = sqlx::query_scalar::<_, String>(
-            "SELECT image_url FROM midjourneys WHERE mj_id=$1 AND COALESCE(image_url,'')<>'' ORDER BY id DESC LIMIT 1",
+            "SELECT image_url FROM midjourneys WHERE user_id=$1 AND mj_id=$2 AND COALESCE(image_url,'')<>'' ORDER BY id DESC LIMIT 1",
         )
+        .bind(user_id)
         .bind(task_id)
         .fetch_optional(&self.pg)
         .await

--- a/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_midjourney.rs
+++ b/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_midjourney.rs
@@ -230,6 +230,69 @@ pub fn build_midjourney_image_url(
     Some(url.to_string())
 }
 
+/// Builds the relative signed image path used in task JSON responses.
+///
+/// A relative path keeps the response correct when the Rust listener is
+/// mounted behind a reverse proxy without requiring the route adapter to
+/// duplicate the dashboard's public-address configuration.
+#[must_use]
+pub fn build_midjourney_image_path(secret: &[u8], user_id: i64, task_id: &str) -> Option<String> {
+    let base = reqwest::Url::parse("https://midjourney-image.invalid").ok()?;
+    let url = build_midjourney_image_url(base.as_str(), secret, user_id, task_id)?;
+    let parsed = reqwest::Url::parse(&url).ok()?;
+    let mut path = parsed.path().to_owned();
+    if let Some(query) = parsed.query() {
+        path.push('?');
+        path.push_str(query);
+    }
+    Some(path)
+}
+
+/// Replaces provider image URLs in a Midjourney JSON response with signed
+/// proxy paths bound to the authenticated user's task.
+///
+/// The provider response shape differs between submit and task-read calls:
+/// submit responses put `imageUrl` under `properties`, while task snapshots
+/// expose it at the top level.  Walking both objects prevents either path
+/// from reintroducing a direct provider URL.
+pub fn rewrite_midjourney_image_urls(body: &mut Value, secret: &[u8], user_id: i64) {
+    fn rewrite(value: &mut Value, secret: &[u8], user_id: i64, inherited_task_id: Option<&str>) {
+        match value {
+            Value::Object(object) => {
+                let task_id = object
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .or_else(|| object.get("result").and_then(Value::as_str))
+                    .or(inherited_task_id)
+                    .map(str::to_owned);
+                for key in ["imageUrl", "image_url"] {
+                    if let Some(Value::String(image_url)) = object.get_mut(key)
+                        && !image_url.is_empty()
+                    {
+                        *image_url = task_id
+                            .as_deref()
+                            .and_then(|task_id| {
+                                build_midjourney_image_path(secret, user_id, task_id)
+                            })
+                            .unwrap_or_default();
+                    }
+                }
+                for child in object.values_mut() {
+                    rewrite(child, secret, user_id, task_id.as_deref());
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    rewrite(item, secret, user_id, inherited_task_id);
+                }
+            }
+            Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+        }
+    }
+
+    rewrite(body, secret, user_id, None);
+}
+
 /// Boundary for authentication, relational task persistence, accounting, and upstream I/O.
 ///
 /// Implementations must insert/charge only from [`Self::record_submit`] after a 200
@@ -406,6 +469,7 @@ async fn submit(
         }
         normalize_replay_code(&mut body);
     }
+    rewrite_midjourney_image_urls(&mut body, &state.image_signing_secret, identity.user_id);
     json_response(
         submitted.response.status,
         submitted.response.content_type,
@@ -484,7 +548,14 @@ async fn task_read(
         .task_read(&identity, operation, id, &headers, body)
         .await
     {
-        Ok(reply) => json_response(reply.status, reply.content_type, reply.body),
+        Ok(mut reply) => {
+            rewrite_midjourney_image_urls(
+                &mut reply.body,
+                &state.image_signing_secret,
+                identity.user_id,
+            );
+            json_response(reply.status, reply.content_type, reply.body)
+        }
         Err(error) => failure(error),
     }
 }

--- a/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_tasks.rs
+++ b/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_tasks.rs
@@ -4,8 +4,8 @@
 //! selection, SSRF validation, PostgreSQL accounting and upstream I/O belong
 //! to [`MediaTaskService`], where they can be kept atomic and tested against
 //! disposable infrastructure.  The image proxy is deliberately separate: it
-//! is a public route in the legacy listener, whereas every task route is
-//! authenticated.
+//! uses a signed bearer URL, whereas every task route is authenticated with a
+//! bearer token.
 
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ use serde_json::{Value, json};
 use crate::{
     RequestContext,
     migration_routes::media_midjourney::{
-        ImageReply, MidjourneyBackend, MidjourneyFailure, PgMidjourneyBackend,
+        ImageReply, MidjourneyBackend, MidjourneyFailure, PgMidjourneyBackend, signed_image_user_id,
     },
 };
 
@@ -67,14 +67,15 @@ pub enum MediaTaskOperation {
 /// and increment user/channel counters.  Codes 21 and 22 are replay successes
 /// and must be presented as code 1 without adding an idempotency guard.
 ///
-/// The image proxy must look up `mj_id`, validate the resulting URL against
-/// SSRF, then stream only successful upstream bytes.  It must not write
-/// PostgreSQL or Valkey.
+/// The image proxy must verify the signed user/task binding, look up `mj_id`
+/// within that user scope, validate the resulting URL against SSRF, then
+/// stream only successful upstream bytes.  It must not write PostgreSQL or
+/// Valkey.
 #[async_trait]
 pub trait MediaTaskService: Send + Sync {
     /// Handle a protected task request, including the legacy auth boundary.
     async fn protected(&self, operation: MediaTaskOperation, request: Request) -> Response;
-    /// Handle the public image proxy after task lookup and SSRF validation.
+    /// Handle the signed image proxy after task lookup and SSRF validation.
     async fn public_image(&self, task_id: String, request: Request) -> Response;
 }
 
@@ -136,6 +137,7 @@ impl TaskRelayProvider for UnconfiguredTaskRelayProvider {
 pub struct MidjourneyMediaTaskService<B = PgMidjourneyBackend> {
     backend: Arc<B>,
     task_relay: Arc<dyn TaskRelayProvider>,
+    image_signing_secret: Arc<[u8]>,
 }
 
 /// Production static-Midjourney service.  It is generic only so contract tests
@@ -155,6 +157,7 @@ impl<B> MidjourneyMediaTaskService<B> {
         Self {
             backend,
             task_relay,
+            image_signing_secret: Arc::from([]),
         }
     }
 
@@ -164,6 +167,13 @@ impl<B> MidjourneyMediaTaskService<B> {
     #[must_use]
     pub fn with_task_relay(mut self, task_relay: Arc<dyn TaskRelayProvider>) -> Self {
         self.task_relay = task_relay;
+        self
+    }
+
+    /// Supplies the deployment-wide `SESSION_SECRET` used for image URLs.
+    #[must_use]
+    pub fn with_image_signing_secret(mut self, secret: impl AsRef<[u8]>) -> Self {
+        self.image_signing_secret = Arc::from(secret.as_ref());
         self
     }
 }
@@ -269,8 +279,17 @@ where
         }
     }
 
-    async fn public_image(&self, task_id: String, _request: Request) -> Response {
-        let stored = match self.backend.image_for(&task_id).await {
+    async fn public_image(&self, task_id: String, request: Request) -> Response {
+        let Some(user_id) =
+            signed_image_user_id(&self.image_signing_secret, &task_id, request.uri().query())
+        else {
+            return (
+                StatusCode::UNAUTHORIZED,
+                axum::Json(json!({"error":"midjourney_image_signature_invalid"})),
+            )
+                .into_response();
+        };
+        let stored = match self.backend.image_for(user_id, &task_id).await {
             Ok(stored) => stored,
             Err(MidjourneyFailure::NotFound) => {
                 return (
@@ -439,13 +458,24 @@ fn media_failure(error: MidjourneyFailure) -> Response {
 #[derive(Clone)]
 pub struct MediaTaskHttpState {
     service: Arc<dyn MediaTaskService>,
+    image_signing_secret: Arc<[u8]>,
 }
 
 impl MediaTaskHttpState {
     /// Creates route state from an application-owned task relay service.
     #[must_use]
     pub fn new(service: Arc<dyn MediaTaskService>) -> Self {
-        Self { service }
+        Self {
+            service,
+            image_signing_secret: Arc::from([]),
+        }
+    }
+
+    /// Supplies the deployment-wide `SESSION_SECRET` used for image URLs.
+    #[must_use]
+    pub fn with_image_signing_secret(mut self, secret: impl AsRef<[u8]>) -> Self {
+        self.image_signing_secret = Arc::from(secret.as_ref());
+        self
     }
 }
 
@@ -498,6 +528,13 @@ async fn public_image(
     Path(id): Path<String>,
     request: Request,
 ) -> Response {
+    if signed_image_user_id(&state.image_signing_secret, &id, request.uri().query()).is_none() {
+        return (
+            StatusCode::UNAUTHORIZED,
+            axum::Json(json!({"error":"midjourney_image_signature_invalid"})),
+        )
+            .into_response();
+    }
     state.service.public_image(id, request).await
 }
 
@@ -657,9 +694,10 @@ mod tests {
     }
 
     fn app(calls: Calls) -> Router {
-        media_task_router(MediaTaskHttpState::new(Arc::new(CapturingService {
-            calls,
-        })))
+        media_task_router(
+            MediaTaskHttpState::new(Arc::new(CapturingService { calls }))
+                .with_image_signing_secret(b"test-midjourney-image-session-secret-2026"),
+        )
     }
 
     #[tokio::test]

--- a/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_tasks.rs
+++ b/apps/api-rust/apps/lmm-api-rs/src/migration_routes/media_tasks.rs
@@ -23,7 +23,8 @@ use serde_json::{Value, json};
 use crate::{
     RequestContext,
     migration_routes::media_midjourney::{
-        ImageReply, MidjourneyBackend, MidjourneyFailure, PgMidjourneyBackend, signed_image_user_id,
+        ImageReply, MidjourneyBackend, MidjourneyFailure, PgMidjourneyBackend,
+        rewrite_midjourney_image_urls, signed_image_user_id,
     },
 };
 
@@ -240,6 +241,11 @@ where
                         response_body["code"] = json!(1);
                     }
                 }
+                rewrite_midjourney_image_urls(
+                    &mut response_body,
+                    &self.image_signing_secret,
+                    identity.user_id,
+                );
                 media_json_response(
                     submitted.response.status,
                     submitted.response.content_type,
@@ -252,7 +258,14 @@ where
                     .task_read(&identity, operation, &task_id, &parts.headers, None)
                     .await
                 {
-                    Ok(reply) => media_json_response(reply.status, reply.content_type, reply.body),
+                    Ok(mut reply) => {
+                        rewrite_midjourney_image_urls(
+                            &mut reply.body,
+                            &self.image_signing_secret,
+                            identity.user_id,
+                        );
+                        media_json_response(reply.status, reply.content_type, reply.body)
+                    }
                     Err(error) => media_failure(error),
                 }
             }
@@ -272,7 +285,14 @@ where
                     )
                     .await
                 {
-                    Ok(reply) => media_json_response(reply.status, reply.content_type, reply.body),
+                    Ok(mut reply) => {
+                        rewrite_midjourney_image_urls(
+                            &mut reply.body,
+                            &self.image_signing_secret,
+                            identity.user_id,
+                        );
+                        media_json_response(reply.status, reply.content_type, reply.body)
+                    }
                     Err(error) => media_failure(error),
                 }
             }

--- a/apps/api-rust/apps/lmm-api-rs/src/test_instance.rs
+++ b/apps/api-rust/apps/lmm-api-rs/src/test_instance.rs
@@ -152,6 +152,7 @@ pub fn safe_candidate_surface(
     pg: PgPool,
     valkey: redis::Client,
     auth: Arc<dyn DashboardAuth>,
+    image_signing_secret: &str,
 ) -> Router {
     let catalog_authorizer: Arc<dyn AdminCatalogAuthorizer> =
         Arc::new(DashboardAdminCatalogAuthorizer::new(Arc::clone(&auth)));
@@ -354,12 +355,17 @@ pub fn safe_candidate_surface(
         // test adapter denies every provider protocol after authentication, so
         // an imported snapshot can exercise route/auth compatibility without
         // contacting a selected production channel.
-        .merge(media_midjourney_router(MidjourneyHttpState::new(Arc::new(
-            TestInstanceMidjourneyBackend::new(pg.clone()),
-        ))))
-        .merge(media_task_router(MediaTaskHttpState::new(Arc::new(
-            MidjourneyMediaTaskService::new(Arc::new(TestInstanceMidjourneyBackend::new(pg))),
-        ))))
+        .merge(media_midjourney_router(
+            MidjourneyHttpState::new(Arc::new(TestInstanceMidjourneyBackend::new(pg.clone())))
+                .with_image_signing_secret(image_signing_secret),
+        ))
+        .merge(media_task_router(
+            MediaTaskHttpState::new(Arc::new(
+                MidjourneyMediaTaskService::new(Arc::new(TestInstanceMidjourneyBackend::new(pg)))
+                    .with_image_signing_secret(image_signing_secret),
+            ))
+            .with_image_signing_secret(image_signing_secret),
+        ))
 }
 
 /// PostgreSQL-backed read adapter for the legacy public/control endpoints.
@@ -2153,7 +2159,7 @@ impl MidjourneyBackend for TestInstanceMidjourneyBackend {
         Err(MidjourneyFailure::Upstream)
     }
 
-    async fn image_for(&self, _: &str) -> Result<StoredImage, MidjourneyFailure> {
+    async fn image_for(&self, _: i64, _: &str) -> Result<StoredImage, MidjourneyFailure> {
         Err(MidjourneyFailure::NotFound)
     }
 
@@ -2774,14 +2780,19 @@ mod tests {
             )
             .expect("test auth config is valid"),
         );
-        let response = safe_candidate_surface(pg, valkey, auth)
-            .oneshot(
-                Request::get("/api/setup")
-                    .body(Body::empty())
-                    .expect("request is valid"),
-            )
-            .await
-            .expect("router is infallible");
+        let response = safe_candidate_surface(
+            pg,
+            valkey,
+            auth,
+            "test-instance-session-secret-with-entropy-123456",
+        )
+        .oneshot(
+            Request::get("/api/setup")
+                .body(Body::empty())
+                .expect("request is valid"),
+        )
+        .await
+        .expect("router is infallible");
         assert_ne!(response.status(), StatusCode::NOT_FOUND);
         assert!(DenyProjectUpdate.latest_main_commit().await.is_err());
     }
@@ -2805,7 +2816,12 @@ mod tests {
             )
             .expect("test auth config is valid"),
         );
-        let app = safe_candidate_surface(pg, valkey, auth);
+        let app = safe_candidate_surface(
+            pg,
+            valkey,
+            auth,
+            "test-instance-session-secret-with-entropy-123456",
+        );
         for path in ["/api/data/self", "/api/perf-metrics/summary"] {
             let response = app
                 .clone()

--- a/apps/api-rust/apps/lmm-api-rs/tests/migration_media_midjourney.rs
+++ b/apps/api-rust/apps/lmm-api-rs/tests/migration_media_midjourney.rs
@@ -12,7 +12,8 @@ use axum::{
 use lmm_api_rs::migration_routes::media_midjourney::{
     BufferedJsonReply, ImageReply, MidjourneyBackend, MidjourneyChannel, MidjourneyFailure,
     MidjourneyHttpState, MidjourneyIdentity, PgMidjourneyBackend, StoredImage, SubmitReply,
-    TaskEffect, media_midjourney_router,
+    TaskEffect, build_midjourney_image_url, media_midjourney_router, midjourney_image_signature,
+    signed_image_user_id,
 };
 use serde_json::json;
 use sqlx::PgPool;
@@ -27,6 +28,7 @@ struct TestMidjourneyBackend {
     effects: Mutex<Vec<TaskEffect>>,
     submit_calls: Mutex<usize>,
     image_fetches: Mutex<usize>,
+    image_users: Mutex<Vec<i64>>,
     image: Mutex<Option<StoredImage>>,
     stream_target: Mutex<Option<String>>,
     reply: Mutex<BufferedJsonReply>,
@@ -42,6 +44,7 @@ impl TestMidjourneyBackend {
             effects: Mutex::new(Vec::new()),
             submit_calls: Mutex::new(0),
             image_fetches: Mutex::new(0),
+            image_users: Mutex::new(Vec::new()),
             image: Mutex::new(None),
             stream_target: Mutex::new(None),
             reply: Mutex::new(BufferedJsonReply {
@@ -160,7 +163,14 @@ impl MidjourneyBackend for TestMidjourneyBackend {
         Ok(self.reply.lock().expect("reply lock").clone())
     }
 
-    async fn image_for(&self, _: &str) -> Result<StoredImage, MidjourneyFailure> {
+    async fn image_for(&self, user_id: i64, _: &str) -> Result<StoredImage, MidjourneyFailure> {
+        self.image_users
+            .lock()
+            .expect("image users lock")
+            .push(user_id);
+        if user_id != 1 {
+            return Err(MidjourneyFailure::NotFound);
+        }
         self.image
             .lock()
             .expect("image lock")
@@ -198,7 +208,35 @@ impl MidjourneyBackend for TestMidjourneyBackend {
 }
 
 fn app(backend: Arc<TestMidjourneyBackend>) -> axum::Router {
-    media_midjourney_router(MidjourneyHttpState::new(backend))
+    media_midjourney_router(
+        MidjourneyHttpState::new(backend).with_image_signing_secret(IMAGE_SECRET),
+    )
+}
+
+const IMAGE_SECRET: &[u8] = b"test-midjourney-image-session-secret-2026";
+
+fn signed_image_path(path: &str, task_id: &str, user_id: i64) -> String {
+    format!(
+        "{path}?uid={user_id}&sig={}",
+        midjourney_image_signature(IMAGE_SECRET, user_id, task_id).expect("image signature")
+    )
+}
+
+#[test]
+fn signed_image_builder_preserves_prefix_and_escapes_task_id() {
+    let url = build_midjourney_image_url(
+        "https://api.example.test/compat",
+        IMAGE_SECRET,
+        42,
+        "task/with space",
+    )
+    .expect("signed URL");
+    let parsed = reqwest::Url::parse(&url).expect("URL");
+    assert_eq!(parsed.path(), "/compat/mj/image/task%2Fwith%20space");
+    assert_eq!(
+        signed_image_user_id(IMAGE_SECRET, "task/with space", parsed.query()),
+        Some(42)
+    );
 }
 
 async fn spawn_tcp_router(router: axum::Router) -> (String, tokio::task::JoinHandle<()>) {
@@ -302,7 +340,7 @@ async fn simultaneous_replays_should_reach_the_backend_twice_without_deduplicati
 }
 
 #[tokio::test]
-async fn public_image_should_stream_exact_binary_without_token() {
+async fn signed_public_image_should_stream_exact_binary_without_bearer_token() {
     let backend = Arc::new(TestMidjourneyBackend::new(Vec::<String>::new()));
     backend.set_image(StoredImage {
         url: "https://images.example.test/image.png".to_owned(),
@@ -310,7 +348,7 @@ async fn public_image_should_stream_exact_binary_without_token() {
     let response = app(backend)
         .oneshot(
             Request::builder()
-                .uri("/proxy/mj/image/task-1")
+                .uri(signed_image_path("/proxy/mj/image/task-1", "task-1", 1))
                 .body(Body::empty())
                 .expect("request"),
         )
@@ -324,6 +362,59 @@ async fn public_image_should_stream_exact_binary_without_token() {
             .expect("image")
             .as_ref(),
         b"mock-png"
+    );
+}
+
+#[tokio::test]
+async fn public_image_rejects_missing_or_tampered_signature_before_lookup() {
+    let backend = Arc::new(TestMidjourneyBackend::new(Vec::<String>::new()));
+    backend.set_image(StoredImage {
+        url: "https://images.example.test/image.png".to_owned(),
+    });
+    for query in ["", "uid=1&sig=deadbeef"] {
+        let uri = if query.is_empty() {
+            "/proxy/mj/image/task-1".to_owned()
+        } else {
+            format!("/proxy/mj/image/task-1?{query}")
+        };
+        let response = app(Arc::clone(&backend))
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+    assert_eq!(backend.image_fetches(), 0);
+}
+
+#[tokio::test]
+async fn public_image_signature_scopes_lookup_to_the_signed_user() {
+    let backend = Arc::new(TestMidjourneyBackend::new(Vec::<String>::new()));
+    backend.set_image(StoredImage {
+        url: "https://images.example.test/image.png".to_owned(),
+    });
+    let response = app(Arc::clone(&backend))
+        .oneshot(
+            Request::builder()
+                .uri(signed_image_path("/proxy/mj/image/task-1", "task-1", 2))
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(backend.image_fetches(), 0);
+    assert_eq!(
+        backend
+            .image_users
+            .lock()
+            .expect("image users lock")
+            .as_slice(),
+        [2]
     );
 }
 
@@ -357,7 +448,11 @@ async fn public_image_returns_headers_before_the_upstream_stream_finishes() {
         Duration::from_secs(1),
         app(backend).oneshot(
             Request::builder()
-                .uri("/proxy/mj/image/task-stream")
+                .uri(signed_image_path(
+                    "/proxy/mj/image/task-stream",
+                    "task-stream",
+                    1,
+                ))
                 .body(Body::empty())
                 .expect("request"),
         ),
@@ -387,7 +482,7 @@ async fn public_image_rejects_ipv6_loopback_before_any_upstream_fetch() {
     let response = app(Arc::clone(&backend))
         .oneshot(
             Request::builder()
-                .uri("/proxy/mj/image/task-1")
+                .uri(signed_image_path("/proxy/mj/image/task-1", "task-1", 1))
                 .body(Body::empty())
                 .expect("request"),
         )
@@ -446,7 +541,7 @@ async fn unknown_public_image_uses_the_frozen_not_found_envelope() {
     let response = app(Arc::clone(&backend))
         .oneshot(
             Request::builder()
-                .uri("/proxy/mj/image/missing")
+                .uri(signed_image_path("/proxy/mj/image/missing", "missing", 1))
                 .body(Body::empty())
                 .expect("request"),
         )
@@ -494,7 +589,11 @@ async fn dynamic_midjourney_auth_and_route_status_contract_holds_over_a_real_tcp
     let client = reqwest::Client::new();
 
     let public_image = client
-        .get(format!("{base_url}/proxy/mj/image/missing"))
+        .get(signed_image_path(
+            &format!("{base_url}/proxy/mj/image/missing"),
+            "missing",
+            1,
+        ))
         .send()
         .await
         .expect("public-image response");

--- a/apps/api-rust/apps/lmm-api-rs/tests/migration_media_midjourney.rs
+++ b/apps/api-rust/apps/lmm-api-rs/tests/migration_media_midjourney.rs
@@ -12,8 +12,8 @@ use axum::{
 use lmm_api_rs::migration_routes::media_midjourney::{
     BufferedJsonReply, ImageReply, MidjourneyBackend, MidjourneyChannel, MidjourneyFailure,
     MidjourneyHttpState, MidjourneyIdentity, PgMidjourneyBackend, StoredImage, SubmitReply,
-    TaskEffect, build_midjourney_image_url, media_midjourney_router, midjourney_image_signature,
-    signed_image_user_id,
+    TaskEffect, build_midjourney_image_path, build_midjourney_image_url, media_midjourney_router,
+    midjourney_image_signature, signed_image_user_id,
 };
 use serde_json::json;
 use sqlx::PgPool;
@@ -237,6 +237,9 @@ fn signed_image_builder_preserves_prefix_and_escapes_task_id() {
         signed_image_user_id(IMAGE_SECRET, "task/with space", parsed.query()),
         Some(42)
     );
+    let path = build_midjourney_image_path(IMAGE_SECRET, 42, "task/with space")
+        .expect("signed image path");
+    assert!(path.starts_with("/mj/image/task%2Fwith%20space?uid=42&sig="));
 }
 
 async fn spawn_tcp_router(router: axum::Router) -> (String, tokio::task::JoinHandle<()>) {
@@ -337,6 +340,75 @@ async fn simultaneous_replays_should_reach_the_backend_twice_without_deduplicati
     assert_eq!(first.expect("first").status(), StatusCode::OK);
     assert_eq!(second.expect("second").status(), StatusCode::OK);
     assert_eq!(backend.effects().len(), 2);
+}
+
+#[tokio::test]
+async fn dynamic_submit_and_task_reads_rewrite_provider_image_urls() {
+    let backend = Arc::new(TestMidjourneyBackend::new(["test-token".to_owned()]));
+    backend.set_reply(BufferedJsonReply {
+        status: StatusCode::OK,
+        content_type: "application/json".parse().expect("header"),
+        body: json!({
+            "code": 21,
+            "description": "exists",
+            "result": "task-with-image",
+            "properties": {
+                "status": "SUCCESS",
+                "imageUrl": "https://provider.example/private.png"
+            }
+        }),
+    });
+    let router = app(Arc::clone(&backend));
+
+    let submit_response = router
+        .clone()
+        .oneshot(submit("/proxy/mj/submit/imagine"))
+        .await
+        .expect("submit response");
+    let submit_body: serde_json::Value = serde_json::from_slice(
+        &to_bytes(submit_response.into_body(), usize::MAX)
+            .await
+            .expect("submit body"),
+    )
+    .expect("submit JSON");
+    let submit_image = submit_body["properties"]["imageUrl"]
+        .as_str()
+        .expect("signed submit image URL");
+    assert!(!submit_image.contains("provider.example"));
+    let submit_url =
+        reqwest::Url::parse(&format!("https://fixture{submit_image}")).expect("signed submit URL");
+    assert_eq!(
+        signed_image_user_id(IMAGE_SECRET, "task-with-image", submit_url.query()),
+        Some(1)
+    );
+
+    let task_response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/proxy/mj/task/task-with-image/fetch")
+                .header("authorization", "Bearer test-token")
+                .body(Body::empty())
+                .expect("task request"),
+        )
+        .await
+        .expect("task response");
+    let task_body: serde_json::Value = serde_json::from_slice(
+        &to_bytes(task_response.into_body(), usize::MAX)
+            .await
+            .expect("task body"),
+    )
+    .expect("task JSON");
+    let task_image = task_body["properties"]["imageUrl"]
+        .as_str()
+        .expect("signed task image URL");
+    assert!(!task_image.contains("provider.example"));
+    let task_url =
+        reqwest::Url::parse(&format!("https://fixture{task_image}")).expect("signed task URL");
+    assert_eq!(
+        signed_image_user_id(IMAGE_SECRET, "task-with-image", task_url.query()),
+        Some(1)
+    );
 }
 
 #[tokio::test]

--- a/apps/api-rust/apps/lmm-api-rs/tests/migration_media_tasks.rs
+++ b/apps/api-rust/apps/lmm-api-rs/tests/migration_media_tasks.rs
@@ -6,8 +6,9 @@ use axum::{
     http::{Request, StatusCode, header},
     response::Response,
 };
-use lmm_api_rs::migration_routes::media_tasks::{
-    MediaTaskHttpState, MediaTaskOperation, MediaTaskService, media_task_router,
+use lmm_api_rs::migration_routes::{
+    media_midjourney::midjourney_image_signature,
+    media_tasks::{MediaTaskHttpState, MediaTaskOperation, MediaTaskService, media_task_router},
 };
 use serde_json::{Value, json};
 use tower::ServiceExt;
@@ -133,8 +134,10 @@ fn json_response(status: StatusCode, body: Value) -> Response {
 }
 
 fn app(service: Arc<StubTaskService>) -> axum::Router {
-    media_task_router(MediaTaskHttpState::new(service))
+    media_task_router(MediaTaskHttpState::new(service).with_image_signing_secret(IMAGE_SECRET))
 }
+
+const IMAGE_SECRET: &[u8] = b"test-midjourney-image-session-secret-2026";
 
 async fn call(router: &axum::Router, method: &str, path: &str, body: Body) -> Response {
     router
@@ -152,12 +155,14 @@ async fn call(router: &axum::Router, method: &str, path: &str, body: Body) -> Re
 }
 
 #[tokio::test]
-async fn public_image_is_unauthenticated_and_preserves_binary_response_without_effects() {
+async fn signed_public_image_preserves_binary_response_without_bearer_token_or_effects() {
     let service = Arc::new(StubTaskService::default());
+    let signature =
+        midjourney_image_signature(IMAGE_SECRET, 1, "stub-image-job").expect("signature");
     let response = app(Arc::clone(&service))
         .oneshot(
             Request::builder()
-                .uri("/mj/image/stub-image-job")
+                .uri(format!("/mj/image/stub-image-job?uid=1&sig={signature}"))
                 .body(Body::empty())
                 .expect("request"),
         )

--- a/apps/api-rust/apps/lmm-api-rs/tests/migration_media_tasks_concrete.rs
+++ b/apps/api-rust/apps/lmm-api-rs/tests/migration_media_tasks_concrete.rs
@@ -51,7 +51,12 @@ impl MidjourneyBackend for MockBackend {
             response: BufferedJsonReply {
                 status: StatusCode::OK,
                 content_type: HeaderValue::from_static("application/json"),
-                body: json!({"code":21,"description":"replayed","result":"task-1"}),
+                body: json!({
+                    "code":21,
+                    "description":"replayed",
+                    "result":"task-1",
+                    "properties":{"imageUrl":"https://provider.example/private.png"}
+                }),
             },
             effect: TaskEffect {
                 mode: "mj".to_owned(),
@@ -122,7 +127,9 @@ fn request(path: &str, body: Body) -> Request<Body> {
 #[tokio::test]
 async fn concrete_static_mj_submit_reuses_backend_accounting_and_normalizes_replay() {
     let backend = Arc::new(MockBackend::default());
-    let service = MidjourneyMediaTaskService::new(Arc::clone(&backend));
+    let secret = b"test-midjourney-image-session-secret-2026";
+    let service =
+        MidjourneyMediaTaskService::new(Arc::clone(&backend)).with_image_signing_secret(secret);
     let response = service
         .protected(
             MediaTaskOperation::Submit("IMAGINE"),
@@ -141,6 +148,20 @@ async fn concrete_static_mj_submit_reuses_backend_accounting_and_normalizes_repl
     )
     .expect("JSON response");
     assert_eq!(body["code"], 1);
+    let image_url = body["properties"]["imageUrl"]
+        .as_str()
+        .expect("signed image URL");
+    assert!(!image_url.contains("provider.example"));
+    let image_url =
+        reqwest::Url::parse(&format!("https://fixture{image_url}")).expect("signed image URL");
+    assert_eq!(
+        lmm_api_rs::migration_routes::media_midjourney::signed_image_user_id(
+            secret,
+            "task-1",
+            image_url.query(),
+        ),
+        Some(7)
+    );
     assert_eq!(*backend.recorded.lock().expect("record lock"), 1);
     assert_eq!(
         backend

--- a/apps/api-rust/apps/lmm-api-rs/tests/migration_media_tasks_concrete.rs
+++ b/apps/api-rust/apps/lmm-api-rs/tests/migration_media_tasks_concrete.rs
@@ -8,7 +8,7 @@ use axum::{
 use lmm_api_rs::migration_routes::{
     media_midjourney::{
         BufferedJsonReply, ImageReply, MidjourneyBackend, MidjourneyFailure, MidjourneyIdentity,
-        StoredImage, SubmitReply, TaskEffect,
+        StoredImage, SubmitReply, TaskEffect, midjourney_image_signature,
     },
     media_tasks::{MediaTaskOperation, MediaTaskService, MidjourneyMediaTaskService},
 };
@@ -97,7 +97,7 @@ impl MidjourneyBackend for MockBackend {
         })
     }
 
-    async fn image_for(&self, _task_id: &str) -> Result<StoredImage, MidjourneyFailure> {
+    async fn image_for(&self, _: i64, _task_id: &str) -> Result<StoredImage, MidjourneyFailure> {
         Ok(StoredImage {
             url: "https://provider.example/task-1.png".to_owned(),
         })
@@ -177,11 +177,17 @@ async fn concrete_static_mj_read_scopes_the_task_id_before_backend_dispatch() {
 #[tokio::test]
 async fn concrete_static_mj_public_image_preserves_stream_without_task_writes() {
     let backend = Arc::new(MockBackend::default());
-    let service = MidjourneyMediaTaskService::new(Arc::clone(&backend));
+    let secret = b"test-midjourney-image-session-secret-2026";
+    let service =
+        MidjourneyMediaTaskService::new(Arc::clone(&backend)).with_image_signing_secret(secret);
+    let signature = midjourney_image_signature(secret, 7, "task-1").expect("signature");
     let response = service
         .public_image(
             "task-1".to_owned(),
-            request("/mj/image/task-1", Body::empty()),
+            request(
+                &format!("/mj/image/task-1?uid=7&sig={signature}"),
+                Body::empty(),
+            ),
         )
         .await;
 


### PR DESCRIPTION
## Summary
- bind signed Midjourney image URLs to the requesting user and task
- enforce task ownership for dynamic and static image routes
- redact upstream provider URLs from task submission, detail, list, and stream responses
- add regression coverage for cross-user access, tampered signatures, streaming, and URL redaction

Closes #33

## Validation
- cargo fmt --check
- cargo metadata --locked
- git diff --check
- focused Midjourney/media-task tests
- clippy
- package tests (pre-existing Windows WSL bash path issue remains)

## Summary by Sourcery

将 Midjourney 图像访问和 URL 通过基于 HMAC 的签名链接绑定到已认证用户，并确保在任务响应中重写和脱敏提供商图像 URL，同时为新的图像作用域和签名行为添加回归测试覆盖。

New Features:
- 引入基于 HMAC 的签名和验证机制，用于按用户和任务 ID 作用域限定的 Midjourney 图像 URL。
- 暴露配置钩子，以便将部署级的图像签名密钥注入到 Midjourney HTTP 和媒体任务服务中。

Bug Fixes:
- 将 Midjourney 图像查询限制为所属用户，以防止通过共享或被篡改的 URL 进行跨用户访问。
- 在通过动态和静态路由提供 Midjourney 图像之前，要求提供有效签名的图像查询参数。

Enhancements:
- 在 Midjourney 任务提交和读取响应中重写上游提供商图像 URL，使用按用户作用域限定的已签名代理路径替代直接的提供商链接。
- 收紧媒体任务文档和接口，明确图像路由基于签名 URL，而非未认证的公共端点。

Tests:
- 添加测试，覆盖图像 URL 签名/验证、URL 重写、带签名 URL 的流式行为以及跨用户访问回归场景。
- 更新现有的 Midjourney 媒体任务测试，以断言使用已签名图像并确保响应中不存在直接的提供商 URL。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bind Midjourney image access and URLs to the authenticated user using signed HMAC-based links, and ensure provider image URLs are rewritten and redacted in task responses while adding regression coverage for the new image-scoping and signing behavior.

New Features:
- Introduce HMAC-based signing and verification for Midjourney image URLs scoped to user and task IDs.
- Expose configuration hooks to inject a deployment-wide image signing secret into Midjourney HTTP and media task services.

Bug Fixes:
- Restrict Midjourney image lookup queries to the owning user to prevent cross-user access via shared or tampered URLs.
- Require valid signed image query parameters before serving Midjourney images from both dynamic and static routes.

Enhancements:
- Rewrite upstream provider image URLs in Midjourney task submit and read responses to use user-scoped signed proxy paths instead of direct provider links.
- Tighten media task documentation and interfaces to clarify that image routes are signed URL-based rather than unauthenticated public endpoints.

Tests:
- Add tests covering image URL signing/verification, URL rewriting, streaming behavior with signed URLs, and cross-user access regression cases.
- Update existing Midjourney media task tests to assert signed image usage and lack of direct provider URLs in responses.

</details>