### PR TITLE
feat(rust): complete migration validation gates

### DIFF
--- a/apps/api-rust/README.md
+++ b/apps/api-rust/README.md
@@ -1,11 +1,11 @@
 # Rust migration workspace
 
 This native (non-container) workspace is the strangler target for the Go
-service. Its root router currently mounts 20 frozen method/path pairs across
-public content, status, authentication, model discovery, and API-token slices.
-Additional migration modules are compiled as candidates without being mounted.
-The production edge still assigns all 356 frozen routes to Go; Rust owns no
-production business traffic or writes yet.
+service. The isolated test-instance root composes the complete Rust candidate
+surface, while the normal listener currently mounts 20 frozen method/path
+pairs across public content, status, authentication, model discovery, and
+API-token slices. The production edge still assigns all 356 frozen routes to
+Go; Rust owns no production business traffic or writes yet.
 
 Required environment variable names are `LMM_RS_LISTEN_ADDR`, `DATABASE_URL`,
 `VALKEY_URL`, and `LMM_SCHEMA_CONTRACT`. `DATABASE_URL` must select the exact
@@ -41,11 +41,12 @@ route validation remains Go-independent after the source moves to the ignored
 local backup. `routes/rust-implemented-routes.tsv` records implementation
 coverage; it does not claim production traffic ownership.
 
-The draft coverage checker currently finds Rust handlers for 300 of the 356
-frozen method/path pairs (84.3%), leaving 56 without a candidate. This is only
-static implementation evidence: it does not grant differential-verification
-credit, root mounting, or production ownership. Run it after every candidate
-wave instead of copying this snapshot into an ownership decision.
+The draft coverage checker currently finds Rust handlers for all 356 frozen
+method/path pairs, including 12 explicitly approved legacy-equivalent 501
+routes. This is only static implementation evidence: it does not grant
+differential-verification credit, root mounting, or production ownership. Run
+it after every candidate wave instead of copying this snapshot into an
+ownership decision.
 
 `/livez` performs no dependency I/O. `/readyz` always requires PostgreSQL, the
 schema reader window, and read/capability checks for every currently mounted

--- a/apps/api-rust/apps/lmm-api-rs/tests/migration_all_routes_contract.rs
+++ b/apps/api-rust/apps/lmm-api-rs/tests/migration_all_routes_contract.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeSet,
-    fs,
+    env, fs,
     path::{Path, PathBuf},
     process::Command,
     sync::{
@@ -40,6 +40,37 @@ fn router_constructors(source: &str) -> BTreeSet<&str> {
         .filter_map(|signature| signature.split_once('(').map(|(name, _)| name))
         .filter(|name| *name == "routes" || name.ends_with("router"))
         .collect()
+}
+
+fn bash_command() -> Command {
+    #[cfg(windows)]
+    {
+        if let Ok(path) = env::var("LMM_BASH") {
+            return Command::new(path);
+        }
+
+        // `C:\Windows\System32\bash.exe` is the WSL launcher and emits a
+        // misleading install prompt when WSL is absent. Prefer the Bash
+        // shipped with the Git installation that Cargo is using.
+        if let Ok(output) = Command::new("git").arg("--exec-path").output()
+            && output.status.success()
+        {
+            let exec_path = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+            let exec_path = Path::new(&exec_path);
+            for candidate in [
+                exec_path.join("..\\..\\..\\bin\\bash.exe"),
+                exec_path.join("..\\..\\..\\usr\\bin\\bash.exe"),
+            ] {
+                if let Ok(candidate) = candidate.canonicalize() {
+                    if candidate.is_file() {
+                        return Command::new(candidate);
+                    }
+                }
+            }
+        }
+    }
+
+    Command::new("bash")
 }
 
 /// These slices are composed by the isolated test-instance root instead of a
@@ -149,7 +180,7 @@ fn every_migration_route_module_should_have_a_router_integration_test() {
 #[test]
 fn all_candidate_route_shapes_should_pass_the_repository_gate() {
     let root = manifest_dir();
-    let output = Command::new("bash")
+    let output = bash_command()
         .arg(root.join("../../scripts/check-draft-route-coverage.sh"))
         .current_dir(&root)
         .output()

--- a/apps/api-rust/crates/lmm-db-migrate/src/inspect.rs
+++ b/apps/api-rust/crates/lmm-db-migrate/src/inspect.rs
@@ -264,7 +264,7 @@ fn quote_identifier(identifier: &str) -> String {
     format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
 

--- a/apps/api-rust/crates/lmm-db-migrate/src/migrate.rs
+++ b/apps/api-rust/crates/lmm-db-migrate/src/migrate.rs
@@ -14,6 +14,8 @@ use rusqlite::{Connection, OpenFlags, types::ValueRef};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 
+#[cfg(windows)]
+use std::os::windows::fs::MetadataExt;
 #[cfg(unix)]
 use std::os::{fd::AsRawFd, unix::fs::MetadataExt};
 
@@ -229,17 +231,37 @@ impl SourceSnapshot {
         let sha256: [u8; 32] = digest.finalize().into();
         file.seek(SeekFrom::Start(0))?;
         #[cfg(unix)]
-        return Ok(Self {
-            canonical,
-            device: metadata.dev(),
-            inode: metadata.ino(),
-            size: metadata.len(),
-            modified_seconds: metadata.mtime(),
-            modified_nanoseconds: metadata.mtime_nsec(),
-            sha256,
-        });
-        #[cfg(not(unix))]
-        compile_error!("lmm-db-migrate requires Unix metadata identity semantics");
+        {
+            Ok(Self {
+                canonical,
+                device: metadata.dev(),
+                inode: metadata.ino(),
+                size: metadata.len(),
+                modified_seconds: metadata.mtime(),
+                modified_nanoseconds: metadata.mtime_nsec(),
+                sha256,
+            })
+        }
+        #[cfg(windows)]
+        {
+            // Stable Rust does not expose Windows volume/file identity until
+            // the `windows_by_handle` API is stabilized.  The immutable
+            // content digest, size, and write timestamp remain authoritative
+            // for this read-only rehearsal; the fields stay zero so a future
+            // handle-based identity implementation can be added without a
+            // schema change.
+            Ok(Self {
+                canonical,
+                device: 0,
+                inode: 0,
+                size: metadata.file_size(),
+                modified_seconds: i64::try_from(metadata.last_write_time()).unwrap_or(i64::MAX),
+                modified_nanoseconds: 0,
+                sha256,
+            })
+        }
+        #[cfg(not(any(unix, windows)))]
+        compile_error!("lmm-db-migrate requires supported file metadata identity semantics");
     }
 }
 
@@ -287,19 +309,22 @@ fn open_source(path: &Path, before: &SourceSnapshot) -> Result<SourceHandle, Mig
     reject_sidecars(path)?;
     let canonical = fs::canonicalize(path)?;
     let mut identity_file = File::open(path)?;
-    let opened = SourceSnapshot::from_file(canonical, &mut identity_file)?;
+    let opened = SourceSnapshot::from_file(canonical.clone(), &mut identity_file)?;
     if &opened != before {
         return Err(MigrationError::Manifest(
             "SQLite source changed between capture and open".into(),
         ));
     }
-    let uri = format!("file:/proc/self/fd/{}?mode=ro", identity_file.as_raw_fd());
+    let flags = OpenFlags::SQLITE_OPEN_READ_ONLY
+        | OpenFlags::SQLITE_OPEN_URI
+        | OpenFlags::SQLITE_OPEN_NO_MUTEX;
+    #[cfg(unix)]
     let connection = Connection::open_with_flags(
-        uri,
-        OpenFlags::SQLITE_OPEN_READ_ONLY
-            | OpenFlags::SQLITE_OPEN_URI
-            | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        format!("file:/proc/self/fd/{}?mode=ro", identity_file.as_raw_fd()),
+        flags,
     )?;
+    #[cfg(windows)]
+    let connection = Connection::open_with_flags(&canonical, flags)?;
     Ok(SourceHandle {
         connection,
         _identity_file: identity_file,

--- a/apps/api-rust/crates/lmm-db-migrate/src/report.rs
+++ b/apps/api-rust/crates/lmm-db-migrate/src/report.rs
@@ -45,15 +45,45 @@ pub fn write_atomic<T: Serialize>(path: &Path, report: &T) -> Result<(), Migrati
         serde_json::to_writer_pretty(&mut file, report)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
+        drop(file);
         reject_symlink_target(path)?;
-        fs::rename(&temporary, path)?;
-        OpenOptions::new().read(true).open(parent)?.sync_all()?;
+        publish_temporary(&temporary, path)?;
+        sync_parent(parent)?;
         Ok(())
     })();
     if result.is_err() {
         let _ = fs::remove_file(&temporary);
     }
     result
+}
+
+#[cfg(not(windows))]
+fn publish_temporary(temporary: &Path, path: &Path) -> Result<(), MigrationError> {
+    fs::rename(temporary, path)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn publish_temporary(temporary: &Path, path: &Path) -> Result<(), MigrationError> {
+    // Windows' std::fs::rename does not replace an existing file. Remove only
+    // the checked report entry, then rename the fully-synced temporary file.
+    if path.exists() {
+        fs::remove_file(path)?;
+    }
+    fs::rename(temporary, path)?;
+    Ok(())
+}
+
+#[cfg(not(windows))]
+fn sync_parent(parent: &Path) -> Result<(), MigrationError> {
+    OpenOptions::new().read(true).open(parent)?.sync_all()?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn sync_parent(_parent: &Path) -> Result<(), MigrationError> {
+    // Windows does not expose portable directory fsync through std::fs.
+    Ok(())
 }
 
 fn reject_symlink_target(path: &Path) -> Result<(), MigrationError> {

--- a/apps/api-rust/crates/lmm-db-migrate/tests/full_copy.rs
+++ b/apps/api-rust/crates/lmm-db-migrate/tests/full_copy.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::{fs, path::Path, process::Command};
 
 use lmm_db_migrate::{
@@ -12,6 +14,7 @@ use rusqlite::Connection;
 use sha2::{Digest, Sha256};
 
 #[test]
+#[cfg(unix)]
 #[ignore = "requires native PostgreSQL from rehearse-postgres.sh"]
 fn full_copy_should_verify_all_tables_and_rollback_both_fault_phases() {
     let database_url = std::env::var("LMM_TEST_DATABASE_URL").expect("test database URL");

--- a/apps/api-rust/scripts/check-draft-route-completion.sh
+++ b/apps/api-rust/scripts/check-draft-route-completion.sh
@@ -30,7 +30,7 @@ require_approved_legacy_stubs() {
     echo "frozen legacy baseline must live below the repository root" >&2
     return 1
   }
-  legacy_sha=$(sha256sum -- "$legacy")
+  legacy_sha=$(sed 's/\r$//' -- "$legacy" | sha256sum)
   legacy_sha=${legacy_sha%% *}
   expected_frozen_ledger="$legacy_relative@sha256:$legacy_sha"
 

--- a/apps/api-rust/scripts/check-draft-route-coverage.sh
+++ b/apps/api-rust/scripts/check-draft-route-coverage.sh
@@ -223,6 +223,9 @@ sub normalize_path {
 
 sub relative_source_path {
     my ($path) = @_;
+    # `rg --files` emits native separators on Windows.  The checked-in
+    # allowlist is repository-relative and always uses forward slashes.
+    $path =~ s{\\}{/}g;
     $path =~ s{^\Q$repo_root/\E}{};
     return $path;
 }

--- a/apps/api-rust/scripts/check-go-route-manifest.sh
+++ b/apps/api-rust/scripts/check-go-route-manifest.sh
@@ -16,7 +16,7 @@ for required_file in "${golden_hash_file}" "${legacy_manifest}" "${rust_manifest
 done
 
 expected_hash="$(awk 'NR == 1 { print $1 }' "${golden_hash_file}")"
-actual_hash="$(sha256sum "${legacy_manifest}" | awk '{ print $1 }')"
+actual_hash="$(sed 's/\r$//' "${legacy_manifest}" | sha256sum | awk '{ print $1 }')"
 if [[ "${actual_hash}" != "${expected_hash}" ]]; then
   echo "expected frozen legacy route hash ${expected_hash}, got ${actual_hash}" >&2
   echo "legacy-go-routes.tsv is immutable evidence; regenerate it only from the pinned Go revision" >&2

--- a/apps/api-rust/scripts/check-migration-plan.sh
+++ b/apps/api-rust/scripts/check-migration-plan.sh
@@ -6,12 +6,20 @@ legacy="$repo_root/apps/api-rust/routes/legacy-go-routes.tsv"
 plan="${MIGRATION_PLAN_PATH:-$repo_root/apps/api-rust/routes/migration-plan.tsv}"
 gate="${MIGRATION_GATE_PATH:-$repo_root/apps/api-rust/routes/migration-gate.tsv}"
 review="${MIGRATION_INTEGRATION_REVIEW_PATH:-$repo_root/apps/api-rust/routes/integration-review.tsv}"
+
+# Git's checkout policy may leave the tracked TSV files with CRLF endings on
+# Windows.  Normalize only command output used for validation; do not rewrite
+# the checked-in route ledgers.
+tsv_without_crlf() {
+  sed 's/\r$//' -- "$1"
+}
+
 expected_header=$'method\tpath\tlegacy_handler\tdomain\tauth_scope\tdata_access\tstreaming\tpriority\tplanned_rust_module\tjob_dependency'
 expected_gate_header=$'method\tpath\tsource_state\tcompile_state\tmount_state\tdifferential_state\tapproval_state\tproduction_owner\tgate_state\tevidence'
 expected_review_header=$'method\tpath\trust_handler\tlistener_differential\tpostgres_evidence\tvalkey_evidence\tdecision\tnotes'
 
 [[ -f "$plan" ]] || { echo "missing migration plan: $plan" >&2; exit 1; }
-[[ $(head -n 1 "$plan") == "$expected_header" ]] || { echo "invalid migration-plan header" >&2; exit 1; }
+[[ $(tsv_without_crlf "$plan" | head -n 1) == "$expected_header" ]] || { echo "invalid migration-plan header" >&2; exit 1; }
 
 awk -F '\t' '
   function frozen_auth_scope(method, path) {
@@ -59,15 +67,15 @@ awk -F '\t' '
   }
 ' "$plan"
 
-cut -f1-3 "$plan" | tail -n +2 | diff -u "$legacy" -
+diff -u <(tsv_without_crlf "$legacy") <(tsv_without_crlf "$plan" | cut -f1-3 | tail -n +2)
 
 [[ -f "$gate" ]] || { echo "missing migration evidence gate: $gate" >&2; exit 1; }
-[[ $(head -n 1 "$gate") == "$expected_gate_header" ]] || {
+[[ $(tsv_without_crlf "$gate" | head -n 1) == "$expected_gate_header" ]] || {
   echo "invalid migration-gate header" >&2
   exit 1
 }
 [[ -f "$review" ]] || { echo "missing integration review: $review" >&2; exit 1; }
-[[ $(head -n 1 "$review") == "$expected_review_header" ]] || {
+[[ $(tsv_without_crlf "$review" | head -n 1) == "$expected_review_header" ]] || {
   echo "invalid integration-review header" >&2
   exit 1
 }
@@ -341,6 +349,7 @@ mapfile -t declared_candidates < <(
 declared_candidate_count=${#declared_candidates[@]}
 mapfile -t candidate_names < <(
   printf '%s\n' "${candidate_files[@]}" |
+    tr '\\' '/' |
     sed -E 's#^.*/##; s#\.rs$##' |
     LC_ALL=C sort
 )

--- a/apps/api-rust/scripts/run-migration-checks.ps1
+++ b/apps/api-rust/scripts/run-migration-checks.ps1
@@ -1,0 +1,57 @@
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$cargo = if ($env:CARGO_EXE) {
+    Get-Command $env:CARGO_EXE -ErrorAction SilentlyContinue
+} else {
+    Get-Command cargo -ErrorAction SilentlyContinue
+}
+if (-not $cargo) {
+    $cargoPath = Join-Path $env:USERPROFILE '.cargo\bin\cargo.exe'
+    if (Test-Path -LiteralPath $cargoPath) {
+        $cargo = Get-Command $cargoPath
+    }
+}
+if (-not $cargo) {
+    throw 'cargo.exe is required; install Rust with rustup or set CARGO_EXE.'
+}
+
+$bashCandidates = @()
+if ($env:LMM_BASH) { $bashCandidates += $env:LMM_BASH }
+try {
+    $execPath = (& git --exec-path 2>$null).Trim()
+    if ($execPath) {
+        $gitRoot = (Resolve-Path (Join-Path $execPath '..\..\..')).Path
+        $bashCandidates += Join-Path $gitRoot 'bin\bash.exe'
+        $bashCandidates += Join-Path $gitRoot 'usr\bin\bash.exe'
+    }
+} catch {
+    # Fall through to the standard PATH lookup.
+}
+$bashCandidates += (Get-Command bash -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source -ErrorAction SilentlyContinue)
+$bash = $bashCandidates | Where-Object { $_ -and (Test-Path -LiteralPath $_) -and ((Resolve-Path $_).Path -notlike 'C:\Windows\System32\*') } | Select-Object -First 1
+if (-not $bash) {
+    throw 'Git Bash is required for the repository shell gates. Set LMM_BASH to the Git Bash executable.'
+}
+
+function Invoke-GitBash([string] $script) {
+    & $bash -lc "cd '$($repoRoot -replace '\\','/')' && $script"
+    if ($LASTEXITCODE -ne 0) { throw "Git Bash command failed with exit code $LASTEXITCODE`: $script" }
+}
+
+Push-Location (Join-Path $repoRoot 'apps\api-rust')
+try {
+    & $cargo.Source fmt --all -- --check
+    if ($LASTEXITCODE -ne 0) { throw "cargo fmt failed with exit code $LASTEXITCODE" }
+    & $cargo.Source metadata --locked --no-deps --format-version 1 *> $null
+    if ($LASTEXITCODE -ne 0) { throw "cargo metadata failed with exit code $LASTEXITCODE" }
+    & $cargo.Source test --locked -p lmm-api-rs --test migration_all_routes_contract
+    if ($LASTEXITCODE -ne 0) { throw "migration route tests failed with exit code $LASTEXITCODE" }
+} finally {
+    Pop-Location
+}
+
+Invoke-GitBash 'bash apps/api-rust/scripts/check-go-route-manifest.sh'
+Invoke-GitBash 'bash apps/api-rust/scripts/check-draft-route-coverage.sh'
+Invoke-GitBash 'bash apps/api-rust/scripts/check-migration-plan.sh'
+Write-Output 'Rust migration checks passed.'


### PR DESCRIPTION
## Summary
- complete the Rust migration route coverage and Windows-compatible validation gates
- make migration ledgers robust to CRLF and Git Bash path separators
- fix Windows atomic report publication and add the one-command migration check

## Validation
- cargo test --workspace --all-targets --locked
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- apps/api-rust/scripts/run-migration-checks.ps1
- 356/356 frozen routes covered; missing=0

## Summary by Sourcery

为 Rust API 迁移工作区新增兼容 Windows 的迁移验证、报告，以及路由覆盖率检查。

New Features:
- 为 Rust 迁移工具链引入兼容 Windows 的代码路径，用于读取 SQLite 迁移源并打开连接。
- 新增一个 PowerShell 脚本，用于在 Windows 上运行完整的 Rust 迁移检查集，包括路由与清单（manifest）验证。
- 为路由覆盖率测试新增一个可移植的 Bash 命令发现辅助工具，用于在 Windows 上定位 Git Bash。

Bug Fixes:
- 通过安全替换现有文件并避免目录 fsync 限制，修复在 Windows 上发布原子 JSON 报告的问题。
- 修正路由账本（route ledger）和清单验证脚本，使其能在各平台正确处理 CRLF 行结尾和本机路径分隔符。

Enhancements:
- 记录所有冻结路由现在都具备 Rust 候选处理器，并澄清迁移覆盖率状态。
- 将某些仅适用于类 Unix 系统的测试和元数据检查工具限制在 Unix 目标上运行，以保持测试套件的可移植性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Windows-compatible migration validation, reporting, and route coverage checks for the Rust API migration workspace.

New Features:
- Introduce a Windows-compatible code path for reading SQLite migration sources and opening connections in the Rust migration tooling.
- Add a PowerShell script to run the full set of Rust migration checks, including route and manifest validation, on Windows.
- Add a portable Bash command discovery helper for route coverage tests to locate Git Bash on Windows.

Bug Fixes:
- Fix atomic JSON report publication on Windows by replacing existing files safely and avoiding directory fsync limitations.
- Correct route ledger and manifest validation scripts to handle CRLF line endings and native path separators across platforms.

Enhancements:
- Document that all frozen routes now have Rust candidate handlers and clarify the migration coverage status.
- Restrict certain Unix-only tests and metadata inspection utilities to Unix targets to keep the test suite portable.

</details>