### PR TITLE
test: avoid Windows channel-affinity cache key collisions

### DIFF
--- a/apps/api-go/service/channel_affinity_usage_cache_test.go
+++ b/apps/api-go/service/channel_affinity_usage_cache_test.go
@@ -4,13 +4,18 @@ import (
 	"fmt"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/QuantumNous/new-api/relaykit/dto"
 	"github.com/QuantumNous/new-api/relaykit/types"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func channelAffinityUsageCacheTestIdentity(t *testing.T) (ruleName, keyFP string) {
+	t.Helper()
+	identity := t.Name()
+	return "rule_" + identity, "fp_" + identity
+}
 
 func buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP string) *gin.Context {
 	rec := httptest.NewRecorder()
@@ -26,9 +31,8 @@ func buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP string)
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_ClaudeMode(t *testing.T) {
-	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
+	ruleName, keyFP := channelAffinityUsageCacheTestIdentity(t)
 	usingGroup := "default"
-	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
 	ctx := buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP)
 
 	usage := &dto.Usage{
@@ -53,9 +57,8 @@ func TestObserveChannelAffinityUsageCacheByRelayFormat_ClaudeMode(t *testing.T) 
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode(t *testing.T) {
-	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
+	ruleName, keyFP := channelAffinityUsageCacheTestIdentity(t)
 	usingGroup := "default"
-	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
 	ctx := buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP)
 
 	openAIUsage := &dto.Usage{
@@ -83,9 +86,8 @@ func TestObserveChannelAffinityUsageCacheByRelayFormat_MixedMode(t *testing.T) {
 }
 
 func TestObserveChannelAffinityUsageCacheByRelayFormat_UnsupportedModeKeepsEmpty(t *testing.T) {
-	ruleName := fmt.Sprintf("rule_%d", time.Now().UnixNano())
+	ruleName, keyFP := channelAffinityUsageCacheTestIdentity(t)
 	usingGroup := "default"
-	keyFP := fmt.Sprintf("fp_%d", time.Now().UnixNano())
 	ctx := buildChannelAffinityStatsContextForTest(ruleName, usingGroup, keyFP)
 
 	usage := &dto.Usage{


### PR DESCRIPTION
## Summary`n- replace time-based test cache identities with stable test-name identities`n- prevent Windows clock-resolution collisions across channel-affinity tests`n`n## Validation`n- go test ./service -run TestObserveChannelAffinityUsageCacheByRelayFormat_ -count=1 -v`n- go test ./service -count=1`n`nReproduction and scope are documented in #41.

## Summary by Sourcery

Tests:
- 更新 channel-affinity 使用缓存的测试，使其使用基于测试名称的确定性规则和指纹标识符，以避免缓存键冲突，尤其是在 Windows 上。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Update channel-affinity usage cache tests to use deterministic, test-name-based rule and fingerprint identifiers to avoid cache key collisions, particularly on Windows.

</details>