### PR TITLE
[codex] show bounty rank on accepted challenge cards

### DIFF
--- a/apps/web/src/features/open-source-bounties/index.tsx
+++ b/apps/web/src/features/open-source-bounties/index.tsx
@@ -276,6 +276,16 @@ export function OpenSourceBounties() {
     queryKey: BOUNTY_QUERY_KEYS[2],
     queryFn: listAcceptedBounties,
   })
+  const bountyRankByProjectId = useMemo(() => {
+    const items = bountyQuery.data?.items ?? []
+    const page = bountyQuery.data?.page ?? 1
+    const pageSize = bountyQuery.data?.page_size ?? 50
+    const firstRank = (page - 1) * pageSize + 1
+
+    return new Map(
+      items.map((project, index) => [project.id, firstRank + index] as const)
+    )
+  }, [bountyQuery.data])
   const disputesQuery = useQuery({
     queryKey: BOUNTY_QUERY_KEYS[3],
     queryFn: listMyBountyDisputes,
@@ -807,6 +817,7 @@ export function OpenSourceBounties() {
                       <ChallengeCard
                         key={challenge.id}
                         challenge={challenge}
+                        rank={bountyRankByProjectId.get(challenge.project_id)}
                         pending={pending}
                         onSubmit={() =>
                           openSubmitDialog(challenge.project_id, challenge)
@@ -1450,12 +1461,14 @@ function OwnerProjectCard(props: {
 
 function ChallengeCard({
   challenge,
+  rank,
   pending,
   onSubmit,
   onWithdraw,
   onRateOwner,
 }: {
   challenge: BountyChallenge
+  rank?: number
   pending: string
   onSubmit: () => void
   onWithdraw: () => void
@@ -1471,6 +1484,7 @@ function ChallengeCard({
       description={`${challenge.owner_username ?? ''} · ${statusLabel(t, challenge.status)}`}
       icon={<HugeiconsIcon icon={Bug01Icon} strokeWidth={1.8} />}
       iconTone='neutral'
+      action={rank != null ? <BountyRankBadge rank={rank} /> : undefined}
       disableHoverEffect
     >
       <div className='flex flex-col gap-4'>


### PR DESCRIPTION
## Summary

- derive each published bounty project's one-based board rank from the current page
- show that rank on matching cards in `My challenges`
- leave the badge hidden when an accepted challenge's project is not present in the current board response

## Why

Accepted challenge cards previously had no stable way to match them back to the numbered bounty board. This makes the cards for the product-details bounty and Rust migration bounty visibly correspond to their board entries without changing bounty state or submission behavior.

## Validation

- `bun run --filter @lmm/web typecheck`
- `bun run --filter @lmm/web test` (182 passed)
- `bunx oxfmt --check apps/web/src/features/open-source-bounties/index.tsx`
- `bun run --filter @lmm/web lint` (exit 0; existing warnings remain outside this change)
- `git diff --check`

## Summary by Sourcery

新功能：
- 当相应项目出现在当前悬赏榜页面时，在已接受的挑战卡片上显示悬赏排名徽章。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Show a bounty rank badge on accepted challenge cards when the corresponding project appears in the current bounty board page.

</details>