### PR TITLE
fix(relay): bill partial Responses WebSocket output

### DIFF
--- a/apps/api-go/relay/responses_websocket.go
+++ b/apps/api-go/relay/responses_websocket.go
@@ -81,6 +81,7 @@ type responsesWSSession struct {
 
 var loadResponsesWSLockedChannel = appmodel.CacheGetChannel
 var isResponsesWSChannelAvailable = appmodel.IsChannelEnabledForGroupModel
+var postResponsesWSConsumeQuota = service.PostTextConsumeQuota
 
 func ResponsesWebSocketHelper(c *gin.Context, client *websocket.Conn) *types.NewAPIError {
 	session := &responsesWSSession{c: c, client: client}
@@ -670,8 +671,9 @@ func (s *responsesWSSession) observeUpstreamMessage(message []byte) {
 		terminal = true
 		success = true
 	case "response.incomplete", "response.failed", "response.cancelled", "response.canceled", "response.error", "error":
-		state.images.Reset()
+		s.applyTerminalResponseUsage(state, streamResponse.Response)
 		terminal = true
+		success = responsesWSHasBillablePartialLocked(state)
 	case "response.output_text.delta":
 		state.outputText.WriteString(streamResponse.Delta)
 	case dto.ResponsesOutputTypeItemDone:
@@ -716,6 +718,15 @@ func (s *responsesWSSession) finishCall(state *responsesWSCallState, success boo
 	}
 	defer s.completeFinish(state)
 	if !success {
+		state.dataMu.Lock()
+		if responsesWSHasBillablePartialLocked(state) {
+			success = true
+		} else {
+			state.images.Reset()
+		}
+		state.dataMu.Unlock()
+	}
+	if !success {
 		state.refund(s.c)
 		if state.commitRate != nil {
 			state.commitRate(false)
@@ -726,10 +737,31 @@ func (s *responsesWSSession) finishCall(state *responsesWSCallState, success boo
 	state.images.Commit(state.info)
 	finalizeResponsesWSUsage(state)
 	state.dataMu.Unlock()
-	service.PostTextConsumeQuota(s.c, state.info, state.usage, nil)
+	postResponsesWSConsumeQuota(s.c, state.info, state.usage, nil)
 	if state.commitRate != nil {
 		state.commitRate(true)
 	}
+}
+
+func responsesWSHasBillablePartialLocked(state *responsesWSCallState) bool {
+	if state == nil {
+		return false
+	}
+	if state.usage != nil && (state.usage.PromptTokens != 0 || state.usage.CompletionTokens != 0 || state.usage.TotalTokens != 0 || state.usage.InputTokens != 0 || state.usage.OutputTokens != 0) {
+		return true
+	}
+	if state.outputText.Len() != 0 || state.images.Count() != 0 {
+		return true
+	}
+	if state.info == nil || state.info.ResponsesUsageInfo == nil {
+		return false
+	}
+	for _, tool := range state.info.ResponsesUsageInfo.BuiltInTools {
+		if tool != nil && tool.CallCount > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func finalizeResponsesWSUsage(state *responsesWSCallState) {

--- a/apps/api-go/relay/responses_websocket_test.go
+++ b/apps/api-go/relay/responses_websocket_test.go
@@ -105,6 +105,68 @@ func TestCancelTerminalSettlesTurnOnce(t *testing.T) {
 	assert.Equal(t, []bool{false}, commits)
 }
 
+func TestResponsesWSIncompleteAfterOutputSettlesPartialUsage(t *testing.T) {
+	previousPost := postResponsesWSConsumeQuota
+	t.Cleanup(func() { postResponsesWSConsumeQuota = previousPost })
+
+	var postedUsage *dto.Usage
+	postResponsesWSConsumeQuota = func(_ *gin.Context, _ *relaycommon.RelayInfo, usage *dto.Usage, _ []string) {
+		postedUsage = usage
+	}
+
+	commits := make([]bool, 0, 1)
+	state := &responsesWSCallState{
+		info: &relaycommon.RelayInfo{
+			ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "gpt-5"},
+		},
+		usage: &dto.Usage{},
+		commitRate: func(success bool) {
+			commits = append(commits, success)
+		},
+	}
+	state.info.SetEstimatePromptTokens(7)
+	session := &responsesWSSession{current: state}
+
+	session.observeUpstreamMessage([]byte(`{"type":"response.output_text.delta","delta":"billable output"}`))
+	session.observeUpstreamMessage([]byte(`{"type":"response.incomplete","response":{"usage":{"input_tokens":7,"output_tokens":3,"total_tokens":10}}}`))
+
+	assert.Nil(t, session.getCurrent())
+	assert.Equal(t, []bool{true}, commits)
+	require.NotNil(t, postedUsage)
+	assert.Equal(t, 7, postedUsage.PromptTokens)
+	assert.Equal(t, 3, postedUsage.CompletionTokens)
+	assert.Equal(t, 10, postedUsage.TotalTokens)
+}
+
+func TestResponsesWSDisconnectAfterOutputSettlesPartialUsage(t *testing.T) {
+	previousPost := postResponsesWSConsumeQuota
+	t.Cleanup(func() { postResponsesWSConsumeQuota = previousPost })
+
+	posted := false
+	postResponsesWSConsumeQuota = func(_ *gin.Context, _ *relaycommon.RelayInfo, _ *dto.Usage, _ []string) {
+		posted = true
+	}
+
+	commits := make([]bool, 0, 1)
+	state := &responsesWSCallState{
+		info: &relaycommon.RelayInfo{
+			ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: "gpt-5"},
+		},
+		usage: &dto.Usage{PromptTokens: 7, CompletionTokens: 3, TotalTokens: 10},
+		commitRate: func(success bool) {
+			commits = append(commits, success)
+		},
+	}
+	session := &responsesWSSession{current: state}
+
+	session.observeUpstreamMessage([]byte(`{"type":"response.output_text.delta","delta":"billable output"}`))
+	session.failCurrent()
+
+	assert.Nil(t, session.getCurrent())
+	assert.Equal(t, []bool{true}, commits)
+	assert.True(t, posted)
+}
+
 func TestBuildResponsesWSErrorPayload(t *testing.T) {
 	payload, err := buildResponsesWSErrorPayload("evt", types.NewErrorWithStatusCode(
 		errors.New("model is required"), types.ErrorCodeInvalidRequest, http.StatusBadRequest,


### PR DESCRIPTION
### Motivation

- Prevent a billing bypass where streamed `response.output_text.delta` / tool/image work is forwarded to the client but the turn is refunded when a terminal `response.incomplete`/cancel/error or disconnect occurs. This change ensures partial billable work is settled instead of always refunded. 
- This change was AI-assisted because the configured git user (`Codex <codex@openai.com>`) is not a recurring repository core developer.

### Description

- Changed terminal handling in `apps/api-go/relay/responses_websocket.go` so terminal `response.incomplete`/`failed`/`cancelled`/`error` events first apply observed usage via `applyTerminalResponseUsage` and then set `success` when billable partial work exists. 
- Added `responsesWSHasBillablePartialLocked` helper to detect billable partial work (reported usage, collected output text, observed images, or counted tool calls) and used it to determine whether to settle rather than refund. 
- Modified `finishCall` to consult the helper and, for turns with billable partials, commit usage and call the quota settlement path instead of refunding; only empty/no-billable-turns are refunded. 
- Introduced `postResponsesWSConsumeQuota` test seam (wrapper around `service.PostTextConsumeQuota`) to allow unit tests to observe when quota settlement is invoked. 
- Added regression tests in `apps/api-go/relay/responses_websocket_test.go`: `TestResponsesWSIncompleteAfterOutputSettlesPartialUsage` and `TestResponsesWSDisconnectAfterOutputSettlesPartialUsage` to assert partial output/usage leads to settlement and commits, and preserved existing `TestCancelTerminalSettlesTurnOnce` behavior.

### Testing

- Ran targeted unit tests: `cd apps/api-go && go test ./relay -run 'TestResponsesWS(IncompleteAfterOutputSettlesPartialUsage|DisconnectAfterOutputSettlesPartialUsage|CancelTerminalSettlesTurnOnce)$' -count=1 -timeout=5m` and they passed. 
- Ran full relay package test suite: `cd apps/api-go && go test ./relay -count=1 -timeout=5m` and it passed. 
- The change is limited to `apps/api-go/relay/responses_websocket.go` and `apps/api-go/relay/responses_websocket_test.go` and adds a small test seam for `PostTextConsumeQuota` to keep runtime behavior identical while enabling tests to validate settlement behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a72d0b557bc8320b86a7afd421eeeac)

## Summary by Sourcery

确保 WebSocket 中继会话在发生可计费工作时，对部分响应进行结算和计费，而不是在这种情况下退款回合。

Bug Fixes:
- 修复一个计费绕过问题：当向客户端发送了流式响应输出或工具/图像处理结果后，如果出现未完成响应、错误或断开连接事件，该回合仍会被退款。

Enhancements:
- 在 WebSocket 中继状态中增加对可计费部分工作的检测，以决定是结算用量还是对空回合进行退款。
- 在 WebSocket 中继中引入可重写的配额消耗钩子，以支持对配额结算行为的测试。

Tests:
- 添加回归测试，验证在发送流式输出之后，未完成的终止事件和断开连接会结算部分用量，并且只提交一次配额。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure WebSocket relay sessions settle and bill partial responses instead of refunding turns when billable work has occurred.

Bug Fixes:
- Fix a billing bypass where streamed response output or tool/image work could be sent to clients but the turn was later refunded on incomplete, error, or disconnect events.

Enhancements:
- Add detection of billable partial work in WebSocket relay state to decide whether to settle usage or refund empty turns.
- Introduce an overridable quota-consume hook in the WebSocket relay to support testing of quota settlement behavior.

Tests:
- Add regression tests verifying that incomplete terminal events and disconnects after streamed output settle partial usage and commit quota once.

</details>