### PR TITLE
fix: keep Postgres passwords out of native backup/psql argv

### DIFF
--- a/apps/api-go/internal/appcli/deploy_production_backup.go
+++ b/apps/api-go/internal/appcli/deploy_production_backup.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -288,6 +289,25 @@ func productionDatabaseURL(values map[string]string) (string, error) {
 	return value, nil
 }
 
+func productionDatabaseCommand(values map[string]string) (string, []string, error) {
+	databaseURL, err := productionDatabaseURL(values)
+	if err != nil {
+		return "", nil, err
+	}
+	parsed, err := url.Parse(databaseURL)
+	if err != nil {
+		return "", nil, errors.New("production database URL is invalid")
+	}
+	overrides := make(map[string]string)
+	if parsed.User != nil {
+		if password, present := parsed.User.Password(); present {
+			overrides["PGPASSWORD"] = password
+			parsed.User = url.User(parsed.User.Username())
+		}
+	}
+	return parsed.String(), productionChildEnvironment(values, overrides), nil
+}
+
 func productionChildEnvironment(values map[string]string, overrides map[string]string) []string {
 	merged := make(map[string]string)
 	for _, assignment := range os.Environ() {
@@ -319,11 +339,10 @@ func (runtime *productionRuntime) captureDatabaseAccess(ctx context.Context, wor
 	if err != nil {
 		return "", fmt.Errorf("parse production environment: %w", err)
 	}
-	databaseURL, err := productionDatabaseURL(values)
+	databaseURL, childEnvironment, err := productionDatabaseCommand(values)
 	if err != nil {
 		return "", err
 	}
-	childEnvironment := productionChildEnvironment(values, nil)
 	schemaOutput, err := runtime.runner.Run(ctx, productionCommand{
 		Name: "psql",
 		Args: []string{"-X", "-v", "ON_ERROR_STOP=1", "--no-align", "--tuples-only", "--command", "SELECT pg_catalog.current_schema()", databaseURL},

--- a/apps/api-go/internal/appcli/deploy_production_snapshot.go
+++ b/apps/api-go/internal/appcli/deploy_production_snapshot.go
@@ -453,7 +453,7 @@ func (runtime *productionRuntime) createBackup(ctx context.Context, options prod
 		if err != nil {
 			return err
 		}
-		databaseURL, err := productionDatabaseURL(environmentValues)
+		databaseURL, childEnvironment, err := productionDatabaseCommand(environmentValues)
 		if err != nil {
 			return err
 		}
@@ -535,7 +535,6 @@ func (runtime *productionRuntime) createBackup(ctx context.Context, options prod
 		}
 		databasePath := filepath.Join(stage, "database.archive")
 		databaseTemporary := databasePath + ".new"
-		childEnvironment := productionChildEnvironment(environmentValues, nil)
 		if _, err := runtime.runner.Run(ctx, productionCommand{
 			Name: "pg_dump", Args: []string{"--format=custom", "--file=" + databaseTemporary, databaseURL},
 			Env: childEnvironment, Timeout: 10 * time.Minute, Sensitive: true,

--- a/apps/api-go/internal/appcli/deploy_production_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_test.go
@@ -8,6 +8,30 @@ import (
 	"testing"
 )
 
+func TestProductionDatabaseCommandKeepsPasswordOutOfArguments(t *testing.T) {
+	databaseURL, environment, err := productionDatabaseCommand(map[string]string{
+		"SQL_DSN": "postgres://app:p%40ssword@database.example/lmm?sslmode=require",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(databaseURL, "p%40ssword") || databaseURL != "postgres://app@database.example/lmm?sslmode=require" {
+		t.Fatalf("database command URL contains credentials: %q", databaseURL)
+	}
+	if !containsString(environment, "PGPASSWORD=p@ssword") {
+		t.Fatal("database password is not available to libpq")
+	}
+}
+
+func containsString(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
 func TestNativeProductionHardenAtomicallyPinsSecurityAndMemoryGuards(t *testing.T) {
 	root := t.TempDir()
 	envFile := filepath.Join(root, "etc", "lmm-api-go.env")


### PR DESCRIPTION
### Motivation

- Native `psql`/`pg_dump` invocations were receiving a full Postgres DSN (from `SQL_DSN`/`DATABASE_URL`) on their argv, exposing credential-bearing URLs in OS process listings.

### Description

- Add `productionDatabaseCommand(values)` which parses the Postgres URL, strips any embedded password from the URL, and returns the sanitized URL plus a child environment that injects the decoded password as `PGPASSWORD` for libpq.
- Replace direct uses of `productionDatabaseURL` with `productionDatabaseCommand` in database probes and backup creation so child processes receive a credential-free argv and the password via the environment instead.
- Add regression `TestProductionDatabaseCommandKeepsPasswordOutOfArguments` to verify percent-encoded passwords are removed from the command-line URL and supplied via `PGPASSWORD` in the child environment.

### Testing

- Ran `go test ./internal/appcli` and the package tests passed successfully.
- Attempted a repository-wide `go test ./...` in this environment but it did not complete reliably and was not used as the verification for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a796e3b58208320ac138e555a5fa8c3)

## Summary by Sourcery

清理生产环境中对 Postgres 连接的使用方式，使本机工具通过环境变量而不是命令行参数接收密码。

Bug Fixes:
- 确保传递给 `psql` 和 `pg_dump` 的 DSN 中已移除 Postgres 密码，同时仍通过 `PGPASSWORD` 将密码提供给 `libpq`。

Enhancements:
- 引入 `productionDatabaseCommand`，用于派生不含密码的数据库 URL，以及用于生产数据库操作的对应子进程环境。

Tests:
- 新增回归测试，验证 `productionDatabaseCommand` 会从 URL 中移除百分号编码的密码，并通过子进程环境中的 `PGPASSWORD` 暴露该密码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Sanitize production Postgres connection usage so native tools receive passwords via environment variables instead of command-line arguments.

Bug Fixes:
- Ensure Postgres passwords are removed from DSNs passed to psql and pg_dump argv while still being provided to libpq via PGPASSWORD.

Enhancements:
- Introduce productionDatabaseCommand to derive a password-free database URL and corresponding child environment for production database operations.

Tests:
- Add regression test verifying productionDatabaseCommand strips percent-encoded passwords from the URL and exposes them via PGPASSWORD in the child environment.

</details>