### PR TITLE
fix: reject symlinked production work root

### DIFF
--- a/apps/api-go/internal/appcli/deploy_production_snapshot_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_snapshot_test.go
@@ -74,6 +74,34 @@ func TestNativeProductionWorkspaceAcceptsManagedVarLibAlias(t *testing.T) {
 	}
 }
 
+func TestNativeProductionWorkspaceRejectsSymlinkedWorkRoot(t *testing.T) {
+	root := t.TempDir()
+	paths := defaultProductionPaths()
+	paths.WorkRoot = filepath.Join(root, "state", "deploy-work")
+	paths.BackupRoot = filepath.Join(root, "state", "deploy-backups")
+	paths.GlobalLock = filepath.Join(root, "run", "deploy.lock")
+	paths.TransactionLock = filepath.Join(root, "state", "deploy-transaction.lock")
+	runtime := &productionRuntime{
+		paths: paths, runner: &fakeProductionRunner{t: t}, now: time.Now,
+		sleep: func(time.Duration) {}, effectiveUID: func() int { return 0 },
+		hostname: func() (string, error) { return productionExpectedHost, nil }, probeAttempts: 1,
+	}
+	result, err := runtime.createWorkspace(context.Background(), "go-symlink-workroot-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	displacedWorkRoot := filepath.Join(root, "attacker-controlled")
+	if err := os.Rename(paths.WorkRoot, displacedWorkRoot); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(displacedWorkRoot, paths.WorkRoot); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.openWorkspace(result.Workspace); err == nil || !strings.Contains(err.Error(), "work root must be a real directory") {
+		t.Fatalf("symlinked production work root error=%v", err)
+	}
+}
+
 func TestNativeProductionBackupCapturesRollbackFrontendConfigAndPostgres(t *testing.T) {
 	fixture := newProductionFixture(t)
 	if err := os.RemoveAll(fixture.options.BackupDir); err != nil {

--- a/apps/api-go/internal/appcli/deploy_production_state.go
+++ b/apps/api-go/internal/appcli/deploy_production_state.go
@@ -425,6 +425,9 @@ func (runtime *productionRuntime) openWorkspace(root string) (productionWorkspac
 	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 		return productionWorkspace{}, errors.New("workspace must be a real directory")
 	}
+	if err := requireRealDirectory(runtime.paths.WorkRoot); err != nil {
+		return productionWorkspace{}, errors.New("production work root must be a real directory")
+	}
 	// Arch systemd's DynamicUser layout exposes /var/lib/lmm-api-go as a
 	// managed symlink to /var/lib/private/lmm-api-go.  The workspace itself
 	// must still be a real directory, but rejecting that trusted parent alias


### PR DESCRIPTION
### Motivation

- `openWorkspace` previously accepted a workspace whose canonical parent matched the canonicalized `WorkRoot` even when the `deploy-work` component itself was a symlink, allowing a writable service-state parent to redirect root deployment operations into attacker-controlled storage. 
- The intent is to allow the systemd-managed parent alias while still rejecting a symlink in the `WorkRoot` component so deployments cannot be redirected by a compromised DynamicUser service account.

### Description

- Added a real-directory check on the configured production work root by calling `requireRealDirectory(runtime.paths.WorkRoot)` in `openWorkspace` to reject a symlinked `deploy-work` directory. 
- Added a regression test `TestNativeProductionWorkspaceRejectsSymlinkedWorkRoot` that renames the legitimate work root, replaces it with a symlink, and verifies `openWorkspace` rejects the symlinked work root. 
- Kept existing test `TestNativeProductionWorkspaceAcceptsManagedVarLibAlias` to preserve support for the managed parent alias while enforcing that the final work-root component is a real directory.

### Testing

- Ran the focused tests with `go test ./internal/appcli -run 'TestNativeProductionWorkspace(AcceptsManagedVarLibAlias|RejectsSymlinkedWorkRoot|CreateClaimsExactTransaction)$' -count=1` and they passed. 
- Ran the full package tests with `go test ./internal/appcli -count=1` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a796b7d3b3483209b21fab13ccec15b)

## Summary by Sourcery

确保生产环境部署拒绝使用符号链接的工作根目录，防止将部署操作重定向到非预期位置。

Bug Fixes:
- 在打开 workspace 时，拒绝解析为符号链接而非真实目录的生产工作根目录。

Tests:
- 添加一个回归测试，验证符号链接的生产工作根目录会被拒绝，同时仍然接受受管的 `var-lib` 父级别名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure production deployments reject symlinked work roots to prevent redirecting deployment operations into unintended locations.

Bug Fixes:
- Reject production work roots that resolve to symlinks instead of real directories when opening a workspace.

Tests:
- Add a regression test that verifies a symlinked production work root is rejected while preserving acceptance of the managed var-lib parent alias.

</details>