### PR TITLE
fix(auth): make Turnstile verification proxy-safe

### DIFF
--- a/apps/api-go/middleware/turnstile-check.go
+++ b/apps/api-go/middleware/turnstile-check.go
@@ -1,22 +1,65 @@
 package middleware
 
 import (
+	"context"
+	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/gin-gonic/gin"
 )
 
 type turnstileCheckResponse struct {
-	Success bool `json:"success"`
+	Success    bool     `json:"success"`
+	ErrorCodes []string `json:"error-codes"`
+	Hostname   string   `json:"hostname"`
+	Action     string   `json:"action"`
+}
+
+var turnstileVerifyURL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+var turnstileHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+func verifyTurnstileToken(ctx context.Context, token string) (turnstileCheckResponse, error) {
+	form := url.Values{
+		"secret":   {common.TurnstileSecretKey},
+		"response": {token},
+	}
+	request, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		turnstileVerifyURL,
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return turnstileCheckResponse{}, err
+	}
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	response, err := turnstileHTTPClient.Do(request)
+	if err != nil {
+		return turnstileCheckResponse{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return turnstileCheckResponse{}, fmt.Errorf("turnstile verification returned HTTP %d", response.StatusCode)
+	}
+
+	var result turnstileCheckResponse
+	if err := common.DecodeJson(response.Body, &result); err != nil {
+		return turnstileCheckResponse{}, err
+	}
+	return result, nil
 }
 
 func TurnstileCheck() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if common.TurnstileCheckEnabled {
-			response := c.Query("turnstile")
-			if response == "" {
+			token := strings.TrimSpace(c.Query("turnstile"))
+			if token == "" {
 				c.JSON(http.StatusOK, gin.H{
 					"success": false,
 					"message": "Turnstile token 为空",
@@ -24,33 +67,23 @@ func TurnstileCheck() gin.HandlerFunc {
 				c.Abort()
 				return
 			}
-			rawRes, err := http.PostForm("https://challenges.cloudflare.com/turnstile/v0/siteverify", url.Values{
-				"secret":   {common.TurnstileSecretKey},
-				"response": {response},
-				"remoteip": {c.ClientIP()},
-			})
+			result, err := verifyTurnstileToken(c.Request.Context(), token)
 			if err != nil {
-				common.SysLog(err.Error())
+				common.SysLog(fmt.Sprintf("Turnstile verification request failed: %v", err))
 				c.JSON(http.StatusOK, gin.H{
 					"success": false,
-					"message": err.Error(),
+					"message": "Turnstile 校验暂时不可用，请稍后重试！",
 				})
 				c.Abort()
 				return
 			}
-			defer rawRes.Body.Close()
-			var res turnstileCheckResponse
-			err = common.DecodeJson(rawRes.Body, &res)
-			if err != nil {
-				common.SysLog(err.Error())
-				c.JSON(http.StatusOK, gin.H{
-					"success": false,
-					"message": err.Error(),
-				})
-				c.Abort()
-				return
-			}
-			if !res.Success {
+			if !result.Success {
+				common.SysLog(fmt.Sprintf(
+					"Turnstile verification rejected: error_codes=%v hostname=%q action=%q",
+					result.ErrorCodes,
+					result.Hostname,
+					result.Action,
+				))
 				c.JSON(http.StatusOK, gin.H{
 					"success": false,
 					"message": "Turnstile 校验失败，请刷新重试！",

--- a/apps/api-go/middleware/turnstile-check_test.go
+++ b/apps/api-go/middleware/turnstile-check_test.go
@@ -1,0 +1,53 @@
+package middleware
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type turnstileRoundTripper func(*http.Request) (*http.Response, error)
+
+func (f turnstileRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+func TestVerifyTurnstileTokenDoesNotSendProxyAddress(t *testing.T) {
+	previousClient := turnstileHTTPClient
+	previousURL := turnstileVerifyURL
+	previousSecret := common.TurnstileSecretKey
+	t.Cleanup(func() {
+		turnstileHTTPClient = previousClient
+		turnstileVerifyURL = previousURL
+		common.TurnstileSecretKey = previousSecret
+	})
+
+	turnstileVerifyURL = "https://turnstile.test/siteverify"
+	common.TurnstileSecretKey = "test-secret"
+	turnstileHTTPClient = &http.Client{Transport: turnstileRoundTripper(func(request *http.Request) (*http.Response, error) {
+		body, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		form, err := url.ParseQuery(string(body))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"test-secret"}, form["secret"])
+		assert.Equal(t, []string{"test-token"}, form["response"])
+		assert.NotContains(t, form, "remoteip")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"success":true,"hostname":"lmm.best"}`)),
+			Header:     make(http.Header),
+		}, nil
+	})}
+
+	result, err := verifyTurnstileToken(context.Background(), "test-token")
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, "lmm.best", result.Hostname)
+}

--- a/apps/web/src/components/turnstile.tsx
+++ b/apps/web/src/components/turnstile.tsx
@@ -21,7 +21,8 @@ import { useEffect, useRef } from 'react'
 declare global {
   interface Window {
     turnstile?: {
-      render: (element: HTMLElement, options: Record<string, unknown>) => void
+      ready?: (callback: () => void) => void
+      render: (element: HTMLElement, options: Record<string, unknown>) => unknown
     }
   }
 }
@@ -42,26 +43,58 @@ export function Turnstile({
   const ref = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
-    const render = () => {
-      if (!ref.current || !window.turnstile) return
-      try {
-        window.turnstile.render(ref.current, {
-          sitekey: siteKey,
-          callback: (token: string) => onVerify(token),
-          'error-callback': () => onExpire?.(),
-          'expired-callback': () => onExpire?.(),
-        })
-      } catch {
-        /* empty */
+    let disposed = false
+    let rendered = false
+    let poller: number | undefined
+
+    const renderWidget = () => {
+      if (disposed || rendered || !ref.current || !window.turnstile) return
+      const renderNow = () => {
+        if (disposed || rendered || !ref.current || !window.turnstile) return
+        try {
+          window.turnstile.render(ref.current, {
+            sitekey: siteKey,
+            callback: (token: string) => onVerify(token),
+            'error-callback': () => onExpire?.(),
+            'expired-callback': () => onExpire?.(),
+          })
+          rendered = true
+        } catch {
+          /* The script can expose the API before its widget runtime is ready. */
+        }
       }
+
+      if (window.turnstile.ready) {
+        window.turnstile.ready(renderNow)
+      } else {
+        renderNow()
+      }
+    }
+
+    const cleanup = () => {
+      disposed = true
+      if (poller !== undefined) window.clearInterval(poller)
+    }
+
+    const scriptId = 'cf-turnstile'
+    const existingScript = document.getElementById(scriptId)
+
+    // A different login form may have inserted the shared script already.
+    // Wait for its runtime instead of returning before this widget is rendered.
+    if (existingScript && !window.turnstile) {
+      poller = window.setInterval(renderWidget, 100)
+      existingScript.addEventListener('load', renderWidget, { once: true })
+      return cleanup
+    }
+
+    const render = () => {
+      renderWidget()
     }
 
     if (window.turnstile) {
       render()
-      return
+      return cleanup
     }
-    const scriptId = 'cf-turnstile'
-    if (document.querySelector(`#${scriptId}`)) return
     const s = document.createElement('script')
     s.id = scriptId
     s.src =
@@ -70,6 +103,8 @@ export function Turnstile({
     s.defer = true
     s.onload = () => render()
     document.head.appendChild(s)
+
+    return cleanup
   }, [siteKey, onVerify, onExpire])
 
   return <div ref={ref} className={className} />

--- a/apps/web/src/components/turnstile.tsx
+++ b/apps/web/src/components/turnstile.tsx
@@ -22,7 +22,10 @@ declare global {
   interface Window {
     turnstile?: {
       ready?: (callback: () => void) => void
-      render: (element: HTMLElement, options: Record<string, unknown>) => unknown
+      render: (
+        element: HTMLElement,
+        options: Record<string, unknown>
+      ) => unknown
     }
   }
 }


### PR DESCRIPTION
## Summary
- stop sending a potentially CDN edge address as Turnstile `remoteip`
- retain Cloudflare rejection metadata in server logs without exposing tokens
- make the shared frontend Turnstile script race-safe

## Validation
- `GOPROXY=off CGO_ENABLED=0 go test ./model ./middleware ./controller`
- `bun run --filter @lmm/web typecheck`
- `bun run --filter @lmm/web build`
- `bun run --filter @lmm/web bundle:check`

## Summary by Sourcery

改进基于 Turnstile 的身份验证，以在代理环境下更安全，并在前后端都更加健壮。

Bug Fixes（错误修复）：
- 停止在验证时将客户端 IP（可能是 CDN 边缘节点地址）作为 Turnstile 的 `remoteip` 发送。
- 防止在共享脚本被多次加载或在其运行时尚未准备好之前加载时，出现 Turnstile 小组件的竞态条件。

Enhancements（增强改进）：
- 在避免在日志中暴露令牌的前提下，记录带有 Cloudflare 元数据（错误代码、主机名、action）的 Turnstile 验证失败信息。

Tests（测试）：
- 添加单元测试，确保 Turnstile 验证请求不再包含 `remoteip` 字段，并能正确解析成功的响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Turnstile-based auth verification to be proxy-safe and more robust across backend and frontend.

Bug Fixes:
- Stop sending client IP (potentially a CDN edge address) as Turnstile remoteip during verification.
- Prevent Turnstile widget race conditions when the shared script is loaded multiple times or before its runtime is ready.

Enhancements:
- Log Turnstile verification failures with Cloudflare metadata (error codes, hostname, action) while avoiding token exposure in logs.

Tests:
- Add unit test ensuring Turnstile verification requests no longer include the remoteip field and correctly parse successful responses.

</details>