### PR TITLE
fix(deploy): capture packaged production payload paths

### DIFF
--- a/deploy/production/capture-precutover-payload.sh
+++ b/deploy/production/capture-precutover-payload.sh
@@ -77,11 +77,15 @@ copy_package_payload() {
       direct:lmm-api-go:/etc/|direct:lmm-api-go:/etc/lmm-api-go/|\
       direct:lmm-api-go:/usr/|direct:lmm-api-go:/usr/bin/|direct:lmm-api-go:/usr/bin/lmm-api-go|\
       direct:lmm-api-go:/usr/lib/|direct:lmm-api-go:/usr/lib/systemd/|direct:lmm-api-go:/usr/lib/systemd/system/|\
+      direct:lmm-api-go:/usr/lib/systemd/system/geoip2-country-update.service|\
+      direct:lmm-api-go:/usr/lib/systemd/system/geoip2-country-update.timer|\
       direct:lmm-api-go:/usr/lib/systemd/system/lmm-api-go.service|direct:lmm-api-go:/usr/share/|\
       direct:lmm-api-go:/usr/share/doc/|direct:lmm-api-go:/usr/share/doc/lmm-api-go/|\
       direct:lmm-api-go:/usr/share/doc/lmm-api-go/*|direct:lmm-api-go:/usr/share/licenses/|\
       direct:lmm-api-go:/usr/share/licenses/lmm-api-go/|direct:lmm-api-go:/usr/share/licenses/lmm-api-go/*|\
-      direct:lmm-api-go:/usr/share/lmm-api-go/|direct:lmm-api-go:/usr/share/lmm-api-go/frontend-dist/|\
+      direct:lmm-api-go:/usr/share/lmm-api-go/|direct:lmm-api-go:/usr/share/lmm-api-go/edge-policy/|\
+      direct:lmm-api-go:/usr/share/lmm-api-go/edge-policy/*|\
+      direct:lmm-api-go:/usr/share/lmm-api-go/frontend-dist/|\
       direct:lmm-api-go:/usr/share/lmm-api-go/frontend-dist/*) ;;
       *) die "package exposes an unexpected path: $package:$logical_source" ;;
     esac

--- a/deploy/production/deploy-go.sh
+++ b/deploy/production/deploy-go.sh
@@ -96,7 +96,7 @@ for output in "$artifacts" "$manifest_dir" "$controller_backup"; do
   [[ ! -e $output && ! -L $output ]] || die "deployment output already exists: $output"
 done
 install -d -m0700 "$new_dir" "$rollback_dir" "$capture_dir" "$manifest_dir" \
-  "$WORKSPACE/tmp" "${controller_backup%/*}"
+  "$WORKSPACE/tmp" "$WORKSPACE/staging" "${controller_backup%/*}"
 
 (
   cd -- "$REPO_ROOT"

--- a/deploy/production/test-precutover-capture.sh
+++ b/deploy/production/test-precutover-capture.sh
@@ -18,6 +18,7 @@ mkdir -p "$bin" "$workspace/staging" \
   "$fs/usr/lib/systemd/system" \
   "$fs/usr/share/doc/lmm-api-go" \
   "$fs/usr/share/licenses/lmm-api-go" \
+  "$fs/usr/share/lmm-api-go/edge-policy/nginx" \
   "$fs/usr/share/lmm-api-go/frontend-dist"
 printf 'format=1\ndeployment_id=direct-fixture\n' >"$workspace/.lmm-deploy-workspace"
 
@@ -56,6 +57,8 @@ case $1 in
       /usr/lib/ \
       /usr/lib/systemd/ \
       /usr/lib/systemd/system/ \
+      /usr/lib/systemd/system/geoip2-country-update.service \
+      /usr/lib/systemd/system/geoip2-country-update.timer \
       /usr/lib/systemd/system/lmm-api-go.service \
       /usr/share/ \
       /usr/share/doc/ \
@@ -67,6 +70,13 @@ case $1 in
       /usr/share/licenses/lmm-api-go/NOTICE \
       /usr/share/licenses/lmm-api-go/THIRD-PARTY-LICENSES.md \
       /usr/share/lmm-api-go/ \
+      /usr/share/lmm-api-go/edge-policy/ \
+      /usr/share/lmm-api-go/edge-policy/nginx/ \
+      /usr/share/lmm-api-go/edge-policy/nginx/http-map.conf \
+      /usr/share/lmm-api-go/edge-policy/nginx/lmm-api-locations.conf \
+      /usr/share/lmm-api-go/edge-policy/nginx/lmm-api-region-policy.conf \
+      /usr/share/lmm-api-go/edge-policy/nginx/mime.types \
+      /usr/share/lmm-api-go/edge-policy/nginx/new-api.conf \
       /usr/share/lmm-api-go/frontend-dist/ \
       /usr/share/lmm-api-go/frontend-dist/index.html
     ;;
@@ -78,9 +88,14 @@ chmod 0755 "$bin"/*
 printf 'SQL_DSN=postgres://secret.invalid/fixture\n' >"$fs/etc/lmm-api-go/lmm-api-go.env"
 printf '#!/bin/sh\nexit 0\n' >"$fs/usr/bin/lmm-api-go"
 printf '[Service]\nExecStart=/usr/bin/lmm-api-go serve\n' >"$fs/usr/lib/systemd/system/lmm-api-go.service"
+printf '[Service]\nExecStart=/usr/bin/geoip2-country-update\n' >"$fs/usr/lib/systemd/system/geoip2-country-update.service"
+printf '[Timer]\nOnCalendar=daily\n' >"$fs/usr/lib/systemd/system/geoip2-country-update.timer"
 printf '50dc6a7f9\n' >"$fs/usr/share/doc/lmm-api-go/REVISION"
 for license_file in LICENSE NOTICE THIRD-PARTY-LICENSES.md; do
   printf 'fixture\n' >"$fs/usr/share/licenses/lmm-api-go/$license_file"
+done
+for edge_file in http-map.conf lmm-api-locations.conf lmm-api-region-policy.conf mime.types new-api.conf; do
+  printf 'fixture edge policy\n' >"$fs/usr/share/lmm-api-go/edge-policy/nginx/$edge_file"
 done
 printf 'old frontend\n' >"$fs/usr/share/lmm-api-go/frontend-dist/index.html"
 chmod 0600 "$fs/etc/lmm-api-go/lmm-api-go.env"


### PR DESCRIPTION
补齐 Go 生产部署回滚载荷的已发布路径白名单（GeoIP 单元与边缘策略资源），并让 deploy-go.sh 自行创建 staging。

验证：
- TMPDIR=... bash deploy/production/test-precutover-capture.sh
- TMPDIR=... bash deploy/production/test-go-deploy-contract.sh
- git diff --check

该修复避免候选包在切换前因自身已打包资源被错误拦截。

## Summary by Sourcery

扩展 lmm-api-go 的生产部署负载捕获范围，以覆盖 GeoIP systemd 单元和 edge-policy 资源，并确保在部署设置期间 `deploy-go.sh` 会创建 staging 目录。

Bug Fixes:
- 允许生产环境的切换前（pre-cutover）负载捕获将 GeoIP 更新的 systemd 单元和定时器（timer）文件加入白名单，以适配 lmm-api-go 包。
- 允许生产环境的切换前（pre-cutover）负载捕获将 edge-policy 的 nginx 配置资产加入白名单，以适配 lmm-api-go 包。
- 通过在部署设置过程中创建 staging 目录，防止 `deploy-go.sh` 部署因为缺少 staging 目录而失败。

Tests:
- 更新切换前（pre-cutover）部署测试夹具，在模拟文件系统中加入 GeoIP systemd 单元和 edge-policy nginx 文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend production deploy payload capture for lmm-api-go to cover GeoIP systemd units and edge-policy resources, and ensure deploy-go.sh creates the staging directory during deployment setup.

Bug Fixes:
- Allow production pre-cutover payload capture to whitelist GeoIP update systemd unit and timer files for lmm-api-go packages.
- Allow production pre-cutover payload capture to whitelist edge-policy nginx configuration assets for lmm-api-go packages.
- Prevent deploy-go.sh deployments from failing due to a missing staging directory by creating it during setup.

Tests:
- Update pre-cutover deploy test fixtures to include GeoIP systemd units and edge-policy nginx files in the simulated filesystem.

</details>