### PR TITLE
fix(trust): honor console activation in user lists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
           bun run --filter @lmm/web build
           bun run --filter @lmm/web bundle:check
 
+      - name: Install deployment contract tools
+        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends libarchive-tools
+
       - name: Verify protected production deployment contract
         env:
           TMPDIR: ${{ runner.temp }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,4 +268,5 @@ jobs:
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-bin-makepkg.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-precutover-packages.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-package-roundtrip.sh
+          install -d -m0700 /run/user/0
           env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-deploy-contract.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Validate all public AUR packages
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
     steps:
       - name: Install checkout and package validation tools
         run: |
-          pacman --sync --refresh --noconfirm git shellcheck
+          pacman --sync --refresh --noconfirm git libarchive shellcheck
           useradd --create-home package-builder
           install -d -o package-builder -g package-builder /home/package-builder/lmm-ci-tmp
 
@@ -265,7 +265,7 @@ jobs:
       - name: Validate all public AUR packages
         run: |
           chown --recursive package-builder:package-builder "$GITHUB_WORKSPACE"
-          runuser --user package-builder -- bash packaging/aur/test-matrix.sh
-          runuser --user package-builder -- bash packaging/aur/test-bin-makepkg.sh
+          runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-matrix.sh
+          runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-bin-makepkg.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-precutover-packages.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-package-roundtrip.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,5 +268,6 @@ jobs:
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-bin-makepkg.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-precutover-packages.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-package-roundtrip.sh
-          install -d -m0700 /run/user/0
-          env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-deploy-contract.sh
+          runtime_dir="/run/user/$(id -u package-builder)"
+          install -d -m0700 -o package-builder -g package-builder "$runtime_dir"
+          runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-deploy-contract.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
     steps:
       - name: Install checkout and package validation tools
         run: |
-          pacman --sync --refresh --noconfirm git libarchive shellcheck
+          pacman --sync --refresh --noconfirm git jq libarchive shellcheck
           useradd --create-home package-builder
           install -d -o package-builder -g package-builder /home/package-builder/lmm-ci-tmp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,4 +268,4 @@ jobs:
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-bin-makepkg.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-precutover-packages.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-package-roundtrip.sh
-          runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-deploy-contract.sh
+          env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-deploy-contract.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,11 @@ jobs:
           bun run --filter @lmm/web build
           bun run --filter @lmm/web bundle:check
 
-      - name: Install deployment contract tools
-        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends libarchive-tools
-
       - name: Verify protected production deployment contract
         env:
           TMPDIR: ${{ runner.temp }}
         run: |
           bash deploy/test-frontend-release.sh
-          bash deploy/production/test-go-deploy-contract.sh
 
   go:
     name: Go default backend, relaykit, and static build
@@ -272,3 +268,4 @@ jobs:
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-bin-makepkg.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-precutover-packages.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-package-roundtrip.sh
+          runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-go-deploy-contract.sh

--- a/apps/api-go/model/trust_level.go
+++ b/apps/api-go/model/trust_level.go
@@ -625,7 +625,14 @@ func EnrichUsersTrustLevels(users []*User) error {
 		} else {
 			aggregate := aggregates[user.Id]
 			anchor := trustActivityAnchor(user.CreatedAt, user.LastAPIActivityAt, aggregate.LastPaidCompleteAt)
-			info = EvaluateTrustLevelWithActivation(user.Role, user.TrustLevelOverride, aggregate.PaidAmount, aggregate.ActivationComplete, anchor, now)
+			info = EvaluateTrustLevelWithActivation(
+				user.Role,
+				user.TrustLevelOverride,
+				aggregate.PaidAmount,
+				aggregate.ActivationComplete || user.ConsoleActivatedAt > 0,
+				anchor,
+				now,
+			)
 		}
 		user.TrustLevelInfo = &info
 	}

--- a/apps/api-go/model/trust_level_test.go
+++ b/apps/api-go/model/trust_level_test.go
@@ -328,3 +328,22 @@ func TestEnrichUsersTrustLevelsQueriesOnlyOrdinaryUsersWithoutOverrides(t *testi
 	assert.NotContains(t, counter.countSQL, "34")
 	assert.NotContains(t, counter.countSQL, "35")
 }
+
+func TestEnrichUsersTrustLevelsHonorsConsoleActivation(t *testing.T) {
+	previousDB := DB
+	db, err := gorm.Open(sqlite.Open(fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))), &gorm.Config{})
+	require.NoError(t, err)
+	DB = db
+	require.NoError(t, db.AutoMigrate(&TopUp{}))
+	t.Cleanup(func() {
+		DB = previousDB
+		sqlDB, _ := db.DB()
+		_ = sqlDB.Close()
+	})
+
+	users := []*User{{Id: 36, Role: common.RoleCommonUser, ConsoleActivatedAt: 1}}
+	require.NoError(t, EnrichUsersTrustLevels(users))
+	require.NotNil(t, users[0].TrustLevelInfo)
+	assert.Equal(t, TrustLevelMinUser+1, users[0].TrustLevelInfo.Level)
+	assert.Equal(t, TrustLevelMinUser+1, users[0].TrustLevelInfo.AutomaticLevel)
+}

--- a/apps/api-rust/src/auth.rs
+++ b/apps/api-rust/src/auth.rs
@@ -339,10 +339,11 @@ fn evaluate_trust_level(role: i64, facts: DashboardSelfUserFacts) -> TrustLevelI
     let (level, inactivity_decay_steps, next_decay_at) =
         if let Some(override_level) = facts.trust_level_override {
             (
-                (0..=4)
-                    .contains(&override_level)
-                    .then_some(override_level)
-                    .unwrap_or(0),
+                if (0..=4).contains(&override_level) {
+                    override_level
+                } else {
+                    0
+                },
                 0,
                 None,
             )

--- a/apps/api-rust/src/auth/http.rs
+++ b/apps/api-rust/src/auth/http.rs
@@ -1137,6 +1137,12 @@ mod tests {
         (StatusCode::CREATED, content_length.to_owned()).into_response()
     }
 
+    const TEST_REGISTRATION_PATH: &str = "/api/user/register";
+
+    fn registration_probe_router() -> Router {
+        Router::new().route(TEST_REGISTRATION_PATH, post(registration_probe))
+    }
+
     impl MockAuth {
         fn success() -> Self {
             Self {
@@ -2184,7 +2190,7 @@ mod tests {
             AuthHttpState::new(auth.clone(), false)
                 .with_anonymous_body_limit_bytes(16)
                 .with_turnstile_verifier(verifier.clone()),
-            Router::new().route("/api/user/register", post(registration_probe)),
+            registration_probe_router(),
         );
 
         let response = router
@@ -2270,7 +2276,7 @@ mod tests {
         let verifier = Arc::new(MockTurnstile::allowing());
         let response = anonymous_registration_surface(
             AuthHttpState::new(auth.clone(), false).with_turnstile_verifier(verifier.clone()),
-            Router::new().route("/api/user/register", post(registration_probe)),
+            registration_probe_router(),
         )
         .oneshot(
             Request::builder()

--- a/apps/api-rust/src/auth/http.rs
+++ b/apps/api-rust/src/auth/http.rs
@@ -1033,20 +1033,6 @@ fn dashboard_auth_error(locale: LegacyLocale, error: AuthError) -> Response {
         .into_response()
 }
 
-fn unauthorized(message: &'static str) -> Response {
-    let mut response = (
-        StatusCode::UNAUTHORIZED,
-        Json(ErrorEnvelope {
-            success: false,
-            code: "AUTH_UNAUTHORIZED",
-            message,
-        }),
-    )
-        .into_response();
-    disable_cache(&mut response, false);
-    response
-}
-
 fn invalid_login_error(locale: LegacyLocale) -> Response {
     let mut response = Json(FailureEnvelope {
         success: false,

--- a/apps/api-rust/src/config.rs
+++ b/apps/api-rust/src/config.rs
@@ -399,6 +399,7 @@ fn test_namespace(value: &str) -> bool {
             .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
 
+#[cfg(test)]
 fn validate_test_valkey_url(raw: &str) -> Result<(), ConfigError> {
     validate_test_valkey_url_with_port(raw, 6380)
 }
@@ -878,7 +879,7 @@ mod tests {
                 ("TurnstileSiteKey".to_owned(), "site-key".to_owned()),
             ]))
             .expect("matching configuration is accepted");
-        assert_eq!(public.enabled, true);
+        assert!(public.enabled);
         assert_eq!(public.site_key, "site-key");
 
         let disabled = super::turnstile_from_values(false, None)

--- a/apps/api-rust/src/http.rs
+++ b/apps/api-rust/src/http.rs
@@ -2649,8 +2649,9 @@ mod tests {
         let (status, _, body) = call("GET", "/api/user/token", None, None).await;
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(
-            body["error"]["type"], "invalid_request_error",
-            "listener-wide concealment keeps the legacy hidden-route envelope"
+            body,
+            serde_json::json!({"message": "Not Found"}),
+            "unmounted token routes use the listener fallback without exposing route ownership"
         );
     }
 

--- a/apps/api-rust/src/migration_routes/control_admin.rs
+++ b/apps/api-rust/src/migration_routes/control_admin.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 
 const ROOT_ROLE: i64 = 100;
 const ADMIN_ROLE: i64 = 10;
+const CUSTOM_OAUTH_COLLECTION_PATH: &str = "/api/custom-oauth-provider/";
 const STALE_INSTANCE_AFTER_SECONDS: i64 = 90;
 const DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
 const DISCOVERY_MAX_RESPONSE_BYTES: usize = 1 << 20;
@@ -597,7 +598,7 @@ impl ControlAdminState {
 /// Routes migrated from `/api/custom-oauth-provider`, `/api/system-task`,
 /// `/api/system-info`, and the administrator half of `/api/task`.
 pub fn control_admin_router(state: ControlAdminState) -> Router {
-    Router::new()
+    control_admin_read_routes()
         .route(
             "/api/custom-oauth-provider/",
             get(list_oauth).post(create_oauth),
@@ -614,9 +615,6 @@ pub fn control_admin_router(state: ControlAdminState) -> Router {
             "/api/system-task/log-cleanup",
             post(create_log_cleanup_task),
         )
-        .route("/api/system-task/list", get(list_system_tasks))
-        .route("/api/system-task/current", get(current_system_task))
-        .route("/api/system-task/{task_id}", get(get_system_task))
         .route("/api/system-info/instances", get(list_instances))
         .route(
             "/api/system-info/stale-instances",
@@ -631,6 +629,13 @@ pub fn control_admin_router(state: ControlAdminState) -> Router {
         .with_state(state)
 }
 
+fn control_admin_read_routes() -> Router<ControlAdminState> {
+    Router::new()
+        .route("/api/system-task/list", get(list_system_tasks))
+        .route("/api/system-task/current", get(current_system_task))
+        .route("/api/system-task/{task_id}", get(get_system_task))
+}
+
 /// Mounts only the read-only control-admin views for the normal listener.
 ///
 /// The broader control-admin router also contains OAuth discovery, task
@@ -638,11 +643,8 @@ pub fn control_admin_router(state: ControlAdminState) -> Router {
 /// makes the production candidate's PostgreSQL read boundary explicit and
 /// prevents an accidental write or outbound-discovery mount.
 pub fn control_admin_read_router(state: ControlAdminState) -> Router {
-    Router::new()
-        .route("/api/system-task/list", get(list_system_tasks))
-        .route("/api/system-task/current", get(current_system_task))
-        .route("/api/system-task/{task_id}", get(get_system_task))
-        .route("/api/custom-oauth-provider/", get(list_oauth))
+    control_admin_read_routes()
+        .route(CUSTOM_OAUTH_COLLECTION_PATH, get(list_oauth))
         .route("/api/system-info/instances", get(list_instances))
         .with_state(state)
 }

--- a/apps/api-rust/src/migration_routes/control_admin.rs
+++ b/apps/api-rust/src/migration_routes/control_admin.rs
@@ -615,7 +615,6 @@ pub fn control_admin_router(state: ControlAdminState) -> Router {
             "/api/system-task/log-cleanup",
             post(create_log_cleanup_task),
         )
-        .route("/api/system-info/instances", get(list_instances))
         .route(
             "/api/system-info/stale-instances",
             delete(delete_stale_instances),
@@ -634,6 +633,7 @@ fn control_admin_read_routes() -> Router<ControlAdminState> {
         .route("/api/system-task/list", get(list_system_tasks))
         .route("/api/system-task/current", get(current_system_task))
         .route("/api/system-task/{task_id}", get(get_system_task))
+        .route("/api/system-info/instances", get(list_instances))
 }
 
 /// Mounts only the read-only control-admin views for the normal listener.
@@ -645,7 +645,6 @@ fn control_admin_read_routes() -> Router<ControlAdminState> {
 pub fn control_admin_read_router(state: ControlAdminState) -> Router {
     control_admin_read_routes()
         .route(CUSTOM_OAUTH_COLLECTION_PATH, get(list_oauth))
-        .route("/api/system-info/instances", get(list_instances))
         .with_state(state)
 }
 

--- a/apps/api-rust/src/migration_routes/identity_2fa.rs
+++ b/apps/api-rust/src/migration_routes/identity_2fa.rs
@@ -40,6 +40,7 @@ const TOTP_LOCK_SECONDS: i64 = 5 * 60;
 const ROLE_ADMIN: i64 = 10;
 const ROLE_ROOT: i64 = 100;
 const AUTH_VERSION: &str = "864b7076dbcd0a3c01b5520316720ebf";
+const TWO_FACTOR_STATUS_PATH: &str = "/api/user/2fa/status";
 
 /// Identity established by the parent authenticated-user extractor.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -233,7 +234,7 @@ pub fn router(state: Identity2FAState) -> Router {
 /// 2FA mutations remain on the isolated candidate router.
 pub fn status_read_router(state: Identity2FAReadState) -> Router {
     Router::new()
-        .route("/api/user/2fa/status", get(status_read))
+        .route(TWO_FACTOR_STATUS_PATH, get(status_read))
         .with_state(state)
         .layer(middleware::map_response(legacy_json_content_type))
 }

--- a/apps/api-rust/src/migration_routes/identity_federation.rs
+++ b/apps/api-rust/src/migration_routes/identity_federation.rs
@@ -644,16 +644,7 @@ pub fn router(state: FederationState) -> Router {
         .route("/api/oauth/telegram/login", get(telegram_login))
         .route("/api/oauth/telegram/bind/start", post(telegram_bind_start))
         .route("/api/oauth/telegram/bind/{flow_token}", get(telegram_bind))
-        .route("/api/user/oauth/bindings", get(list_self_bindings))
-        .route(
-            "/api/user/oauth/bindings/{provider_id}",
-            delete(unbind_self),
-        )
-        .route("/api/user/{id}/oauth/bindings", get(list_admin_bindings))
-        .route(
-            "/api/user/{id}/oauth/bindings/{provider_id}",
-            delete(unbind_admin),
-        )
+        .merge(bindings_routes())
         .with_state(state)
 }
 
@@ -664,6 +655,10 @@ pub fn router(state: FederationState) -> Router {
 /// These four routes are PostgreSQL/session-authority operations and can be
 /// mounted independently without exposing a half-configured provider flow.
 pub fn bindings_router(state: FederationState) -> Router {
+    bindings_routes().with_state(state)
+}
+
+fn bindings_routes() -> Router<FederationState> {
     Router::new()
         .route("/api/user/oauth/bindings", get(list_self_bindings))
         .route(
@@ -675,7 +670,6 @@ pub fn bindings_router(state: FederationState) -> Router {
             "/api/user/{id}/oauth/bindings/{provider_id}",
             delete(unbind_admin),
         )
-        .with_state(state)
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/apps/api-rust/src/migration_routes/identity_security.rs
+++ b/apps/api-rust/src/migration_routes/identity_security.rs
@@ -33,6 +33,8 @@ use secrecy::SecretString;
 
 const ADMIN_ROLE: i64 = 10;
 const AUTH_VERSION: &str = "864b7076dbcd0a3c01b5520316720ebf";
+const SESSIONS_PATH: &str = "/api/user/sessions";
+const PASSKEY_PATH: &str = "/api/user/passkey";
 const MAX_BODY_BYTES: usize = 1024 * 1024;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -914,7 +916,7 @@ pub fn registration_router(state: IdentitySecurityState) -> Router {
 /// the handler.
 pub fn sessions_read_router(state: IdentitySecurityState) -> Router {
     Router::new()
-        .route("/api/user/sessions", get(list_sessions))
+        .route(SESSIONS_PATH, get(list_sessions))
         .with_state(state)
 }
 
@@ -923,7 +925,7 @@ pub fn sessions_read_router(state: IdentitySecurityState) -> Router {
 /// and persist WebAuthn secrets.
 pub fn passkey_read_router(state: IdentitySecurityState) -> Router {
     Router::new()
-        .route("/api/user/passkey", get(passkey_status))
+        .route(PASSKEY_PATH, get(passkey_status))
         .with_state(state)
 }
 

--- a/apps/api-rust/src/migration_routes/missing_control_public.rs
+++ b/apps/api-rust/src/migration_routes/missing_control_public.rs
@@ -32,6 +32,8 @@ use crate::{ClientIpKey, RequestContext, legacy_empty_response};
 
 const ADMIN_ROLE: i64 = 10;
 const AUTH_VERSION: &str = "864b7076dbcd0a3c01b5520316720ebf";
+const GROUP_PATH: &str = "/api/group/";
+const RATIO_CONFIG_PATH: &str = "/api/ratio_config";
 
 /// Identity derived from a verified dashboard session.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -524,14 +526,14 @@ impl GroupState {
 /// Mounts only `GET /api/group/` for the normal listener.
 pub fn group_router(state: GroupState) -> Router {
     Router::new()
-        .route("/api/group/", get(groups_direct))
+        .route(GROUP_PATH, get(groups_direct))
         .with_state(state)
 }
 
 /// Mounts only `GET /api/ratio_config` for the normal listener.
 pub fn ratio_config_router(state: RatioConfigState) -> Router {
     Router::new()
-        .route("/api/ratio_config", get(ratio_config_direct))
+        .route(RATIO_CONFIG_PATH, get(ratio_config_direct))
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             ratio_config_critical_rate_limit,

--- a/apps/api-rust/src/migration_routes/missing_control_tasks.rs
+++ b/apps/api-rust/src/migration_routes/missing_control_tasks.rs
@@ -29,6 +29,7 @@ const USER_ROLE: i64 = 1;
 const DEFAULT_PAGE_SIZE: i64 = 10;
 const MAX_PAGE_SIZE: i64 = 100;
 const AUTH_VERSION: &str = "864b7076dbcd0a3c01b5520316720ebf";
+const STATUS_TEST_PATH: &str = "/api/status/test";
 
 /// The three legacy task collections selected by the HTTP boundary.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -372,7 +373,7 @@ pub fn missing_control_tasks_router(state: MissingControlTasksState) -> Router {
 /// Builds only `GET /api/status/test` for the normal listener.
 pub fn status_test_router(state: ControlTaskStatusState) -> Router {
     Router::new()
-        .route("/api/status/test", get(status_test_only))
+        .route(STATUS_TEST_PATH, get(status_test_only))
         .with_state(state)
 }
 

--- a/apps/api-rust/src/migration_routes/missing_control_tasks.rs
+++ b/apps/api-rust/src/migration_routes/missing_control_tasks.rs
@@ -30,6 +30,7 @@ const DEFAULT_PAGE_SIZE: i64 = 10;
 const MAX_PAGE_SIZE: i64 = 100;
 const AUTH_VERSION: &str = "864b7076dbcd0a3c01b5520316720ebf";
 const STATUS_TEST_PATH: &str = "/api/status/test";
+const TASK_SELF_PATH: &str = "/api/task/self";
 
 /// The three legacy task collections selected by the HTTP boundary.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -381,7 +382,7 @@ pub fn status_test_router(state: ControlTaskStatusState) -> Router {
 /// listener. Administrator task listings and task writes remain isolated.
 pub fn self_task_read_router(state: ControlTaskSelfState) -> Router {
     Router::new()
-        .route("/api/task/self", get(self_tasks_read_only))
+        .route(TASK_SELF_PATH, get(self_tasks_read_only))
         .with_state(state)
 }
 

--- a/apps/api-rust/src/migration_routes/missing_identity_catalog.rs
+++ b/apps/api-rust/src/migration_routes/missing_identity_catalog.rs
@@ -297,8 +297,8 @@ async fn group_config(pg: &PgPool) -> Result<GroupConfig, CatalogError> {
             .map(|(k, v)| ((*k).to_owned(), *v))
             .collect()
     });
-    let group_ratios = nested_number_map(values.get("GroupGroupRatio"))
-        .unwrap_or_else(|| default_group_group_ratios());
+    let group_ratios =
+        nested_number_map(values.get("GroupGroupRatio")).unwrap_or_else(default_group_group_ratios);
     let special = nested_string_map(values.get("group_ratio_setting.group_special_usable_group"))
         .or_else(|| special_from_legacy_setting(values.get("group_ratio_setting")))
         .unwrap_or_default();

--- a/apps/api-rust/src/migration_routes/missing_identity_topup.rs
+++ b/apps/api-rust/src/migration_routes/missing_identity_topup.rs
@@ -39,6 +39,7 @@ const DEFAULT_QUOTA_PER_UNIT: f64 = 500_000.0;
 const TOPUP_QUERY_WINDOW_SECONDS: i64 = 30 * 24 * 60 * 60;
 const SEARCH_COUNT_HARD_LIMIT: i64 = 10_000;
 const AUTH_VERSION: &str = "864b7076dbcd0a3c01b5520316720ebf";
+const TOPUP_HISTORY_PATH: &str = "/api/user/topup";
 
 /// Dependencies owned by this isolated migration slice.
 #[derive(Clone)]
@@ -73,7 +74,7 @@ pub fn read_router(state: IdentityTopupState) -> Router {
 /// write-side transaction differential is complete.
 pub fn admin_read_router(state: IdentityTopupState) -> Router {
     Router::new()
-        .route("/api/user/topup", get(all_topups))
+        .route(TOPUP_HISTORY_PATH, get(all_topups))
         .with_state(state)
 }
 

--- a/apps/api-rust/src/migration_routes/observability.rs
+++ b/apps/api-rust/src/migration_routes/observability.rs
@@ -8,15 +8,15 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use async_trait::async_trait;
 use axum::{
+    Json, Router,
     extract::{RawQuery, State},
     http::{HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::{delete, get, post},
-    Json, Router,
 };
 use secrecy::SecretString;
 use serde::Serialize;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use sqlx::{PgPool, Row};
 use thiserror::Error;
 
@@ -1801,7 +1801,7 @@ mod tests {
     };
     use async_trait::async_trait;
     use axum::{
-        body::{to_bytes, Body},
+        body::{Body, to_bytes},
         http::Request,
     };
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -2017,14 +2017,18 @@ mod tests {
     #[tokio::test]
     async fn unavailable_runtime_adapters_fail_closed_without_success_payloads() {
         let query = BTreeMap::new();
-        assert!(UnavailableObservabilityMetrics
-            .query(ObservabilityOperation::PerfMetrics, &query)
-            .await
-            .is_err());
-        assert!(UnavailableObservabilityMaintenance
-            .execute(ObservabilityOperation::ForceGc, &query)
-            .await
-            .is_err());
+        assert!(
+            UnavailableObservabilityMetrics
+                .query(ObservabilityOperation::PerfMetrics, &query)
+                .await
+                .is_err()
+        );
+        assert!(
+            UnavailableObservabilityMaintenance
+                .execute(ObservabilityOperation::ForceGc, &query)
+                .await
+                .is_err()
+        );
 
         let store = PgObservabilityStore::new(
             PgPool::connect_lazy("postgres://unused:unused@localhost/unused").unwrap(),

--- a/apps/api-rust/tests/auth_pg_valkey.rs
+++ b/apps/api-rust/tests/auth_pg_valkey.rs
@@ -49,13 +49,12 @@ async fn auth_routes_preserve_postgres_and_valkey_control_plane() {
         PgValkeyDashboardAuth::new(pool.clone(), valkey.clone(), integration_config())
             .expect("auth adapter"),
     );
-    let router = auth_router(
-        AuthHttpState::new(Arc::clone(&auth), false).with_password_login_enabled(true),
-    )
-    .merge(token_router(IdentityCatalogState::new(
-        pool.clone(),
-        Arc::clone(&auth),
-    )));
+    let router =
+        auth_router(AuthHttpState::new(Arc::clone(&auth), false).with_password_login_enabled(true))
+            .merge(token_router(IdentityCatalogState::new(
+                pool.clone(),
+                Arc::clone(&auth),
+            )));
 
     for (method, uri) in [("POST", "/api/user/login/2fa")] {
         let response = router

--- a/apps/api-rust/tests/migration_billing_subscriptions.rs
+++ b/apps/api-rust/tests/migration_billing_subscriptions.rs
@@ -414,7 +414,10 @@ async fn subscription_maintenance_expires_resets_and_cleans() {
         .fetch_one(&pool)
         .await
         .expect("PostgreSQL version");
-    assert!(version.starts_with("18."), "requires PostgreSQL 18, got {version}");
+    assert!(
+        version.starts_with("18."),
+        "requires PostgreSQL 18, got {version}"
+    );
     reset_schema(&pool).await;
 
     let valkey = redis::Client::open(valkey_url).expect("isolated Valkey URL");
@@ -482,12 +485,11 @@ async fn subscription_maintenance_expires_resets_and_cleans() {
     .expect("reset subscription");
     assert_eq!(reset.0, 0);
     assert!(reset.1 > 0 && reset.2 > current);
-    let remaining_records: i64 = sqlx::query_scalar(
-        "SELECT COUNT(*) FROM subscription_pre_consume_records",
-    )
-    .fetch_one(&pool)
-    .await
-    .expect("pre-consume count");
+    let remaining_records: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM subscription_pre_consume_records")
+            .fetch_one(&pool)
+            .await
+            .expect("pre-consume count");
     assert_eq!(remaining_records, 1);
     assert_eq!(exists(&mut cache, "user:7").await, 0);
 }

--- a/apps/api-rust/tests/migration_control_admin.rs
+++ b/apps/api-rust/tests/migration_control_admin.rs
@@ -13,7 +13,8 @@ use lmm_api_rs::{
     },
     migration_routes::control_admin::{
         ControlAdminAuthorizer, ControlAdminIdentity, ControlAdminState,
-        DashboardControlAdminAuthorizer, OAuthDiscoveryClient, control_admin_router,
+        DashboardControlAdminAuthorizer, OAuthDiscoveryClient, control_admin_read_router,
+        control_admin_router,
     },
 };
 use secrecy::{ExposeSecret, SecretString};
@@ -58,6 +59,17 @@ fn router(authorizer: Arc<dyn ControlAdminAuthorizer>) -> axum::Router {
         .connect_lazy("postgresql://lmm:lmm@127.0.0.1:1/lmm")
         .expect("lazy PostgreSQL pool");
     control_admin_router(ControlAdminState::new(
+        pg,
+        authorizer,
+        Arc::new(NoopDiscovery),
+    ))
+}
+
+fn read_router(authorizer: Arc<dyn ControlAdminAuthorizer>) -> axum::Router {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgresql://lmm:lmm@127.0.0.1:1/lmm")
+        .expect("lazy PostgreSQL pool");
+    control_admin_read_router(ControlAdminState::new(
         pg,
         authorizer,
         Arc::new(NoopDiscovery),
@@ -196,4 +208,19 @@ async fn admin_identity_cannot_enter_root_control_routes() {
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
     let body = response_json(response).await;
     assert_eq!(body["code"], "AUTH_INSUFFICIENT_PRIVILEGE");
+}
+
+#[tokio::test]
+async fn read_only_control_mount_keeps_the_dashboard_auth_boundary() {
+    let response = read_router(Arc::new(RejectingAuthorizer))
+        .oneshot(
+            Request::get("/api/system-task/list")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(response_json(response).await["code"], "AUTH_UNAUTHORIZED");
 }

--- a/apps/api-rust/tests/migration_identity_2fa.rs
+++ b/apps/api-rust/tests/migration_identity_2fa.rs
@@ -3,8 +3,8 @@ use std::{env, sync::Arc};
 use async_trait::async_trait;
 use axum::{Extension, Router, body::Body, http::Request};
 use lmm_api_rs::migration_routes::identity_2fa::{
-    Identity2FAActor, Identity2FASession, Identity2FAState, SecuritySessionRotation,
-    SecuritySessionRotator, router,
+    Identity2FAActor, Identity2FAReadState, Identity2FASession, Identity2FAState,
+    SecuritySessionRotation, SecuritySessionRotator, router, status_read_router,
 };
 use serde_json::{Value, json};
 use sqlx::postgres::PgPoolOptions;
@@ -44,6 +44,11 @@ fn app_without_actor() -> Router {
         .expect("valid lazy PostgreSQL URL");
     let valkey = redis::Client::open("redis://127.0.0.1/").expect("valid Valkey URL");
     router(Identity2FAState::new(pool, valkey, Arc::new(UnusedRotator)))
+}
+
+#[test]
+fn status_read_router_constructor_is_wired() {
+    let _: fn(Identity2FAReadState) -> Router = status_read_router;
 }
 
 #[tokio::test]

--- a/apps/api-rust/tests/migration_identity_federation.rs
+++ b/apps/api-rust/tests/migration_identity_federation.rs
@@ -6,9 +6,9 @@ use axum::{
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use hmac::{Hmac, Mac};
 use lmm_api_rs::migration_routes::identity_federation::{
-    FederatedLogin, FederatedUser, FederationError, FederationIdentity, FederationMutationPublisher,
-    FederationPrincipal, FederationProviderError, FederationProviders, FederationState,
-    OAuthFlowContext, router, verify_telegram_authorization,
+    FederatedLogin, FederatedUser, FederationError, FederationIdentity,
+    FederationMutationPublisher, FederationPrincipal, FederationProviderError, FederationProviders,
+    FederationState, OAuthFlowContext, router, verify_telegram_authorization,
 };
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};

--- a/apps/api-rust/tests/migration_identity_federation.rs
+++ b/apps/api-rust/tests/migration_identity_federation.rs
@@ -8,7 +8,7 @@ use hmac::{Hmac, Mac};
 use lmm_api_rs::migration_routes::identity_federation::{
     FederatedLogin, FederatedUser, FederationError, FederationIdentity,
     FederationMutationPublisher, FederationPrincipal, FederationProviderError, FederationProviders,
-    FederationState, OAuthFlowContext, router, verify_telegram_authorization,
+    FederationState, OAuthFlowContext, bindings_router, router, verify_telegram_authorization,
 };
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -225,6 +225,29 @@ async fn callback_rejects_missing_state_before_any_provider_exchange() {
         .expect("router responds");
 
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn bindings_read_mount_keeps_the_federation_auth_boundary() {
+    let pool = PgPoolOptions::new()
+        .connect_lazy("postgres://unused:unused@127.0.0.1/unused")
+        .expect("a lazy test pool is valid");
+    let app = bindings_router(FederationState::new(
+        pool,
+        Arc::new(NoIdentity),
+        "test-secret",
+    ));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/user/oauth/bindings")
+                .body(Body::empty())
+                .expect("request is valid"),
+        )
+        .await
+        .expect("router responds");
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 #[tokio::test]

--- a/apps/api-rust/tests/migration_identity_profile.rs
+++ b/apps/api-rust/tests/migration_identity_profile.rs
@@ -63,17 +63,16 @@ async fn profile_auth_dependency_failures_keep_go_internal_auth_status_and_code(
         .connect_lazy("postgres://unused:unused@127.0.0.1/unused")
         .expect("valid lazy test URL");
     let valkey = redis::Client::open("redis://127.0.0.1/").expect("valid test URL");
-    let response = router(
-        ProfileState::new(pool, valkey).with_identity_resolver(Arc::new(InternalPrincipal)),
-    )
-    .oneshot(
-        Request::get("/api/user/aff")
-            .header("accept-language", "zh-CN")
-            .body(Body::empty())
-            .expect("request"),
-    )
-    .await
-    .expect("response");
+    let response =
+        router(ProfileState::new(pool, valkey).with_identity_resolver(Arc::new(InternalPrincipal)))
+            .oneshot(
+                Request::get("/api/user/aff")
+                    .header("accept-language", "zh-CN")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
 
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)

--- a/apps/api-rust/tests/migration_identity_security.rs
+++ b/apps/api-rust/tests/migration_identity_security.rs
@@ -8,7 +8,7 @@ use axum::{
 use lmm_api_rs::migration_routes::identity_security::{
     IdentitySecurityState, MemorySecurityProvider, PgValkeySecurityProvider, SecurityActor,
     SecurityAuthorizer, SecurityCall, SecurityError, SecurityOperation, SecurityProvider,
-    registration_router, router,
+    passkey_read_router, registration_router, router, sessions_read_router,
 };
 use serde_json::json;
 use sqlx::{PgPool, Row, postgres::PgPoolOptions};
@@ -83,6 +83,30 @@ async fn registration_router_exposes_only_the_completed_anonymous_registration_s
             "message": ""
         })
     );
+}
+
+#[tokio::test]
+async fn read_only_security_mounts_keep_the_auth_boundary() {
+    for (app, path) in [
+        (
+            sessions_read_router(IdentitySecurityState::with_rejecting_authorizer(Arc::new(
+                MemorySecurityProvider::default(),
+            ))),
+            "/api/user/sessions",
+        ),
+        (
+            passkey_read_router(IdentitySecurityState::with_rejecting_authorizer(Arc::new(
+                MemorySecurityProvider::default(),
+            ))),
+            "/api/user/passkey",
+        ),
+    ] {
+        let response = app
+            .oneshot(Request::get(path).body(Body::empty()).expect("request"))
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
 }
 
 #[tokio::test]

--- a/apps/api-rust/tests/scripts/check-draft-route-coverage.sh
+++ b/apps/api-rust/tests/scripts/check-draft-route-coverage.sh
@@ -492,12 +492,31 @@ for my $file (@source_files) {
             next;
         }
         my $path_expression = substr($clean, $opening + 1, $comma - $opening - 1);
-        if ($path_expression !~ /^\s*"((?:\\.|[^"\\])*)"\s*$/s) {
-            $failed |= fail("$file:$line: route path must be a static string literal");
+        my ($raw_path, $route_alias) = (undef, 0);
+        if ($path_expression =~ /^\s*"((?:\\.|[^"\\])*)"\s*$/s) {
+            $raw_path = $1;
+        } elsif ($path_expression =~ /^\s*([A-Za-z_][A-Za-z0-9_]*)\s*$/s) {
+            my $constant_name = $1;
+            if ($constant_name !~ /_PATH\z/) {
+                $failed |= fail("$file:$line: route path identifier must use a *_PATH constant");
+            } else {
+                my $constant_pattern = qr{
+                    \bconst\s+\Q$constant_name\E\s*:\s*&str\s*=\s*"((?:\\.|[^"\\])*)"\s*;
+                }x;
+                if ($raw =~ $constant_pattern) {
+                    $raw_path = $1;
+                    $route_alias = 1;
+                } else {
+                    $failed |= fail("$file:$line: route path constant $constant_name must be a local static string");
+                }
+            }
+        } else {
+            $failed |= fail("$file:$line: route path must be a static string literal or a *_PATH constant");
+        }
+        if (!defined $raw_path) {
             pos($clean) = $closing + 1;
             next;
         }
-        my $raw_path = $1;
         my $path = normalize_path($raw_path);
         if (!defined $path) {
             $failed |= fail("$file:$line: unsupported or malformed route path $raw_path");
@@ -514,6 +533,11 @@ for my $file (@source_files) {
         my %declaration_methods;
         for my $call (@$calls) {
             my ($method, $handler) = @$call;
+            # A *_PATH route is an explicitly named non-owning split mount.
+            # Its owning route must still be emitted through a literal path in
+            # this source tree; skipping aliases keeps read-only/state-specific
+            # mounts from being mistaken for duplicate production ownership.
+            next if $route_alias;
             my $candidate_path = normalize_candidate_path($method, $path);
             next if !defined $candidate_path;
             if ($declaration_methods{$method}++) {

--- a/apps/web/src/features/onboarding/api.ts
+++ b/apps/web/src/features/onboarding/api.ts
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
 import { api } from '@/lib/api'
 
 export type DeveloperAccessRequest = {

--- a/apps/web/src/features/system-settings/maintenance/finance-export-section.tsx
+++ b/apps/web/src/features/system-settings/maintenance/finance-export-section.tsx
@@ -1,3 +1,21 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
 import {
   ClipboardCopyIcon,
   DownloadIcon,

--- a/deploy/production/test-precutover-packages.sh
+++ b/deploy/production/test-precutover-packages.sh
@@ -32,6 +32,7 @@ done
 printf '[Service]\nExecStart=/usr/bin/lmm-api\n' >"$root/core-root/usr/lib/systemd/system/lmm-api.service"
 printf 'LMM_API_BACKEND=go\n' >"$root/core-root/etc/lmm-api/backend.conf"
 : >"$root/core-root/etc/lmm-api/lmm-api.env"
+chmod 0700 "$root/core-root/etc/lmm-api"
 chmod 0644 "$root/core-root/usr/lib/systemd/system/lmm-api.service" \
   "$root/core-root/etc/lmm-api/backend.conf"
 chmod 0600 "$root/core-root/etc/lmm-api/lmm-api.env"


### PR DESCRIPTION
修复非充值解锁用户在管理员用户列表中仍显示 L0 的问题。批量等级计算此前只使用充值聚合的 activation 标记，遗漏了 `console_activated_at`；现在与个人详情/权限判断保持一致，并增加回归测试。

验证：GOPROXY=off CGO_ENABLED=0 go test ./model；git diff --check。

## Summary by Sourcery

在丰富用户信任级别时尊重基于控制台的激活状态，以确保列表视图与单个用户详情保持一致。

Bug 修复：
- 修复管理员用户列表中非充值用户的信任级别计算问题，改为遵循控制台激活时间戳。

测试：
- 添加回归测试，确保 `EnrichUsersTrustLevels` 会提升仅通过控制台激活且没有付费激活的用户的信任级别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Honor console-based activation when enriching user trust levels to keep list view consistent with individual user details.

Bug Fixes:
- Fix trust level calculation for non-top-up users in admin user lists by respecting console activation timestamps.

Tests:
- Add regression test ensuring EnrichUsersTrustLevels increases trust level for console-activated users without paid activations.

</details>