### PR TITLE
fix: make setup initialization atomic

### DIFF
--- a/apps/api-go/controller/setup.go
+++ b/apps/api-go/controller/setup.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/QuantumNous/new-api/common"
@@ -8,6 +10,7 @@ import (
 	"github.com/QuantumNous/new-api/model"
 	"github.com/QuantumNous/new-api/setting/operation_setting"
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 type Setup struct {
@@ -23,6 +26,8 @@ type SetupRequest struct {
 	SelfUseModeEnabled bool   `json:"SelfUseModeEnabled"`
 	DemoSiteEnabled    bool   `json:"DemoSiteEnabled"`
 }
+
+var errSetupAlreadyCompleted = errors.New("setup already completed")
 
 func GetSetup(c *gin.Context) {
 	setup := Setup{
@@ -66,6 +71,7 @@ func PostSetup(c *gin.Context) {
 		return
 	}
 
+	var rootUser model.User
 	// If root doesn't exist, validate and create admin account
 	if !rootExists {
 		// Validate username length: max 12 characters to align with model.User validation
@@ -102,7 +108,7 @@ func PostSetup(c *gin.Context) {
 			})
 			return
 		}
-		rootUser := model.User{
+		rootUser = model.User{
 			Username:    req.Username,
 			Password:    hashedPassword,
 			Role:        common.RoleRootUser,
@@ -111,48 +117,45 @@ func PostSetup(c *gin.Context) {
 			AccessToken: nil,
 			Quota:       100000000,
 		}
-		err = model.DB.Create(&rootUser).Error
-		if err != nil {
+	}
+
+	err = model.DB.Transaction(func(tx *gorm.DB) error {
+		setup := model.Setup{
+			ID:            model.SetupSingletonID,
+			Version:       common.Version,
+			InitializedAt: time.Now().Unix(),
+		}
+		if err := tx.Create(&setup).Error; err != nil {
+			if isUniqueConstraintError(err) {
+				return errSetupAlreadyCompleted
+			}
+			return err
+		}
+
+		var rootCount int64
+		if err := tx.Model(&model.User{}).Where("role = ?", common.RoleRootUser).Count(&rootCount).Error; err != nil {
+			return err
+		}
+		if rootCount == 0 {
+			if rootExists {
+				return errors.New("root user disappeared during setup")
+			}
+			if err := tx.Create(&rootUser).Error; err != nil {
+				return err
+			}
+		}
+
+		return saveSetupOptions(tx, req)
+	})
+	if err != nil {
+		if errors.Is(err, errSetupAlreadyCompleted) {
+			constant.Setup = true
 			c.JSON(200, gin.H{
 				"success": false,
-				"message": "创建管理员账号失败: " + err.Error(),
+				"message": "系统已经初始化完成",
 			})
 			return
 		}
-	}
-
-	// Set operation modes
-	operation_setting.SelfUseModeEnabled = req.SelfUseModeEnabled
-	operation_setting.DemoSiteEnabled = req.DemoSiteEnabled
-
-	// Save operation modes to database for persistence
-	err = model.UpdateOption("SelfUseModeEnabled", boolToString(req.SelfUseModeEnabled))
-	if err != nil {
-		c.JSON(200, gin.H{
-			"success": false,
-			"message": "保存自用模式设置失败: " + err.Error(),
-		})
-		return
-	}
-
-	err = model.UpdateOption("DemoSiteEnabled", boolToString(req.DemoSiteEnabled))
-	if err != nil {
-		c.JSON(200, gin.H{
-			"success": false,
-			"message": "保存演示站点模式设置失败: " + err.Error(),
-		})
-		return
-	}
-
-	// Update setup status
-	constant.Setup = true
-
-	setup := model.Setup{
-		Version:       common.Version,
-		InitializedAt: time.Now().Unix(),
-	}
-	err = model.DB.Create(&setup).Error
-	if err != nil {
 		c.JSON(200, gin.H{
 			"success": false,
 			"message": "系统初始化失败: " + err.Error(),
@@ -160,10 +163,53 @@ func PostSetup(c *gin.Context) {
 		return
 	}
 
+	applySetupOperationModes(req)
+	constant.Setup = true
+
 	c.JSON(200, gin.H{
 		"success": true,
 		"message": "系统初始化成功",
 	})
+}
+
+func saveSetupOptions(tx *gorm.DB, req SetupRequest) error {
+	values := map[string]string{
+		"SelfUseModeEnabled": boolToString(req.SelfUseModeEnabled),
+		"DemoSiteEnabled":    boolToString(req.DemoSiteEnabled),
+	}
+	for key, value := range values {
+		option := model.Option{Key: key}
+		if err := tx.FirstOrCreate(&option, model.Option{Key: key}).Error; err != nil {
+			return err
+		}
+		option.Value = value
+		if err := tx.Save(&option).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applySetupOperationModes(req SetupRequest) {
+	operation_setting.SelfUseModeEnabled = req.SelfUseModeEnabled
+	operation_setting.DemoSiteEnabled = req.DemoSiteEnabled
+
+	common.OptionMapRWMutex.Lock()
+	defer common.OptionMapRWMutex.Unlock()
+	if common.OptionMap == nil {
+		return
+	}
+	common.OptionMap["SelfUseModeEnabled"] = boolToString(req.SelfUseModeEnabled)
+	common.OptionMap["DemoSiteEnabled"] = boolToString(req.DemoSiteEnabled)
+}
+
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "unique") ||
+		strings.Contains(message, "duplicate")
 }
 
 func boolToString(b bool) string {

--- a/apps/api-go/controller/setup_test.go
+++ b/apps/api-go/controller/setup_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/setting/operation_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupPostSetupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	previousDB := model.DB
+	previousSetup := constant.Setup
+	previousOptionMap := common.OptionMap
+	previousMainDatabaseType := common.MainDatabaseType()
+	previousLogDatabaseType := common.LogDatabaseType()
+	previousSelfUseMode := operation_setting.SelfUseModeEnabled
+	previousDemoSite := operation_setting.DemoSiteEnabled
+
+	common.SetDatabaseTypes(common.DatabaseTypeSQLite, common.DatabaseTypeSQLite)
+	constant.Setup = false
+	common.OptionMap = map[string]string{}
+	operation_setting.SelfUseModeEnabled = false
+	operation_setting.DemoSiteEnabled = false
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.User{}, &model.Option{}, &model.Setup{}))
+	model.DB = db
+
+	t.Cleanup(func() {
+		model.DB = previousDB
+		constant.Setup = previousSetup
+		common.OptionMap = previousOptionMap
+		common.SetDatabaseTypes(previousMainDatabaseType, previousLogDatabaseType)
+		operation_setting.SelfUseModeEnabled = previousSelfUseMode
+		operation_setting.DemoSiteEnabled = previousDemoSite
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+
+	return db
+}
+
+func performPostSetupRequest(body string) *httptest.ResponseRecorder {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/setup", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	PostSetup(c)
+	return recorder
+}
+
+func TestPostSetupConcurrentRequestsCreateSingleRoot(t *testing.T) {
+	db := setupPostSetupTestDB(t)
+
+	const requestCount = 16
+	start := make(chan struct{})
+	responses := make(chan string, requestCount)
+	var wg sync.WaitGroup
+
+	for i := 0; i < requestCount; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			body := fmt.Sprintf(`{"username":"root%d","password":"Password123","confirmPassword":"Password123","SelfUseModeEnabled":true,"DemoSiteEnabled":false}`, i)
+			responses <- performPostSetupRequest(body).Body.String()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(responses)
+
+	successCount := 0
+	for response := range responses {
+		if strings.Contains(response, `"success":true`) {
+			successCount++
+		}
+	}
+
+	var rootCount int64
+	require.NoError(t, db.Model(&model.User{}).Where("role = ?", common.RoleRootUser).Count(&rootCount).Error)
+	var setupCount int64
+	require.NoError(t, db.Model(&model.Setup{}).Count(&setupCount).Error)
+	var setup model.Setup
+	require.NoError(t, db.First(&setup).Error)
+
+	assert.Equal(t, 1, successCount)
+	assert.Equal(t, int64(1), rootCount)
+	assert.Equal(t, int64(1), setupCount)
+	assert.Equal(t, model.SetupSingletonID, setup.ID)
+}

--- a/apps/api-go/model/main.go
+++ b/apps/api-go/model/main.go
@@ -120,6 +120,7 @@ func checkSetup() {
 			common.SysLog("system is not initialized, but root user exists")
 			// Create setup record
 			newSetup := Setup{
+				ID:            SetupSingletonID,
 				Version:       common.Version,
 				InitializedAt: time.Now().Unix(),
 			}

--- a/apps/api-go/model/setup.go
+++ b/apps/api-go/model/setup.go
@@ -1,5 +1,7 @@
 package model
 
+const SetupSingletonID uint = 1
+
 type Setup struct {
 	ID            uint   `json:"id" gorm:"primaryKey"`
 	Version       string `json:"version" gorm:"type:varchar(50);not null"`


### PR DESCRIPTION
## Summary
- Serialize first-time setup initialization with a fixed setup sentinel row inside the transaction.
- Prevent concurrent requests from creating multiple permanent RoleRootUser records.
- Use the same sentinel when bootstrapping the setup record at startup.
- Add a concurrent regression test covering 16 setup requests.

## Testing
- python scripts/misc/public_release_check.py passed.
- Go tests were not run locally because the Go toolchain is unavailable in the environment.

Fixes #67

## Summary by Sourcery

使用单例的 setup 记录使 setup 初始化具备原子性，以防止首次初始化时发生并发竞争。

New Features:
- 添加事务性 setup 逻辑，用于串行化创建 setup 记录、root 用户以及 setup 选项。
- 引入辅助函数，以事务方式持久化 setup 选项，并将其应用到内存配置中。
- 新增唯一约束冲突检测，将重复的 setup 尝试视为已完成初始化的情况。

Bug Fixes:
- 防止并发的 setup 请求创建多个 root 用户或重复的 setup 记录。
- 确保在启动过程中创建的 setup 记录使用固定的单例 ID，以保持一致性。

Tests:
- 添加并发回归测试，发起多个并行的 setup 请求，并断言最终只创建一个 root 用户和一条 setup 记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make setup initialization atomic using a singleton setup record to prevent concurrent first-time setup races.

New Features:
- Add transactional setup logic that serializes creation of the setup record, root user, and setup options.
- Introduce helper functions to persist setup options transactionally and to apply them to in-memory configuration.
- Add detection of unique-constraint violations to treat repeated setup attempts as already-initialized.

Bug Fixes:
- Prevent concurrent setup requests from creating multiple root users or duplicate setup records.
- Ensure the setup record created during startup uses a fixed singleton ID for consistency.

Tests:
- Add a concurrent regression test that issues multiple parallel setup requests and asserts only one root user and one setup record are created.

</details>