### PR TITLE
fix(api-rust): align current Go auth and transaction fixtures

### DIFF
--- a/apps/api-rust/src/migration_routes/missing_identity_catalog.rs
+++ b/apps/api-rust/src/migration_routes/missing_identity_catalog.rs
@@ -219,6 +219,17 @@ async fn generate_access_token(
 ) -> Result<Json<LegacySuccess<String>>, CatalogError> {
     let access_token =
         credential(&headers).ok_or_else(|| CatalogError::unauthorized(locale(&headers)))?;
+    // The current Go listener's outer ConsoleAccessGate hides this developer
+    // surface until trust-level activation. Keep the same 404 boundary rather
+    // than issuing a management token to a merely authenticated account.
+    let user_view = state
+        .auth
+        .self_user_view_for_optional(SecretString::from(access_token.clone()))
+        .await
+        .map_err(|error| CatalogError::from_auth(error, locale(&headers)))?;
+    if !user_view.developer_access_granted {
+        return Err(CatalogError::not_found());
+    }
     // `generate_personal_access_token` verifies the same bearer session and
     // generates the 29..=32-character legacy base64 token atomically.  Do not
     // reimplement this here: it also owns duplicate detection and user-cache
@@ -490,6 +501,14 @@ struct CatalogError {
 }
 
 impl CatalogError {
+    fn not_found() -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: None,
+            message: "Not Found".to_owned(),
+        }
+    }
+
     fn unauthorized(locale: Locale) -> Self {
         Self {
             status: StatusCode::UNAUTHORIZED,

--- a/apps/api-rust/src/migration_routes/missing_identity_topup.rs
+++ b/apps/api-rust/src/migration_routes/missing_identity_topup.rs
@@ -721,15 +721,40 @@ async fn complete_topup(
         if units <= 0 {
             return fail("无效的充值额度");
         }
-        match sqlx::query(
-            "UPDATE top_ups SET complete_time = $1, status = $2 WHERE id = $3 AND status = $4",
+        // Current Go persists the normalized credited amount on the order
+        // while completing it. Keep the fallback update for older schemas
+        // that predate the settlement columns; those schemas remain readable
+        // during the staged migration, but current schemas get exact parity.
+        let has_credited_quota = sqlx::query_scalar::<_, bool>(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name = 'top_ups' AND column_name = 'credited_quota')",
         )
-        .bind(unix_now())
-        .bind(TOPUP_SUCCESS)
-        .bind(id)
-        .bind(TOPUP_PENDING)
-        .execute(&mut *tx)
-        .await {
+        .fetch_one(&mut *tx)
+        .await
+        .unwrap_or(false);
+        let completed_at = unix_now();
+        let completion = if has_credited_quota {
+            sqlx::query(
+                "UPDATE top_ups SET credited_quota = $1, complete_time = $2, status = $3 WHERE id = $4 AND status = $5",
+            )
+            .bind(units)
+            .bind(completed_at)
+            .bind(TOPUP_SUCCESS)
+            .bind(id)
+            .bind(TOPUP_PENDING)
+            .execute(&mut *tx)
+            .await
+        } else {
+            sqlx::query(
+                "UPDATE top_ups SET complete_time = $1, status = $2 WHERE id = $3 AND status = $4",
+            )
+            .bind(completed_at)
+            .bind(TOPUP_SUCCESS)
+            .bind(id)
+            .bind(TOPUP_PENDING)
+            .execute(&mut *tx)
+            .await
+        };
+        match completion {
             Ok(result) if result.rows_affected() == 1 => {}
             Ok(_) => return fail("系统错误"),
             Err(error) => return fail(legacy_database_error(&error)),

--- a/apps/api-rust/tests/behavior-oracle/tests/api-token-parity-differential.sh
+++ b/apps/api-rust/tests/behavior-oracle/tests/api-token-parity-differential.sh
@@ -39,7 +39,17 @@ build_root=${TMPDIR:-/dev/shm}
 [[ -d $build_root && -w $build_root ]] || { echo "temporary build directory is not writable: $build_root" >&2; exit 1; }
 # PostgreSQL requires a normal filesystem for its data directory on this host;
 # the frozen Go build is the only sizeable transient tree and belongs in RAM.
-runtime=$(mktemp -d /tmp/lmm-api-token-parity.XXXXXX)
+runtime_root=${LMM_API_TOKEN_PARITY_RUNTIME_ROOT:-/tmp}
+[[ $runtime_root == /* && $runtime_root != *..* ]] || {
+  echo 'LMM_API_TOKEN_PARITY_RUNTIME_ROOT must be an absolute path without ..' >&2
+  exit 2
+}
+mkdir -p -- "$runtime_root"
+[[ -d $runtime_root && -w $runtime_root ]] || {
+  echo "API-token parity runtime root is not writable: $runtime_root" >&2
+  exit 1
+}
+runtime=$(mktemp -d "$runtime_root/lmm-api-token-parity.XXXXXX")
 go_build=$(mktemp -d "$build_root/lmm-api-token-parity-go.XXXXXX")
 go_static_keys="$runtime/go.static.keys"
 rust_static_keys="$runtime/rust.static.keys"
@@ -141,7 +151,7 @@ cleanup() {
   rm -f -- "$go_env_file" "$rust_env_file" "$go_valkey_config" "$rust_valkey_config"
   [[ -d $runtime/pg ]] && pg_ctl -D "$runtime/pg" -m fast -w stop >/dev/null 2>&1 || true
   case "$runtime" in
-    /tmp/lmm-api-token-parity.*) rm -rf "$runtime" ;;
+    "$runtime_root"/lmm-api-token-parity.*) rm -rf "$runtime" ;;
     *) echo "refusing unexpected runtime: $runtime" >&2 ;;
   esac
   case "$go_build" in
@@ -371,8 +381,16 @@ token_snapshot() {
   local database=$1 generated
   refresh_generated_keys "$database"
   generated=$(generated_keys_json "$database")
+  local snapshot_filter=''
+  if [[ $allow_current_oracle != 1 ]]; then
+    # The frozen 5418ce6 Go schema predates Rust's optional auto-groups
+    # extension. It is deliberately not part of the historical token-table
+    # comparison; the route wire contract above still verifies that frozen
+    # responses omit the field.
+    snapshot_filter='del(.auto_groups) | '
+  fi
   sql "$database" "SELECT COALESCE(json_agg(to_jsonb(token) ORDER BY id), '[]'::json) FROM tokens AS token" |
-    jq -S --argjson generated "$generated" '
+    jq -S --argjson generated "$generated" --arg snapshot_filter "$snapshot_filter" '
       def canonical_generated_key:
         . as $candidate
         | if ($candidate | type) == "string"
@@ -381,7 +399,8 @@ token_snapshot() {
           then "<KEY>"
           else .
           end;
-      map(.key |= canonical_generated_key
+      map((if $snapshot_filter == "" then . else (del(.auto_groups)) end)
+        | .key |= canonical_generated_key
         | .created_time = "<TIME>"
         | .accessed_time = "<TIME>"
         | .deleted_at = (if .deleted_at == null then null else "<DELETED>" end))'
@@ -429,6 +448,10 @@ assert_only_tokens_may_change() {
   go_after=$(business_snapshot_without_tokens "$go_database")
   rust_after=$(business_snapshot_without_tokens "$rust_database")
   if [[ $allow_console_activation == true ]]; then
+    # The disposable Go database installs the same first-token activation
+    # trigger for frozen and current-oracle runs. Permit only that one
+    # explicitly scoped create side effect while keeping every other
+    # non-token column strict.
     # The current forge contract intentionally changes only this derived user
     # bit on a successful first-credential create.  Keep the stronger
     # non-token immutability check for every other column and every rejected
@@ -1131,6 +1154,9 @@ wait_for_valkey() {
 write_valkey_config() {
   local config=$1 port=$2 password=$3
   (umask 077
+    # The exhaustive matrix runs longer than the deployed 60-second search
+    # window. Keep the counter alive for the whole isolated run so Go and
+    # Rust cannot cross the expiry boundary between their paired requests.
     printf '%s\n' \
       'bind 127.0.0.1' \
       "port $port" \
@@ -1178,7 +1204,7 @@ write_app_env() {
       'export CRITICAL_RATE_LIMIT_DURATION=1200' \
       'export SEARCH_RATE_LIMIT_ENABLE=true' \
       'export SEARCH_RATE_LIMIT=100000' \
-      'export SEARCH_RATE_LIMIT_DURATION=60'
+      'export SEARCH_RATE_LIMIT_DURATION=3600'
     } >"$file")
   chmod 600 "$file"
 }

--- a/apps/api-rust/tests/behavior-oracle/tests/missing-routes-transaction-differential.sh
+++ b/apps/api-rust/tests/behavior-oracle/tests/missing-routes-transaction-differential.sh
@@ -43,8 +43,11 @@ rust_pid_start=
 valkey_pid_start=
 
 cleanup() {
-  stop_listeners || true
-  stop_owned_process valkey_pid || true
+  # The trap is installed before the helper definitions so that preflight
+  # failures still clean their exact runtime. Guard calls whose definitions
+  # may not have been reached yet.
+  if declare -F stop_listeners >/dev/null 2>&1; then stop_listeners || true; fi
+  if declare -F stop_owned_process >/dev/null 2>&1; then stop_owned_process valkey_pid || true; fi
   [[ -d $runtime/pg ]] && pg_ctl -D "$runtime/pg" -m fast -w stop >/dev/null 2>&1 || true
   if [[ $keep_runtime == 1 ]]; then
     echo "preserved transaction runtime: $runtime" >&2
@@ -103,11 +106,15 @@ admin_schema_sql() {
 }
 snapshot() {
   local engine=$1
+  local topup_projection="to_jsonb(x) - 'id' - 'create_time' - 'complete_time'"
+  if [[ ${LMM_TRANSACTION_OMIT_OPTIONAL_TOPUP_COLUMNS:-0} == 1 ]]; then
+    topup_projection+=" - 'credited_quota' - 'expected_amount_micros' - 'provider_event_id' - 'provider_product_id' - 'provider_store_id' - 'provider_transaction_id' - 'settled_amount_micros' - 'settlement_currency'"
+  fi
   app_sql "$engine" "SELECT jsonb_build_object(
-    'users', COALESCE((SELECT jsonb_agg(to_jsonb(x) - 'access_token' - 'created_at' - 'last_login_at' ORDER BY id) FROM users x),'[]'::jsonb),
+    'users', COALESCE((SELECT jsonb_agg(to_jsonb(x) - 'access_token' - 'created_at' - 'last_login_at' - 'last_api_activity_at' - 'trust_level_override' ORDER BY id) FROM users x),'[]'::jsonb),
     'checkins', COALESCE((SELECT jsonb_agg(to_jsonb(x) - 'id' - 'created_at' ORDER BY user_id,checkin_date) FROM checkins x),'[]'::jsonb),
     'redemptions', COALESCE((SELECT jsonb_agg(to_jsonb(x) - 'id' - 'created_time' - 'redeemed_time' ORDER BY key) FROM redemptions x),'[]'::jsonb),
-    'top_ups', COALESCE((SELECT jsonb_agg(to_jsonb(x) - 'id' - 'create_time' - 'complete_time' ORDER BY trade_no) FROM top_ups x),'[]'::jsonb),
+    'top_ups', COALESCE((SELECT jsonb_agg($topup_projection ORDER BY trade_no) FROM top_ups x),'[]'::jsonb),
     'logs', COALESCE((SELECT jsonb_agg(to_jsonb(x) - 'id' - 'created_at' - 'request_id' - 'upstream_request_id' ORDER BY user_id,type,content) FROM logs x WHERE type <> 7),'[]'::jsonb),
     'options', COALESCE((SELECT jsonb_object_agg(key,value ORDER BY key) FROM options WHERE key IN ('checkin_setting','checkin_setting.enabled','checkin_setting.min_quota','checkin_setting.max_quota','payment_setting.compliance_confirmed','payment_setting.compliance_terms_version','QuotaPerUnit','MinTopUp','Price','TopupGroupRatio','general_setting')),'{}'::jsonb))" | jq -S .
 }
@@ -167,7 +174,9 @@ if [[ ${LMM_TRANSACTION_CANONICAL_JSON_SELF_TEST:-0} == 1 ]]; then
 fi
 wait_for() {
   local port=$1 path=$2
-  for _ in {1..300}; do curl --silent --output /dev/null "http://127.0.0.1:$port$path" && return 0 || true; sleep .05; done
+  # Go's first PostgreSQL AutoMigrate can exceed 15 seconds on a loaded
+  # shared host even though the process is healthy and making progress.
+  for _ in {1..6000}; do curl --silent --output /dev/null "http://127.0.0.1:$port$path" && return 0 || true; sleep .05; done
   return 1
 }
 start_listeners() {
@@ -359,6 +368,9 @@ if [[ ${LMM_TRANSACTION_SKIP_RUST_BUILD:-0} != 1 ]]; then
 fi
 [[ -x $rust_binary ]] || { echo "Rust test-instance binary unavailable: $rust_binary" >&2; exit 1; }
 cp -a "$legacy_root/." "$go_build/go-source"
+# The frozen oracle archive is intentionally immutable; the disposable copy
+# must be writable for the embedded frontend placeholder and cleanup hooks.
+chmod -R u+rwX -- "$go_build/go-source"
 mkdir -p "$go_build/go-source/web/dist"; : >"$go_build/go-source/web/dist/index.html"
 (cd "$go_build/go-source" && GOTOOLCHAIN=local CGO_ENABLED=1 go build -buildvcs=false -o "$go_build/legacy-go" .)
 initdb --no-locale --encoding=UTF8 --auth=trust -D "$runtime/pg" >/dev/null
@@ -381,6 +393,28 @@ for owner_pair in "$go_schema:$go_role" "$rust_schema:$rust_role"; do
     END LOOP;
   END \$\$; ALTER SCHEMA $schema OWNER TO $role;"
 done
+# Current Go's settlement model is additive to the frozen baseline. When the
+# oracle is the current Go checkout, provision the same nullable-safe columns
+# in both disposable schemas so the transaction snapshot exercises the real
+# normalized credited-quota write rather than silently hiding it as an absent
+# legacy column. The default stays off for the immutable 5418 contract.
+if [[ ${LMM_TRANSACTION_TOPUP_SETTLEMENT_COLUMNS:-0} == 1 ]]; then
+  for schema in "$go_schema" "$rust_schema"; do
+    admin_schema_sql "$schema" "ALTER TABLE top_ups
+      ADD COLUMN IF NOT EXISTS credited_quota BIGINT NOT NULL DEFAULT 0,
+      ADD COLUMN IF NOT EXISTS expected_amount_micros BIGINT NOT NULL DEFAULT 0,
+      ADD COLUMN IF NOT EXISTS settled_amount_micros BIGINT NOT NULL DEFAULT 0,
+      ADD COLUMN IF NOT EXISTS settlement_currency VARCHAR(16) NOT NULL DEFAULT '',
+      ADD COLUMN IF NOT EXISTS provider_product_id VARCHAR(255) NOT NULL DEFAULT '',
+      ADD COLUMN IF NOT EXISTS provider_store_id VARCHAR(255) NOT NULL DEFAULT '',
+      ADD COLUMN IF NOT EXISTS provider_event_id VARCHAR(255),
+      ADD COLUMN IF NOT EXISTS provider_transaction_id VARCHAR(255);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_topup_provider_event
+        ON top_ups (payment_provider, provider_event_id);
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_topup_provider_transaction
+        ON top_ups (payment_provider, provider_transaction_id);"
+  done
+fi
 # Rust's readiness probe also requires the forward-only contract-2
 # open-source-bounty relations.  Apply this after the baseline ownership pass
 # because PostgreSQL does not allow a linked serial sequence to be re-owned

--- a/apps/api-rust/tests/behavior-oracle/tests/models-listener-differential.sh
+++ b/apps/api-rust/tests/behavior-oracle/tests/models-listener-differential.sh
@@ -235,6 +235,9 @@ fi
 rust_binary_sha256=$(sha256sum -- "$rust_binary" | awk '{print $1}')
 [[ $rust_binary_sha256 =~ ^[[:xdigit:]]{64}$ ]] || { echo 'Rust binary hash calculation failed' >&2; exit 1; }
 cp -a "$legacy_root/." "$runtime/go-source"
+# The frozen archive is intentionally immutable; the disposable build copy
+# must still be writable so the embedded frontend placeholder can be created.
+chmod -R u+rwX -- "$runtime/go-source"
 mkdir -p "$runtime/go-source/web/dist"
 : >"$runtime/go-source/web/dist/index.html"
 (
@@ -316,7 +319,10 @@ start_go_listener() {
     go_redis_startup_diagnostics
     return 1
   fi
-  for _ in {1..300}; do
+  # The first Go boot performs the full SQLite migration before binding. On a
+  # constrained shared CI/desktop host that can exceed the old 15-second
+  # ownership window even though the listener is healthy and progressing.
+  for _ in {1..6000}; do
     owned_pid_is_live go_pid && listener_owned_by "$go_port" "$go_pid" && break
     sleep .05
   done
@@ -367,7 +373,7 @@ go_valkey FLUSHDB >/dev/null
 start_go_listener
 
 psql -h 127.0.0.1 -p "$pg_port" -d lmm_test_models_rust -v ON_ERROR_STOP=1 <<'SQL' >/dev/null
-CREATE SCHEMA lmm_test_models_rust;
+CREATE SCHEMA IF NOT EXISTS lmm_test_models_rust;
 ALTER DATABASE lmm_test_models_rust SET search_path TO lmm_test_models_rust;
 SET search_path TO lmm_test_models_rust;
 CREATE ROLE lmm_test_models_runtime LOGIN;
@@ -386,6 +392,7 @@ CREATE TABLE tokens (id BIGINT PRIMARY KEY DEFAULT nextval('tokens_id_seq'), use
 ALTER SEQUENCE tokens_id_seq OWNED BY tokens.id;
 CREATE TABLE channels (id BIGINT PRIMARY KEY, type INTEGER DEFAULT 0, status INTEGER DEFAULT 1);
 CREATE TABLE abilities ("group" VARCHAR(64), model VARCHAR(255), channel_id BIGINT, enabled BOOLEAN, priority INTEGER DEFAULT 0, weight INTEGER DEFAULT 0, PRIMARY KEY ("group", model, channel_id));
+ALTER SCHEMA lmm_test_models_rust OWNER TO lmm_test_models_runtime;
 GRANT USAGE ON SCHEMA lmm_test_models_rust TO lmm_test_models_runtime;
 GRANT SELECT ON lmm_schema_contract, options, custom_oauth_providers, setups, users, user_sessions, two_fas, casbin_rule, tokens, channels, abilities TO lmm_test_models_runtime;
 GRANT UPDATE ON users TO lmm_test_models_runtime;


### PR DESCRIPTION
### Summary

This checkpoint keeps the Rust migration aligned with the current Go contract at two money-sensitive boundaries:

- personal-token generation now returns the current Go trust-gate 404 for accounts that are authenticated but not activated;
- manual top-up completion persists `credited_quota` when the additive settlement column exists, while retaining the older-schema fallback;
- the real TCP behavior fixtures now handle immutable Go oracle copies, long first boot, schema ownership, and optional settlement columns without broad temporary cleanup.

### Validation

- `cargo fmt --manifest-path apps/api-rust/Cargo.toml --all -- --check`
- `TMPDIR=/tmp cargo check --manifest-path apps/api-rust/Cargo.toml -p lmm-api-rs --locked`
- `cargo test --manifest-path apps/api-rust/Cargo.toml -p lmm-api-rs --lib completed_quota_keeps_the_legacy_default_and_rejects_malformed_values` (1 passed)
- `bash -n` on all three changed behavior-oracle scripts
- transaction fixture contract and canonical JSON self-test passed

The branch is based on the latest fetched `origin/main` (`a0e032d57`) and contains signed commit `47e2ca7d4`; the full 28-phase TCP transaction run remains a separate migration gate and is not claimed by this checkpoint.

## Summary by Sourcery

使 Rust API 的行为和测试数据夹具与当前 Go 在鉴权门控、充值结算以及 behavior-oracle 运行时上的实现保持一致。

新特性：
- 将个人访问令牌的生成置于开发者访问激活门控之后，对于已认证但未激活的账号返回 404。

缺陷修复：
- 在存在结算列时，确保手动充值完成后已记入的配额能够持久化，同时保持旧版 schema 的行为不变。
- 防止在辅助函数尚未定义时 behavior-oracle 清理过程失败，从而在预检错误场景下提升健壮性。

增强项：
- 扩展交易和 Token 对账（parity）夹具，以支持不可变的 Go oracle 归档、可配置的运行时根路径、可选结算列以及更长的首次启动时间窗口。
- 规范化 Token 对账快照，以容忍诸如可选 auto-groups 之类的 schema 差异，同时对非 Token 数据保持严格不可变。
- 调整限流和 Valkey 过期配置，使长时间运行的 parity 和矩阵测试在 Go 与 Rust 之间维持一致的共享计数器。
- 让 Rust 的 models-listener 测试幂等地创建其运行时 schema，并将所有权赋予运行时角色，以更好地贴近生产环境。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Rust API behavior and test fixtures with the current Go implementation for auth gating, top-up settlement, and behavior-oracle runtimes.

New Features:
- Gate personal access token generation behind developer access activation, returning a 404 for authenticated but not activated accounts.

Bug Fixes:
- Ensure manual top-up completion persists credited quota when settlement columns are present while preserving legacy-schema behavior.
- Prevent behavior-oracle cleanup from failing when helper functions are not yet defined, improving robustness on preflight errors.

Enhancements:
- Extend transaction and token parity fixtures to support immutable Go oracle archives, configurable runtime roots, optional settlement columns, and longer first-boot windows.
- Normalize token parity snapshots to tolerate schema differences such as optional auto-groups while keeping non-token data strictly immutable.
- Adjust rate-limiting and Valkey expiry configuration so long-running parity and matrix tests maintain consistent shared counters between Go and Rust.
- Make the Rust models-listener test idempotently create its runtime schema and assign ownership to the runtime role to better mirror production.

</details>

新特性：
- 将个人访问令牌的生成置于开发者访问权限已激活的前提之下，对已鉴权但未激活的账户返回 404。

缺陷修复：
- 在存在结算字段的情况下，手动充值完成后持久化已入账的配额，同时保留旧版数据表结构的行为。
- 防止 behavior-oracle 脚本在辅助函数尚未定义时清理失败，从而在预检错误场景下提升测试数据的健壮性。

改进增强：
- 扩展交易和模型对等测试数据，以支持不可变的 Go oracle 归档、可配置的运行时根路径、可选的结算字段，以及更长的首次启动窗口。
- 规范化令牌对等快照，以兼容诸如可选自动分组等架构差异，同时保留对非令牌数据严格不可变性的校验。
- 调整对等测试中的限流和 Valkey 过期设置，确保长时间运行的矩阵测试在 Go 和 Rust 之间保持共享计数器的一致性。
- 确保 Rust models-listener 测试以幂等方式创建运行时 schema，并将所有权赋予运行时角色，以更贴近生产环境配置。

测试：
- 更新 behavior-oracle 的交易、令牌以及 models-listener 差异脚本，使其与当前 Go 的约定和迁移特性保持一致，包括新的 schema 和快照预期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使 Rust API 的行为和测试数据夹具与当前 Go 在鉴权门控、充值结算以及 behavior-oracle 运行时上的实现保持一致。

新特性：
- 将个人访问令牌的生成置于开发者访问激活门控之后，对于已认证但未激活的账号返回 404。

缺陷修复：
- 在存在结算列时，确保手动充值完成后已记入的配额能够持久化，同时保持旧版 schema 的行为不变。
- 防止在辅助函数尚未定义时 behavior-oracle 清理过程失败，从而在预检错误场景下提升健壮性。

增强项：
- 扩展交易和 Token 对账（parity）夹具，以支持不可变的 Go oracle 归档、可配置的运行时根路径、可选结算列以及更长的首次启动时间窗口。
- 规范化 Token 对账快照，以容忍诸如可选 auto-groups 之类的 schema 差异，同时对非 Token 数据保持严格不可变。
- 调整限流和 Valkey 过期配置，使长时间运行的 parity 和矩阵测试在 Go 与 Rust 之间维持一致的共享计数器。
- 让 Rust 的 models-listener 测试幂等地创建其运行时 schema，并将所有权赋予运行时角色，以更好地贴近生产环境。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align Rust API behavior and test fixtures with the current Go implementation for auth gating, top-up settlement, and behavior-oracle runtimes.

New Features:
- Gate personal access token generation behind developer access activation, returning a 404 for authenticated but not activated accounts.

Bug Fixes:
- Ensure manual top-up completion persists credited quota when settlement columns are present while preserving legacy-schema behavior.
- Prevent behavior-oracle cleanup from failing when helper functions are not yet defined, improving robustness on preflight errors.

Enhancements:
- Extend transaction and token parity fixtures to support immutable Go oracle archives, configurable runtime roots, optional settlement columns, and longer first-boot windows.
- Normalize token parity snapshots to tolerate schema differences such as optional auto-groups while keeping non-token data strictly immutable.
- Adjust rate-limiting and Valkey expiry configuration so long-running parity and matrix tests maintain consistent shared counters between Go and Rust.
- Make the Rust models-listener test idempotently create its runtime schema and assign ownership to the runtime role to better mirror production.

</details>

</details>