### PR TITLE
fix(security): resolve code scanning alerts

### DIFF
--- a/apps/api-go/common/email.go
+++ b/apps/api-go/common/email.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"encoding/base64"
 	"fmt"
+	"net/mail"
 	"net/smtp"
 	"slices"
 	"strings"
@@ -11,12 +12,35 @@ import (
 )
 
 func generateMessageID() (string, error) {
-	split := strings.Split(SMTPFrom, "@")
-	if len(split) < 2 {
+	sender, err := mail.ParseAddress(SMTPFrom)
+	if err != nil {
+		return "", fmt.Errorf("invalid SMTP sender: %w", err)
+	}
+	at := strings.LastIndexByte(sender.Address, '@')
+	if at < 1 || at == len(sender.Address)-1 {
 		return "", fmt.Errorf("invalid SMTP account")
 	}
-	domain := strings.Split(SMTPFrom, "@")[1]
+	domain := sender.Address[at+1:]
 	return fmt.Sprintf("<%d.%s@%s>", time.Now().UnixNano(), GetRandomString(12), domain), nil
+}
+
+func parseEmailRecipients(raw string) (string, []string, error) {
+	parts := strings.Split(raw, ";")
+	headerAddresses := make([]string, 0, len(parts))
+	recipients := make([]string, 0, len(parts))
+	for _, part := range parts {
+		candidate := strings.TrimSpace(part)
+		if candidate == "" {
+			return "", nil, fmt.Errorf("email recipient is empty")
+		}
+		address, err := mail.ParseAddress(candidate)
+		if err != nil {
+			return "", nil, fmt.Errorf("invalid email recipient: %w", err)
+		}
+		headerAddresses = append(headerAddresses, address.String())
+		recipients = append(recipients, address.Address)
+	}
+	return strings.Join(headerAddresses, ", "), recipients, nil
 }
 
 func shouldUseSMTPLoginAuth() bool {
@@ -79,6 +103,14 @@ func SendEmail(subject string, receiver string, content string) error {
 	if SMTPFrom == "" { // for compatibility
 		SMTPFrom = SMTPAccount
 	}
+	sender, err := mail.ParseAddress(SMTPFrom)
+	if err != nil {
+		return fmt.Errorf("invalid SMTP sender: %w", err)
+	}
+	toHeader, recipients, err := parseEmailRecipients(receiver)
+	if err != nil {
+		return err
+	}
 	id, err2 := generateMessageID()
 	if err2 != nil {
 		return err2
@@ -87,17 +119,16 @@ func SendEmail(subject string, receiver string, content string) error {
 		return fmt.Errorf("SMTP 服务器未配置")
 	}
 	encodedSubject := fmt.Sprintf("=?UTF-8?B?%s?=", base64.StdEncoding.EncodeToString([]byte(subject)))
+	fromHeader := (&mail.Address{Name: SystemName, Address: sender.Address}).String()
 	mail := []byte(fmt.Sprintf("To: %s\r\n"+
-		"From: %s <%s>\r\n"+
+		"From: %s\r\n"+
 		"Subject: %s\r\n"+
 		"Date: %s\r\n"+
 		"Message-ID: %s\r\n"+ // 添加 Message-ID 头
 		"Content-Type: text/html; charset=UTF-8\r\n\r\n%s\r\n",
-		receiver, SystemName, SMTPFrom, encodedSubject, time.Now().Format(time.RFC1123Z), id, content))
+		toHeader, fromHeader, encodedSubject, time.Now().Format(time.RFC1123Z), id, content))
 	auth := getSMTPAuth()
 	addr := fmt.Sprintf("%s:%d", SMTPServer, SMTPPort)
-	to := strings.Split(receiver, ";")
-	var err error
 	client, err := newSMTPClient(addr)
 	if err != nil {
 		return err
@@ -108,10 +139,10 @@ func SendEmail(subject string, receiver string, content string) error {
 			return err
 		}
 	}
-	if err = client.Mail(SMTPFrom); err != nil {
+	if err = client.Mail(sender.Address); err != nil {
 		return err
 	}
-	for _, receiver := range to {
+	for _, receiver := range recipients {
 		if err = client.Rcpt(receiver); err != nil {
 			return err
 		}

--- a/apps/api-go/common/email_security_test.go
+++ b/apps/api-go/common/email_security_test.go
@@ -1,0 +1,23 @@
+package common
+
+import "testing"
+
+func TestParseEmailRecipientsRejectsHeaderInjection(t *testing.T) {
+	_, _, err := parseEmailRecipients("victim@example.com\r\nBcc: attacker@example.com")
+	if err == nil {
+		t.Fatal("recipient containing an injected header was accepted")
+	}
+}
+
+func TestParseEmailRecipientsBuildsCanonicalHeaderAndEnvelope(t *testing.T) {
+	header, recipients, err := parseEmailRecipients("first@example.com; second@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if header != "<first@example.com>, <second@example.com>" {
+		t.Fatalf("header = %q", header)
+	}
+	if len(recipients) != 2 || recipients[0] != "first@example.com" || recipients[1] != "second@example.com" {
+		t.Fatalf("recipients = %#v", recipients)
+	}
+}

--- a/apps/api-go/common/rate-limit.go
+++ b/apps/api-go/common/rate-limit.go
@@ -65,7 +65,10 @@ func (l *InMemoryRateLimiter) Request(key string, maxRequestNum int, duration in
 			}
 		}
 	} else {
-		s := make([]int64, 0, maxRequestNum)
+		// Grow with actual traffic instead of reserving an administrator-provided
+		// maximum up front. A large limit must not turn one request into a large
+		// allocation.
+		s := make([]int64, 0, 1)
 		l.store[key] = &s
 		*(l.store[key]) = append(*(l.store[key]), now)
 	}

--- a/apps/api-go/common/rate_limit_test.go
+++ b/apps/api-go/common/rate_limit_test.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestInMemoryRateLimiterDoesNotPreallocateConfiguredMaximum(t *testing.T) {
+	limiter := &InMemoryRateLimiter{}
+	limiter.Init(time.Minute)
+
+	if !limiter.Request("user", math.MaxInt, 60) {
+		t.Fatal("first request was unexpectedly rejected")
+	}
+	if queue := limiter.store["user"]; queue == nil || len(*queue) != 1 {
+		t.Fatalf("stored queue length = %v, want 1", queue)
+	}
+}

--- a/apps/api-go/controller/channel.go
+++ b/apps/api-go/controller/channel.go
@@ -1119,7 +1119,9 @@ func UpdateChannel(c *gin.Context) {
 					}
 				}
 
-				seen := make(map[string]struct{}, len(existingKeys)+len(newKeys))
+				// Avoid combining attacker-influenced lengths in an allocation hint.
+				// The map grows only for keys that survive normalization.
+				seen := make(map[string]struct{})
 				for _, key := range existingKeys {
 					normalized := strings.TrimSpace(key)
 					if normalized == "" {

--- a/apps/api-go/controller/misc.go
+++ b/apps/api-go/controller/misc.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/QuantumNous/new-api/common"
@@ -357,12 +359,19 @@ func SendPasswordResetEmail(c *gin.Context) {
 	if _, err := model.GetUniqueUserByEmail(email); err == nil {
 		code := common.GenerateVerificationCode(0)
 		common.RegisterVerificationCodeWithKey(email, code, common.PasswordResetPurpose)
-		link := fmt.Sprintf("%s/user/reset?email=%s&token=%s", system_setting.ServerAddress, email, code)
 		subject := fmt.Sprintf("%s密码重置", common.SystemName)
-		content := fmt.Sprintf("<p>您好，你正在进行%s密码重置。</p>"+
-			"<p>点击 <a href='%s'>此处</a> 进行密码重置。</p>"+
-			"<p>如果链接无法点击，请尝试点击下面的链接或将其复制到浏览器中打开：<br> %s </p>"+
-			"<p>重置链接 %d 分钟内有效，如果不是本人操作，请忽略。</p>", common.SystemName, link, link, common.VerificationValidMinutes)
+		content, buildErr := buildPasswordResetEmailContent(
+			system_setting.ServerAddress,
+			common.SystemName,
+			email,
+			code,
+			common.VerificationValidMinutes,
+		)
+		if buildErr != nil {
+			logger.LogError(c.Request.Context(), "failed to build password reset email: "+buildErr.Error())
+			c.JSON(http.StatusOK, gin.H{"success": true, "message": ""})
+			return
+		}
 		err := common.SendEmail(subject, email, content)
 		if err != nil {
 			logger.LogError(c.Request.Context(), fmt.Sprintf("failed to send password reset email to %s: %s", email, err.Error()))
@@ -374,6 +383,28 @@ func SendPasswordResetEmail(c *gin.Context) {
 		"success": true,
 		"message": "",
 	})
+}
+
+func buildPasswordResetEmailContent(serverAddress, systemName, email, token string, validMinutes int) (string, error) {
+	resetURL, err := url.Parse(strings.TrimSpace(serverAddress))
+	if err != nil {
+		return "", fmt.Errorf("invalid server address: %w", err)
+	}
+	if resetURL.Host == "" || (resetURL.Scheme != "http" && resetURL.Scheme != "https") {
+		return "", fmt.Errorf("server address must be an absolute http/https URL")
+	}
+	resetURL.Path = strings.TrimRight(resetURL.Path, "/") + "/user/reset"
+	query := resetURL.Query()
+	query.Set("email", email)
+	query.Set("token", token)
+	resetURL.RawQuery = query.Encode()
+
+	safeSystemName := html.EscapeString(systemName)
+	safeLink := html.EscapeString(resetURL.String())
+	return fmt.Sprintf("<p>您好，你正在进行%s密码重置。</p>"+
+		"<p>点击 <a href=\"%s\">此处</a> 进行密码重置。</p>"+
+		"<p>如果链接无法点击，请尝试点击下面的链接或将其复制到浏览器中打开：<br> %s </p>"+
+		"<p>重置链接 %d 分钟内有效，如果不是本人操作，请忽略。</p>", safeSystemName, safeLink, safeLink, validMinutes), nil
 }
 
 type PasswordResetRequest struct {

--- a/apps/api-go/controller/misc_email_security_test.go
+++ b/apps/api-go/controller/misc_email_security_test.go
@@ -1,0 +1,35 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildPasswordResetEmailContentEscapesAttributesAndQueryValues(t *testing.T) {
+	content, err := buildPasswordResetEmailContent(
+		"https://panel.example.com/base",
+		`<img src=x onerror=alert(1)>`,
+		"alice'o@example.com",
+		"token&next=attacker",
+		10,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, unsafe := range []string{"<img", "alice'o@example.com", "token&next=attacker", "href='"} {
+		if strings.Contains(content, unsafe) {
+			t.Fatalf("email content contains unsafe fragment %q: %s", unsafe, content)
+		}
+	}
+	for _, safe := range []string{"&lt;img", "alice%27o%40example.com", "token%26next%3Dattacker", `href="https://panel.example.com/base/user/reset?`} {
+		if !strings.Contains(content, safe) {
+			t.Fatalf("email content is missing safe fragment %q: %s", safe, content)
+		}
+	}
+}
+
+func TestBuildPasswordResetEmailContentRejectsExecutableServerAddress(t *testing.T) {
+	if _, err := buildPasswordResetEmailContent("javascript:alert(1)", "LMM", "user@example.com", "token", 10); err == nil {
+		t.Fatal("executable server address was accepted")
+	}
+}

--- a/apps/api-go/relay/common/override.go
+++ b/apps/api-go/relay/common/override.go
@@ -1140,7 +1140,9 @@ func resolveHeaderOverrideValueByMapping(context map[string]interface{}, headerN
 	}
 
 	wildcardValue, hasWildcard := mapping["*"]
-	resultTokens := make([]string, 0, len(sourceTokens)+len(appendTokens))
+	// Grow from the values that are actually retained. Adding two
+	// request-derived lengths here could overflow before make is called.
+	resultTokens := make([]string, 0)
 	for _, token := range sourceTokens {
 		replacementRaw, hasReplacement := mapping[token]
 		if !hasReplacement && hasWildcard && !keepOnlyDeclared {

--- a/apps/api-go/router/main.go
+++ b/apps/api-go/router/main.go
@@ -122,10 +122,13 @@ func newFrontendHandler(configuredRoot string) (http.Handler, error) {
 func (handler *frontendHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	requestPath := path.Clean("/" + request.URL.Path)
 	if requestPath != "/" {
-		candidate := filepath.Join(handler.root, filepath.FromSlash(strings.TrimPrefix(requestPath, "/")))
-		if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() {
-			handler.fileServer.ServeHTTP(writer, request)
-			return
+		relativeRequestPath := filepath.FromSlash(strings.TrimPrefix(requestPath, "/"))
+		if filepath.IsLocal(relativeRequestPath) {
+			candidate := filepath.Join(handler.root, relativeRequestPath)
+			if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() {
+				handler.fileServer.ServeHTTP(writer, request)
+				return
+			}
 		}
 	}
 	if isFrontendAssetPath(requestPath) {

--- a/apps/api-go/service/channel.go
+++ b/apps/api-go/service/channel.go
@@ -40,8 +40,15 @@ func DisableChannel(channelError types.ChannelError, reason string) {
 			CloseActiveWebSocketsForChannel(channelError.ChannelId, ChannelDisabledCloseReason)
 		}
 		subject := fmt.Sprintf("通道「%s」（#%d）已被禁用", channelError.ChannelName, channelError.ChannelId)
-		content := fmt.Sprintf("通道「%s」（#%d）已被禁用，原因：%s", channelError.ChannelName, channelError.ChannelId, reason)
-		NotifyRootUser(formatNotifyType(channelError.ChannelId, common.ChannelStatusAutoDisabled), subject, content)
+		content := "通道「{{value}}」（#{{value}}）已被禁用，原因：{{value}}"
+		NotifyRootUser(
+			formatNotifyType(channelError.ChannelId, common.ChannelStatusAutoDisabled),
+			subject,
+			content,
+			channelError.ChannelName,
+			channelError.ChannelId,
+			reason,
+		)
 	}
 }
 

--- a/apps/api-go/service/user_notify.go
+++ b/apps/api-go/service/user_notify.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"strings"
@@ -13,9 +14,9 @@ import (
 	"github.com/QuantumNous/new-api/setting/system_setting"
 )
 
-func NotifyRootUser(t string, subject string, content string) {
+func NotifyRootUser(t string, subject string, content string, values ...interface{}) {
 	user := model.GetRootUser().ToBaseUser()
-	err := NotifyUser(user.Id, user.Email, user.GetSetting(), dto.NewNotify(t, subject, content, nil))
+	err := NotifyUser(user.Id, user.Email, user.GetSetting(), dto.NewNotify(t, subject, content, values))
 	if err != nil {
 		common.SysLog(fmt.Sprintf("failed to notify root user: %s", err.Error()))
 	}
@@ -105,13 +106,17 @@ func NotifyUser(userId int, userEmail string, userSetting dto.UserSetting, data 
 }
 
 func sendEmailNotify(userEmail string, data dto.Notify) error {
-	// make email content
-	content := data.Content
-	// 处理占位符
-	for _, value := range data.Values {
-		content = strings.Replace(content, dto.ContentValueParam, fmt.Sprintf("%v", value), 1)
-	}
+	content := renderEmailNotification(data.Content, data.Values)
 	return common.SendEmail(data.Title, userEmail, content)
+}
+
+func renderEmailNotification(contentTemplate string, values []interface{}) string {
+	content := contentTemplate
+	for _, value := range values {
+		escapedValue := html.EscapeString(fmt.Sprintf("%v", value))
+		content = strings.Replace(content, dto.ContentValueParam, escapedValue, 1)
+	}
+	return content
 }
 
 func sendBarkNotify(barkURL string, data dto.Notify) error {

--- a/apps/api-go/service/user_notify_test.go
+++ b/apps/api-go/service/user_notify_test.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderEmailNotificationEscapesValuesButPreservesTemplateMarkup(t *testing.T) {
+	content := renderEmailNotification(
+		`Quota low.<br/>Recharge: <a href="{{value}}">{{value}}</a>`,
+		[]interface{}{`https://example.com/' onclick='alert(1)`, `<script>alert(1)</script>`},
+	)
+
+	if !strings.Contains(content, `<a href="https://example.com/&#39; onclick=&#39;alert(1)">`) {
+		t.Fatalf("trusted template markup was not preserved: %s", content)
+	}
+	if strings.Contains(content, "<script>") || !strings.Contains(content, "&lt;script&gt;") {
+		t.Fatalf("notification value was not escaped: %s", content)
+	}
+}

--- a/apps/api-rust/tests/behavior-oracle/fixtures/relay_misc_provider.py
+++ b/apps/api-rust/tests/behavior-oracle/fixtures/relay_misc_provider.py
@@ -53,9 +53,10 @@ class Fixture(http.server.BaseHTTPRequestHandler):
         length = int(self.headers.get("content-length", "0"))
         raw_body = self.rfile.read(length)
         record = {
-            "authorization": self.headers.get("authorization", ""),
+            "authorization_valid": self.headers.get("authorization", "")
+            == "Bearer provider-owned-secret",
             "body": json.loads(raw_body),
-            "caller_secret": self.headers.get("x-caller-secret", ""),
+            "caller_secret_present": bool(self.headers.get("x-caller-secret", "")),
             "content_encoding": self.headers.get("content-encoding", ""),
             "content_type": self.headers.get("content-type", ""),
             "path": self.path,
@@ -65,7 +66,7 @@ class Fixture(http.server.BaseHTTPRequestHandler):
                 output.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
                 output.write("\n")
 
-        if record["authorization"] != "Bearer provider-owned-secret":
+        if not record["authorization_valid"]:
             self.send_response(400)
             self.send_header("content-type", "application/json")
             self.end_headers()

--- a/apps/api-rust/tests/behavior-oracle/tests/relay-misc-pg-listener-differential.sh
+++ b/apps/api-rust/tests/behavior-oracle/tests/relay-misc-pg-listener-differential.sh
@@ -536,8 +536,8 @@ fi
 jq -s -e '
   length == 2 and .[0] == .[1]
   and .[0].path == "/v1/embeddings"
-  and .[0].authorization == "Bearer provider-owned-secret"
-  and .[0].caller_secret == ""
+  and .[0].authorization_valid == true
+  and .[0].caller_secret_present == false
   and .[0].content_type == "application/json"
   and .[0].body == {model:"gpt-test",input:"hello"}
 ' "$runtime/provider-hits.jsonl" >/dev/null
@@ -725,8 +725,8 @@ jq -s -e '
   and .[14] == .[15]
   and all(.[];
     .path == "/v1/embeddings"
-    and .authorization == "Bearer provider-owned-secret"
-    and .caller_secret == ""
+    and .authorization_valid == true
+    and .caller_secret_present == false
     and .content_encoding == "")
   and [.[2].body.input,.[4].body.input,.[6].body.input]
     == ["compressed-gzip","compressed-br","compressed-zstd"]

--- a/apps/web/src/components/ai-elements/web-preview-url.ts
+++ b/apps/web/src/components/ai-elements/web-preview-url.ts
@@ -16,23 +16,17 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import DOMPurify from 'dompurify'
+export function sanitizeWebPreviewUrl(rawUrl: string): string | undefined {
+  const candidate = rawUrl.trim()
+  if (!candidate) return undefined
 
-/**
- * Get plain text preview (strip HTML tags and Markdown formatting)
- */
-export function getPreviewText(
-  content: string,
-  maxLength: number = 60
-): string {
-  if (!content) return ''
-  const plainText = DOMPurify.sanitize(content, {
-    ALLOWED_TAGS: [],
-    ALLOWED_ATTR: [],
-  })
-    .replaceAll(/[#*_]/g, '') // Remove Markdown formatting symbols
-    .trim()
-  return plainText.length > maxLength
-    ? `${plainText.slice(0, maxLength)}...`
-    : plainText
+  try {
+    const parsed = new URL(candidate)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return undefined
+    }
+    return encodeURI(parsed.href)
+  } catch {
+    return undefined
+  }
 }

--- a/apps/web/src/components/ai-elements/web-preview.test.ts
+++ b/apps/web/src/components/ai-elements/web-preview.test.ts
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { sanitizeWebPreviewUrl } from './web-preview-url'
+
+test('sanitizeWebPreviewUrl accepts absolute HTTP URLs', () => {
+  assert.equal(
+    sanitizeWebPreviewUrl(' https://example.com/docs?q=1 '),
+    'https://example.com/docs?q=1'
+  )
+})
+
+test('sanitizeWebPreviewUrl rejects executable and inline-document schemes', () => {
+  for (const value of [
+    'javascript:alert(document.domain)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+  ]) {
+    assert.equal(sanitizeWebPreviewUrl(value), undefined)
+  }
+})
+
+test('sanitizeWebPreviewUrl rejects relative and malformed URLs', () => {
+  assert.equal(sanitizeWebPreviewUrl('/same-origin-admin'), undefined)
+  assert.equal(sanitizeWebPreviewUrl('not a url'), undefined)
+})

--- a/apps/web/src/components/ai-elements/web-preview.tsx
+++ b/apps/web/src/components/ai-elements/web-preview.tsx
@@ -45,6 +45,8 @@ import {
 import dayjs from '@/lib/dayjs'
 import { cn } from '@/lib/utils'
 
+import { sanitizeWebPreviewUrl } from './web-preview-url'
+
 export type WebPreviewContextValue = {
   url: string
   setUrl: (url: string) => void
@@ -211,11 +213,12 @@ export const WebPreviewBody = ({
   return (
     <div className='flex-1'>
       <iframe
-        className={cn('size-full', className)}
-        sandbox='allow-scripts allow-same-origin allow-forms allow-popups allow-presentation'
-        src={(src ?? url) || undefined}
-        title={t('Preview')}
         {...props}
+        className={cn('size-full', className)}
+        referrerPolicy='no-referrer'
+        sandbox='allow-scripts allow-forms allow-popups allow-presentation'
+        src={sanitizeWebPreviewUrl(src ?? url)}
+        title={t('Preview')}
       />
       {loading}
     </div>

--- a/apps/web/src/features/dashboard/lib/text.test.ts
+++ b/apps/web/src/features/dashboard/lib/text.test.ts
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { after, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+
+const domWindow = new Window()
+Object.defineProperty(globalThis, 'window', {
+  configurable: true,
+  value: domWindow,
+})
+
+const { getPreviewText } = await import('./text')
+
+after(() => domWindow.close())
+
+test('getPreviewText removes nested markup without rebuilding a script tag', () => {
+  const preview = getPreviewText('<scr<script>ipt>alert(1)</scr</script>ipt>')
+
+  assert.doesNotMatch(preview, /</)
+  assert.match(preview, /&lt;\/script&gt;/)
+  assert.match(preview, /alert\(1\)/)
+})
+
+test('getPreviewText preserves ordinary text and applies the length limit', () => {
+  assert.equal(getPreviewText('<strong>Hello</strong> world', 8), 'Hello wo...')
+})


### PR DESCRIPTION
## What changed

- validate and canonicalize SMTP sender/recipient addresses to prevent header injection
- safely construct password-reset links and escape dynamic HTML notification values
- remove attacker-influenced allocation capacities and guard frontend file paths with `filepath.IsLocal`
- restrict web-preview URLs to absolute HTTP(S), tighten iframe sandboxing, and replace incomplete tag stripping with DOMPurify
- stop the Rust behavior-oracle fixture from persisting raw authorization secrets
- add focused regression tests for the repaired attack paths

## Why

GitHub CodeQL reported nine actionable paths across the Go API, web frontend, and Rust behavior-oracle fixture. The root causes were unvalidated values reaching security-sensitive sinks, allocation hints derived from externally configurable sizes, an incomplete regex sanitizer, and test logging of raw credentials.

Seventeen additional alerts were separately reviewed and dismissed with audit comments because they are test-only constants, protocol-mandated signing hashes, privileged operator-controlled provider URLs, already SSRF-protected requests, or the documented local HTTP cookie compatibility mode.

## Impact

Malicious email headers, executable iframe URLs, crafted HTML, unsafe file paths, and extreme allocation sizes are rejected or neutralized while preserving normal SMTP delivery, HTTP(S) previews, provider configuration, and local development behavior.

## Validation

- `go test ./...`
- `go vet ./...`
- `bun run typecheck`
- `bun run lint`
- `bun test src` (354 passing)
- `bun run format:check`
- `bun run build:check`
- `bun run bundle:check`
- `git diff --check`

The Go/Rust PostgreSQL differential script reaches the provider assertions but still reports the pre-existing `group_ratio` snapshot difference (`0.9` in Go versus `0.97` in Rust), outside the files changed here.

## Summary by Sourcery

解决电子邮件处理、网页预览、速率限制、头部覆盖映射以及 behavior-oracle fixtures 中的安全代码扫描警报。

Bug Fixes（错误修复）：
- 校验并规范化 SMTP 发件人和收件人地址，防止头部注入和错误的邮件封套。
- 从绝对 HTTP(S) 服务器 URL 安全构造密码重置链接，并在密码重置和通知邮件中对动态 HTML 值进行转义。
- 将前端文件服务限制在本地且已验证的路径上，避免不安全的文件系统访问。
- 通过将预览 URL 清洗为绝对 HTTP(S)，并强化 sandbox 和 referrer 行为，收紧基于 iframe 的网页预览。
- 防止攻击者控制的配置驱动内存速率限制器和头部覆盖映射中的大规模预分配。
- 阻止 behavior-oracle fixtures 持久化原始授权和调用方秘钥值，仅存储有效性和存在性指示器。

Enhancements（增强改进）：
- 在自动禁用通道通知中对值进行模板化和转义，同时保留预期的标记格式。

Tests（测试）：
- 添加针对密码重置邮件构造、邮件收件人解析、通知渲染、速率限制器分配行为以及可执行服务器地址拒绝的 Go 单元测试。
- 添加前端测试，用于网页预览 URL 清洗以及基于 DOMPurify 的文本预览，以覆盖此前可被利用的 HTML 与脚本注入路径。
- 更新 Rust behavior-oracle 差分测试，使其断言非敏感的授权有效性和调用方秘钥存在标志，而非原始秘钥本身。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve security code scanning alerts across email handling, web previews, rate limiting, header override mapping, and behavior-oracle fixtures.

Bug Fixes:
- Validate and canonicalize SMTP sender and recipient addresses to prevent header injection and malformed envelopes.
- Safely construct password-reset links from absolute HTTP(S) server URLs and escape dynamic HTML values in password reset and notification emails.
- Restrict frontend file serving to local, validated paths to avoid unsafe filesystem access.
- Tighten iframe-based web previews by sanitizing preview URLs to absolute HTTP(S) and hardening sandbox and referrer behavior.
- Prevent attacker-controlled configuration from driving large preallocations in the in-memory rate limiter and header override mappings.
- Stop behavior-oracle fixtures from persisting raw authorization and caller secret values, storing only validity and presence indicators instead.

Enhancements:
- Template and escape values in auto-disable channel notifications while preserving expected markup formatting.

Tests:
- Add focused Go unit tests for password reset email construction, email recipient parsing, notification rendering, rate limiter allocation behavior, and executable server address rejection.
- Add frontend tests for web preview URL sanitization and DOMPurify-based text previews to cover previously exploitable HTML and script injection paths.
- Update Rust behavior-oracle differential tests to assert on non-sensitive authorization validity and caller secret presence flags instead of raw secrets.

</details>

Bug Fixes（错误修复）:
- 校验并规范化 SMTP 发件人和收件人地址，并在密码重置和通知邮件中转义动态值，以防止邮件头注入以及 HTML/脚本注入。
- 将前端文件服务限制为本地且已验证的路径，并对网页预览中使用的绝对 HTTP(S) URL 实施安全校验和更严格的沙箱限制，以避免路径遍历和可执行的 iframe URL。
- 用基于 DOMPurify 的净化替换仪表盘预览中临时拼凑的 HTML 去除逻辑，从富文本内容中安全地提取纯文本摘要。
- 确保内存中的限流器和头部映射工具不再预先分配或合并受攻击者影响的容量，以避免过度内存分配。
- 停止在 Rust 的 behavior-oracle 测试夹具中持久化原始授权凭证，改为只跟踪其有效性和存在标记。

Enhancements（增强改进）:
- 收紧通道停用通知的处理，改为使用模板化内容，并对其中的值进行安全转义，同时保留预期的标记格式。

Tests（测试）:
- 为邮件收件人解析、密码重置链接构造、通知渲染以及限流器分配行为新增有针对性的 Go 单元测试。
- 为安全网页预览 URL 净化以及基于 DOMPurify 的文本预览新增前端测试，以覆盖之前的攻击路径。
- 更新 Rust behavior-oracle 的差分测试，使其对非敏感授权信息以及调用方密钥指示器进行断言，而不是对原始值进行断言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决电子邮件处理、网页预览、速率限制、头部覆盖映射以及 behavior-oracle fixtures 中的安全代码扫描警报。

Bug Fixes（错误修复）：
- 校验并规范化 SMTP 发件人和收件人地址，防止头部注入和错误的邮件封套。
- 从绝对 HTTP(S) 服务器 URL 安全构造密码重置链接，并在密码重置和通知邮件中对动态 HTML 值进行转义。
- 将前端文件服务限制在本地且已验证的路径上，避免不安全的文件系统访问。
- 通过将预览 URL 清洗为绝对 HTTP(S)，并强化 sandbox 和 referrer 行为，收紧基于 iframe 的网页预览。
- 防止攻击者控制的配置驱动内存速率限制器和头部覆盖映射中的大规模预分配。
- 阻止 behavior-oracle fixtures 持久化原始授权和调用方秘钥值，仅存储有效性和存在性指示器。

Enhancements（增强改进）：
- 在自动禁用通道通知中对值进行模板化和转义，同时保留预期的标记格式。

Tests（测试）：
- 添加针对密码重置邮件构造、邮件收件人解析、通知渲染、速率限制器分配行为以及可执行服务器地址拒绝的 Go 单元测试。
- 添加前端测试，用于网页预览 URL 清洗以及基于 DOMPurify 的文本预览，以覆盖此前可被利用的 HTML 与脚本注入路径。
- 更新 Rust behavior-oracle 差分测试，使其断言非敏感的授权有效性和调用方秘钥存在标志，而非原始秘钥本身。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve security code scanning alerts across email handling, web previews, rate limiting, header override mapping, and behavior-oracle fixtures.

Bug Fixes:
- Validate and canonicalize SMTP sender and recipient addresses to prevent header injection and malformed envelopes.
- Safely construct password-reset links from absolute HTTP(S) server URLs and escape dynamic HTML values in password reset and notification emails.
- Restrict frontend file serving to local, validated paths to avoid unsafe filesystem access.
- Tighten iframe-based web previews by sanitizing preview URLs to absolute HTTP(S) and hardening sandbox and referrer behavior.
- Prevent attacker-controlled configuration from driving large preallocations in the in-memory rate limiter and header override mappings.
- Stop behavior-oracle fixtures from persisting raw authorization and caller secret values, storing only validity and presence indicators instead.

Enhancements:
- Template and escape values in auto-disable channel notifications while preserving expected markup formatting.

Tests:
- Add focused Go unit tests for password reset email construction, email recipient parsing, notification rendering, rate limiter allocation behavior, and executable server address rejection.
- Add frontend tests for web preview URL sanitization and DOMPurify-based text previews to cover previously exploitable HTML and script injection paths.
- Update Rust behavior-oracle differential tests to assert on non-sensitive authorization validity and caller secret presence flags instead of raw secrets.

</details>

</details>