### PR TITLE
fix: restrict assistant admin config/pricing changes to root

### DIFF
--- a/apps/api-go/controller/assistant_admin.go
+++ b/apps/api-go/controller/assistant_admin.go
@@ -382,6 +382,14 @@ func assistantAdminUser(userID int) (*model.UserBase, error) {
 	return user, nil
 }
 
+func assistantRootUser(userID int) (*model.UserBase, error) {
+	user, err := assistantAdminUser(userID)
+	if err != nil || user.Role < common.RoleRootUser {
+		return nil, errors.New("root administrator access is required")
+	}
+	return user, nil
+}
+
 func assistantAdminConfiguredGroups() map[string]string {
 	groups := setting.GetUserUsableGroupsCopy()
 	for group := range ratio_setting.GetGroupRatioCopy() {
@@ -1181,7 +1189,7 @@ func createAssistantAdminFlow(c *gin.Context, userID int, payload assistantAdmin
 }
 
 func executeAssistantAdminConfigTool(c *gin.Context, userID int) map[string]any {
-	user, err := assistantAdminUser(userID)
+	user, err := assistantRootUser(userID)
 	if err != nil {
 		return map[string]any{"ok": false, "error": err.Error()}
 	}
@@ -1206,7 +1214,7 @@ func executeAssistantAdminConfigTool(c *gin.Context, userID int) map[string]any 
 }
 
 func executeAssistantAdminConfigChangeTool(c *gin.Context, userID int, input map[string]any) map[string]any {
-	if _, err := assistantAdminUser(userID); err != nil {
+	if _, err := assistantRootUser(userID); err != nil {
 		return map[string]any{"ok": false, "error": err.Error()}
 	}
 	changes, err := assistantAdminConfigChanges(input)
@@ -1416,7 +1424,7 @@ func assistantAdminPricingPreview(change assistantAdminPricingChange) map[string
 }
 
 func executeAssistantAdminPricingChangeTool(c *gin.Context, userID int, input map[string]any) map[string]any {
-	if _, err := assistantAdminUser(userID); err != nil {
+	if _, err := assistantRootUser(userID); err != nil {
 		return map[string]any{"ok": false, "error": err.Error()}
 	}
 	modelID := inputString(input, "model_id")
@@ -1791,6 +1799,12 @@ func ApplyAssistantAdminChange(c *gin.Context) {
 	if err := json.Unmarshal([]byte(flow.Payload), &payload); err != nil {
 		writeAssistantError(c, http.StatusInternalServerError, "ASSISTANT_ADMIN_CHANGE_INVALID", errors.New("administrator preview could not be decoded"))
 		return
+	}
+	if payload.Kind == assistantAdminConfigChangeKind || payload.Kind == assistantAdminPricingChangeKind {
+		if _, err := assistantRootUser(user.Id); err != nil {
+			writeAssistantError(c, http.StatusForbidden, "ASSISTANT_ROOT_REQUIRED", err)
+			return
+		}
 	}
 	if err := applyAssistantAdminChange(c, payload); err != nil {
 		writeAssistantError(c, http.StatusUnprocessableEntity, "ASSISTANT_ADMIN_CHANGE_FAILED", err)

--- a/apps/api-go/controller/assistant_admin_test.go
+++ b/apps/api-go/controller/assistant_admin_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/model"
@@ -80,7 +81,7 @@ func TestAssistantAdminPricingPreviewAndApplyUpdatesRuntimeRates(t *testing.T) {
 	admin := model.User{
 		Username: "assistant-admin-pricing-apply",
 		Password: "password",
-		Role:     common.RoleAdminUser,
+		Role:     common.RoleRootUser,
 		Status:   common.UserStatusEnabled,
 		Group:    "default",
 	}
@@ -263,7 +264,7 @@ func TestAssistantAdminPreviewIsSessionBoundAndOneTime(t *testing.T) {
 	user := model.User{
 		Username: "assistant-admin-apply",
 		Password: "password",
-		Role:     common.RoleAdminUser,
+		Role:     common.RoleRootUser,
 		Status:   common.UserStatusEnabled,
 		Group:    "default",
 	}
@@ -325,6 +326,51 @@ func TestAssistantAdminPreviewIsSessionBoundAndOneTime(t *testing.T) {
 	replayContext.Set("session_id", "admin-browser-session")
 	ApplyAssistantAdminChange(replayContext)
 	require.Equal(t, http.StatusUnprocessableEntity, replayRecorder.Code)
+}
+
+func TestAssistantConfigChangesRequireRootAdministrator(t *testing.T) {
+	db := setupTokenControllerTestDB(t)
+	require.NoError(t, db.AutoMigrate(&model.User{}, &model.Option{}, &model.AuthFlow{}))
+	admin := model.User{
+		Username: "assistant-non-root-admin",
+		Password: "password",
+		Role:     common.RoleAdminUser,
+		Status:   common.UserStatusEnabled,
+		Group:    "default",
+	}
+	require.NoError(t, db.Create(&admin).Error)
+
+	previewContext, _ := gin.CreateTestContext(httptest.NewRecorder())
+	previewContext.Set("session_id", "non-root-admin-session")
+	preview := executeAssistantAdminConfigChangeTool(previewContext, admin.Id, map[string]any{
+		"changes": map[string]any{"RegisterEnabled": false},
+	})
+	require.Equal(t, false, preview["ok"])
+	require.Contains(t, preview["error"], "root administrator access is required")
+
+	payload, err := json.Marshal(assistantAdminChangePayload{
+		Kind:           assistantAdminConfigChangeKind,
+		ConfigChanges:  map[string]string{"RegisterEnabled": "false"},
+		ConfigExpected: map[string]string{"RegisterEnabled": "true"},
+	})
+	require.NoError(t, err)
+	token, _, err := model.CreateAuthFlow(model.AuthFlowCreate{
+		Purpose:   model.AuthFlowPurposeAssistantAdmin,
+		UserId:    admin.Id,
+		SessionId: "non-root-admin-session",
+		Payload:   string(payload),
+		ExpiresAt: time.Now().Add(time.Minute),
+	})
+	require.NoError(t, err)
+
+	applyRecorder := httptest.NewRecorder()
+	applyContext, _ := gin.CreateTestContext(applyRecorder)
+	applyContext.Request = httptest.NewRequest(http.MethodPost, "/api/assistant/admin/apply", strings.NewReader(`{"confirmed":true,"confirmation_token":"`+token+`"}`))
+	applyContext.Request.Header.Set("Content-Type", "application/json")
+	applyContext.Set("id", admin.Id)
+	applyContext.Set("session_id", "non-root-admin-session")
+	ApplyAssistantAdminChange(applyContext)
+	require.Equal(t, http.StatusForbidden, applyRecorder.Code)
 }
 
 func float64Pointer(value float64) *float64 {


### PR DESCRIPTION
### Motivation
- The assistant admin flow allowed any user with `RoleAdminUser` to prepare and apply changes to options that are intended to be root-only, creating an authorization bypass for global server configuration and pricing.

### Description
- Add `assistantRootUser(userID int)` which requires `RoleRootUser` and reuse it as a root-only authorization helper. 
- Require root access in configuration discovery and preparation paths by switching `executeAssistantAdminConfigTool` and `executeAssistantAdminConfigChangeTool` to call `assistantRootUser` instead of `assistantAdminUser`.
- Require root access for pricing changes by switching `executeAssistantAdminPricingChangeTool` to call `assistantRootUser`.
- Add a defense-in-depth check in `ApplyAssistantAdminChange` to verify the requester is a root administrator before applying `assistantAdminConfigChangeKind` or `assistantAdminPricingChangeKind` payloads consumed from the confirmation token.
- Add regression test `TestAssistantConfigChangesRequireRootAdministrator` and update existing assistant admin tests to use root accounts where appropriate so they exercise the corrected authorization.

### Testing
- Ran targeted unit tests: `go test ./controller -run 'TestAssistant(AdminPricingPreviewAndApplyUpdatesRuntimeRates|AdminChannelPreviewKeepsProviderSecretsOut|AdminPreviewIsSessionBoundAndOneTime|ConfigChangesRequireRootAdministrator)$'` and they passed.
- Ran the full controller test suite `go test ./controller` which passed.
- Performed formatting and diff checks (`gofmt` and `git diff --check`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c5195c1808320b72d57523cd0a0c9)

## Summary by Sourcery

要求具有根管理员权限才能进行助手管理配置和定价更改，并为更新后的授权行为添加回归测试覆盖。

Bug Fixes:
- 防止非根管理员准备和应用影响全局服务器选项的助手配置更改。
- 防止非根管理员准备和应用助手定价更改。

Enhancements:
- 引入专用辅助工具，在助手管理流程中强制要求根管理员访问权限。
- 在根据确认令牌应用助手管理配置和定价更改时，添加纵深防御的授权检查。

Tests:
- 添加回归测试，确保非根管理员的助手配置更改会被拒绝，并在适当情况下更新现有的助手管理测试以使用根账户。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Require root administrator privileges for assistant admin configuration and pricing changes and add regression coverage for the updated authorization behavior.

Bug Fixes:
- Prevent non-root administrators from preparing and applying assistant configuration changes that affect global server options.
- Prevent non-root administrators from preparing and applying assistant pricing changes.

Enhancements:
- Introduce a dedicated helper to enforce root administrator access in assistant admin flows.
- Add a defense-in-depth authorization check when applying assistant admin configuration and pricing changes from confirmation tokens.

Tests:
- Add a regression test ensuring assistant configuration changes are rejected for non-root administrators and update existing assistant admin tests to use root accounts where appropriate.

</details>