### PR TITLE
fix(assistant): shell-quote setup values to prevent shell-injection

### DIFF
--- a/apps/api-go/controller/assistant_agent.go
+++ b/apps/api-go/controller/assistant_agent.go
@@ -800,6 +800,18 @@ func executeAssistantAccountTool(userID int) map[string]any {
 	}
 }
 
+// quotePOSIXShellLiteral returns a single shell word without leaving any part of
+// value open to expansion or command substitution.
+func quotePOSIXShellLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+// quotePowerShellLiteral returns a single-quoted PowerShell string. PowerShell
+// represents a literal apostrophe inside such a string as two apostrophes.
+func quotePowerShellLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}
+
 func executeAssistantSetupTool(input map[string]any) map[string]any {
 	platform := strings.ToLower(strings.TrimSpace(inputString(input, "platform")))
 	topic := strings.ToLower(strings.TrimSpace(inputString(input, "topic")))
@@ -836,10 +848,10 @@ func executeAssistantSetupTool(input map[string]any) map[string]any {
 	switch topic {
 	case "claude-code":
 		installCommand := "curl -fsSL https://claude.ai/install.sh | bash"
-		configuration := fmt.Sprintf("export ANTHROPIC_BASE_URL=%q\nexport ANTHROPIC_AUTH_TOKEN='<YOUR_API_KEY>'\nexport ANTHROPIC_MODEL=%q\nclaude", rootURL, clientModel)
+		configuration := fmt.Sprintf("export ANTHROPIC_BASE_URL=%s\nexport ANTHROPIC_AUTH_TOKEN='<YOUR_API_KEY>'\nexport ANTHROPIC_MODEL=%s\nclaude", quotePOSIXShellLiteral(rootURL), quotePOSIXShellLiteral(clientModel))
 		if platform == "windows" {
 			installCommand = "winget install Anthropic.ClaudeCode"
-			configuration = fmt.Sprintf("$env:ANTHROPIC_BASE_URL=%q\n$env:ANTHROPIC_AUTH_TOKEN='<YOUR_API_KEY>'\n$env:ANTHROPIC_MODEL=%q\nclaude", rootURL, clientModel)
+			configuration = fmt.Sprintf("$env:ANTHROPIC_BASE_URL=%s\n$env:ANTHROPIC_AUTH_TOKEN='<YOUR_API_KEY>'\n$env:ANTHROPIC_MODEL=%s\nclaude", quotePowerShellLiteral(rootURL), quotePowerShellLiteral(clientModel))
 		} else if platform == "macos" {
 			installCommand = "brew install --cask claude-code"
 		}

--- a/apps/api-go/controller/assistant_test.go
+++ b/apps/api-go/controller/assistant_test.go
@@ -414,8 +414,8 @@ func TestAssistantSetupToolReturnsExactEndpointFormatsAndClientLimits(t *testing
 	assert.Equal(t, "https://api.example.com", claudeCode["service_root"])
 	assert.Equal(t, "https://api.example.com/v1", claudeCode["openai_base_url"])
 	assert.Equal(t, "winget install Anthropic.ClaudeCode", claudeCode["install_command"])
-	assert.Contains(t, claudeCode["configuration"], "ANTHROPIC_BASE_URL=\"https://api.example.com\"")
-	assert.Contains(t, claudeCode["configuration"], "ANTHROPIC_MODEL=\"claude-sonnet-4-5\"")
+	assert.Contains(t, claudeCode["configuration"], "ANTHROPIC_BASE_URL='https://api.example.com'")
+	assert.Contains(t, claudeCode["configuration"], "ANTHROPIC_MODEL='claude-sonnet-4-5'")
 	assert.NotContains(t, claudeCode["configuration"], "api.example.com/v1")
 
 	codex := executeAssistantSetupTool(map[string]any{
@@ -449,6 +449,28 @@ func TestAssistantSetupToolReturnsExactEndpointFormatsAndClientLimits(t *testing
 	})
 	assert.Equal(t, false, claudeDesktopLinux["supported"])
 	assert.Contains(t, claudeDesktopLinux["limitation"], "use Claude Code on Linux")
+}
+
+func TestAssistantSetupToolShellQuotesConfiguredValues(t *testing.T) {
+	originalServerAddress := system_setting.ServerAddress
+	system_setting.ServerAddress = "https://api.example.com/$(touch /tmp/base-pwned)'suffix"
+	t.Cleanup(func() { system_setting.ServerAddress = originalServerAddress })
+
+	linux := executeAssistantSetupTool(map[string]any{
+		"platform": "linux",
+		"topic":    "claude-code",
+		"model_id": "claude-$(touch /tmp/model-pwned)'suffix",
+	})
+	assert.Contains(t, linux["configuration"], "ANTHROPIC_BASE_URL='https://api.example.com/$(touch /tmp/base-pwned)'\"'\"'suffix'")
+	assert.Contains(t, linux["configuration"], "ANTHROPIC_MODEL='claude-$(touch /tmp/model-pwned)'\"'\"'suffix'")
+
+	windows := executeAssistantSetupTool(map[string]any{
+		"platform": "windows",
+		"topic":    "claude-code",
+		"model_id": "claude-$(touch /tmp/model-pwned)'suffix",
+	})
+	assert.Contains(t, windows["configuration"], "ANTHROPIC_BASE_URL='https://api.example.com/$(touch /tmp/base-pwned)''suffix'")
+	assert.Contains(t, windows["configuration"], "ANTHROPIC_MODEL='claude-$(touch /tmp/model-pwned)''suffix'")
 }
 
 func TestAssistantCostToolAndResponseContent(t *testing.T) {


### PR DESCRIPTION
### Motivation
- The assistant setup guidance previously embedded configurable `ServerAddress` and model IDs into copy-paste shell and PowerShell snippets using `fmt.Sprintf` with `%q`, which produced double-quoted Go literals and left command substitution (e.g. `$(...)`) active in user shells.
- This allowed a malicious or compromised operator-controlled setting to inject commands that would execute if a user copy-pasted the returned snippet into a shell.

### Description
- Added `quotePOSIXShellLiteral` and `quotePowerShellLiteral` helpers in `apps/api-go/controller/assistant_agent.go` to produce safe single-quoted POSIX shell words and PowerShell single-quoted strings respectively.
- Replaced `fmt.Sprintf(... %q ...)` usage for Claude Code setup snippets with the new helpers so `ANTHROPIC_BASE_URL` and `ANTHROPIC_MODEL` are emitted as safely quoted literals for POSIX and PowerShell (`'...'`).
- Updated expectations in `apps/api-go/controller/assistant_test.go` to assert single-quoted outputs and added `TestAssistantSetupToolShellQuotesConfiguredValues` to cover malicious payloads containing `$(...)` and embedded apostrophes.
- Ran `gofmt` on modified files to normalize formatting.

### Testing
- Ran the controller package tests with `go test ./controller -run 'TestAssistantSetupTool(ReturnsExactEndpointFormatsAndClientLimits|ShellQuotesConfiguredValues)$' -count=1` and the targeted tests passed (package reported `ok`).
- New regression test `TestAssistantSetupToolShellQuotesConfiguredValues` verifies that values containing `$(...)` and single quotes are safely escaped for both POSIX shell and PowerShell and it succeeded.
- Verified code formatting with `gofmt` and performed `git diff --check` to ensure no whitespace or formatting issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b44ae6ae883209cdf33cc1046d94c)

## Summary by Sourcery

通过在 POSIX 和 PowerShell 平台上安全地引用 Claude Code 的可配置值，防止助手设置代码片段中的命令行注入问题。

Bug Fixes:
- 确保在生成的 shell 和 PowerShell 配置代码片段中，将 `ANTHROPIC_BASE_URL` 和 `ANTHROPIC_MODEL` 作为安全引用的字面量输出，从而阻止恶意配置值中的命令替换和注入。

Enhancements:
- 在构建助手设置配置代码片段时，引入专用的辅助方法，用于对 POSIX shell 和 PowerShell 的字面量进行安全引用。

Tests:
- 扩展助手设置工具的测试，用于断言配置输出为单引号包裹的字面量，并增加对包含命令替换和嵌入单引号的恶意载荷的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent shell-injection in assistant setup snippets by safely quoting configurable values for Claude Code across POSIX and PowerShell platforms.

Bug Fixes:
- Ensure ANTHROPIC_BASE_URL and ANTHROPIC_MODEL in generated shell and PowerShell configuration snippets are emitted as safely quoted literals to block command substitution and injection from malicious configuration values.

Enhancements:
- Introduce dedicated helpers to quote POSIX shell and PowerShell literals when constructing assistant setup configuration snippets.

Tests:
- Extend assistant setup tool tests to assert single-quoted configuration output and add coverage for malicious payloads containing command substitution and embedded apostrophes.

</details>