### PR TITLE
fix(auth): require 2FA for first passkey enrollment

### DIFF
--- a/apps/api-go/controller/passkey_test.go
+++ b/apps/api-go/controller/passkey_test.go
@@ -77,13 +77,10 @@ func TestPasskeyRegisterFinishRejectsMissingOrWrongProofWithoutConsumingFlow(t *
 	}
 	require.NoError(t, db.Create(user).Error)
 	require.NoError(t, db.Create(&model.TwoFA{UserId: user.Id, Secret: "totp-secret", IsEnabled: true}).Error)
-	require.NoError(t, db.Create(&model.PasskeyCredential{
-		UserID: user.Id, CredentialID: "credential-id", PublicKey: "public-key",
-	}).Error)
 	identity := service.AuthIdentity{
 		UserID: user.Id, SessionID: "passkey-proof-session", UserAuthVersion: 1, SessionVersion: 1,
 	}
-	wrongScopeProof, _, err := service.IssueSecurityProof(identity, secureVerificationMethodPasskey, []string{securityProofScopePasskeyDelete})
+	wrongScopeProof, _, err := service.IssueSecurityProof(identity, secureVerificationMethod2FA, []string{securityProofScopePasskeyDelete})
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/apps/api-go/middleware/secure_verification.go
+++ b/apps/api-go/middleware/secure_verification.go
@@ -61,8 +61,8 @@ func RequireSecurityProof(c *gin.Context, requiredScope string, allowedMethods [
 }
 
 // PreferredSecurityProofMethods returns the only proof method accepted for
-// sensitive dashboard actions. Email is the primary path when bound; Passkey
-// remains the compatibility fallback for accounts without a bound email.
+// sensitive dashboard actions. Email is the primary path when bound, followed
+// by an enabled 2FA factor; Passkey is the compatibility fallback otherwise.
 func PreferredSecurityProofMethods(userID int) ([]string, error) {
 	user, err := model.GetUserCache(userID)
 	if err != nil {
@@ -70,6 +70,13 @@ func PreferredSecurityProofMethods(userID int) ([]string, error) {
 	}
 	if model.NormalizeEmail(user.Email) != "" {
 		return []string{"email"}, nil
+	}
+	twoFA, err := model.GetTwoFAByUserId(userID)
+	if err != nil {
+		return nil, err
+	}
+	if twoFA != nil && twoFA.IsEnabled {
+		return []string{"2fa"}, nil
 	}
 	return []string{"passkey"}, nil
 }

--- a/apps/web/src/features/auth/secure-verification/components/secure-verification-dialog.tsx
+++ b/apps/web/src/features/auth/secure-verification/components/secure-verification-dialog.tsx
@@ -16,7 +16,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { ShieldCheck, KeyRound, Loader2, Mail } from 'lucide-react'
+import { ShieldCheck, KeyRound, Loader2, Mail, Smartphone } from 'lucide-react'
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -67,6 +67,7 @@ export function SecureVerificationDialog({
   const availableTabs: VerificationMethod[] = useMemo(() => {
     const tabs: VerificationMethod[] = []
     if (preferredMethods.hasEmail) tabs.push('email')
+    if (preferredMethods.has2FA) tabs.push('2fa')
     if (preferredMethods.hasPasskey) tabs.push('passkey')
     return tabs
   }, [preferredMethods])
@@ -88,7 +89,7 @@ export function SecureVerificationDialog({
     state.description ??
     (availableTabs.length
       ? 'Confirm your identity before accessing this sensitive action.'
-      : 'Bind an email or set up a Passkey before continuing.')
+      : 'Bind an email, enable 2FA, or set up a Passkey before continuing.')
 
   const handleVerify = () => {
     if (!activeMethod) return
@@ -149,7 +150,7 @@ export function SecureVerificationDialog({
           </div>
           <p className='text-muted-foreground text-sm'>
             {t(
-              'Bind an email or set up a Passkey in your profile to unlock sensitive operations.'
+              'Bind an email, enable 2FA, or set up a Passkey in your profile to unlock sensitive operations.'
             )}
           </p>
         </div>
@@ -162,6 +163,11 @@ export function SecureVerificationDialog({
           <TabsList>
             {preferredMethods.hasEmail && (
               <TabsTrigger value='email'>{t('Email verification')}</TabsTrigger>
+            )}
+            {preferredMethods.has2FA && (
+              <TabsTrigger value='2fa'>
+                {t('Two-factor authentication')}
+              </TabsTrigger>
             )}
             {preferredMethods.hasPasskey && (
               <TabsTrigger value='passkey'>{t('Passkey')}</TabsTrigger>
@@ -206,6 +212,32 @@ export function SecureVerificationDialog({
                 {emailCodeSent ? t('Resend code') : t('Send code')}
               </Button>
             </div>
+          </TabsContent>
+
+          <TabsContent value='2fa' className='space-y-3'>
+            <div className='bg-muted/50 flex items-center gap-3 rounded-lg p-4'>
+              <Smartphone className='text-primary h-6 w-6' />
+              <p className='text-muted-foreground text-sm'>
+                {t(
+                  'Enter the code from your authenticator app or a backup code.'
+                )}
+              </p>
+            </div>
+            <Input
+              inputMode='numeric'
+              autoComplete='one-time-code'
+              value={state.code}
+              onChange={(event) => onCodeChange(event.target.value)}
+              placeholder={t('Enter verification code or backup code')}
+              disabled={state.loading}
+              autoFocus={activeMethod === '2fa'}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !verifyDisabled) {
+                  event.preventDefault()
+                  handleVerify()
+                }
+              }}
+            />
           </TabsContent>
 
           <TabsContent value='passkey' className='space-y-4'>

--- a/apps/web/src/features/auth/secure-verification/hooks/use-secure-verification.ts
+++ b/apps/web/src/features/auth/secure-verification/hooks/use-secure-verification.ts
@@ -93,30 +93,42 @@ export function useSecureVerification(
       apiCall: (proofToken?: string) => Promise<unknown>,
       config: StartVerificationOptions
     ) => {
-      const { scope, title, description } = config
+      const { scope, preferredMethod, title, description } = config
       const availableMethods = getPreferredVerificationMethods(
         await fetchVerificationMethods()
       )
 
-      if (!availableMethods.hasEmail && !availableMethods.hasPasskey) {
+      if (
+        !availableMethods.hasEmail &&
+        !availableMethods.has2FA &&
+        !availableMethods.hasPasskey
+      ) {
         toast.error(
           i18next.t(
-            'Please bind an email or set up a Passkey before proceeding'
+            'Please bind an email, enable 2FA, or set up a Passkey before proceeding'
           )
         )
         onError?.(
           new Error(
-            'No verification methods available. Bind an email or set up a Passkey to continue.'
+            'No verification methods available. Bind an email, enable 2FA, or set up a Passkey to continue.'
           )
         )
         return false
       }
 
-      const defaultMethod: VerificationMethod | null = availableMethods.hasEmail
-        ? 'email'
-        : availableMethods.hasPasskey
-          ? 'passkey'
-          : null
+      const preferredMethodAvailable =
+        (preferredMethod === 'email' && availableMethods.hasEmail) ||
+        (preferredMethod === '2fa' && availableMethods.has2FA) ||
+        (preferredMethod === 'passkey' && availableMethods.hasPasskey)
+      const defaultMethod: VerificationMethod | null = preferredMethodAvailable
+        ? (preferredMethod ?? null)
+        : availableMethods.hasEmail
+          ? 'email'
+          : availableMethods.has2FA
+            ? '2fa'
+            : availableMethods.hasPasskey
+              ? 'passkey'
+              : null
 
       setState((prev) => ({
         ...prev,
@@ -246,6 +258,7 @@ export function useSecureVerification(
     (method: VerificationMethod) => {
       const preferredMethods = getPreferredVerificationMethods(methods)
       if (method === 'email') return preferredMethods.hasEmail
+      if (method === '2fa') return preferredMethods.has2FA
       if (method === 'passkey') return preferredMethods.hasPasskey
       return false
     },
@@ -255,6 +268,7 @@ export function useSecureVerification(
   const recommendedMethod = useMemo<VerificationMethod | null>(() => {
     const preferredMethods = getPreferredVerificationMethods(methods)
     if (preferredMethods.hasEmail) return 'email'
+    if (preferredMethods.has2FA) return '2fa'
     if (preferredMethods.hasPasskey) return 'passkey'
     return null
   }, [methods])
@@ -282,7 +296,10 @@ export function useSecureVerification(
     fetchVerificationMethods,
     canUseMethod,
     recommendedMethod,
-    hasAnyMethod: preferredMethods.hasEmail || preferredMethods.hasPasskey,
+    hasAnyMethod:
+      preferredMethods.hasEmail ||
+      preferredMethods.has2FA ||
+      preferredMethods.hasPasskey,
     preferredMethods,
     isLoading: state.loading,
     currentMethod: state.method,

--- a/apps/web/src/features/auth/secure-verification/types.test.ts
+++ b/apps/web/src/features/auth/secure-verification/types.test.ts
@@ -38,10 +38,23 @@ describe('preferred secure verification methods', () => {
     })
   })
 
-  test('falls back to a supported Passkey when no email is bound', () => {
+  test('falls back to 2FA when no email is bound', () => {
     const result = getPreferredVerificationMethods({
       hasEmail: false,
       has2FA: true,
+      hasPasskey: true,
+      passkeySupported: true,
+    })
+
+    assert.equal(result.hasEmail, false)
+    assert.equal(result.has2FA, true)
+    assert.equal(result.hasPasskey, false)
+  })
+
+  test('falls back to a supported Passkey when email and 2FA are unavailable', () => {
+    const result = getPreferredVerificationMethods({
+      hasEmail: false,
+      has2FA: false,
       hasPasskey: true,
       passkeySupported: true,
     })
@@ -51,10 +64,10 @@ describe('preferred secure verification methods', () => {
     assert.equal(result.hasPasskey, true)
   })
 
-  test('fails closed when neither preferred method is usable', () => {
+  test('fails closed when no proof method is usable', () => {
     const result = getPreferredVerificationMethods({
       hasEmail: false,
-      has2FA: true,
+      has2FA: false,
       hasPasskey: true,
       passkeySupported: false,
     })

--- a/apps/web/src/features/auth/secure-verification/types.ts
+++ b/apps/web/src/features/auth/secure-verification/types.ts
@@ -39,9 +39,8 @@ export interface VerificationMethods {
 }
 
 /**
- * Sensitive dashboard actions use email when it is bound and otherwise fall
- * back to the existing Passkey flow. Other account capabilities, such as
- * signing in with 2FA, are intentionally not exposed as step-up methods.
+ * Sensitive dashboard actions use the strongest available independent proof
+ * in a stable order: email, 2FA, then an existing Passkey.
  */
 export function getPreferredVerificationMethods(
   methods: VerificationMethods
@@ -50,6 +49,14 @@ export function getPreferredVerificationMethods(
     return {
       ...methods,
       has2FA: false,
+      hasPasskey: false,
+    }
+  }
+
+  if (methods.has2FA) {
+    return {
+      ...methods,
+      hasEmail: false,
       hasPasskey: false,
     }
   }

--- a/apps/web/src/features/profile/components/passkey-card.tsx
+++ b/apps/web/src/features/profile/components/passkey-card.tsx
@@ -112,7 +112,7 @@ export function PasskeyCard({ loading: pageLoading }: PasskeyCardProps) {
     }
 
     const methods = await fetchVerificationMethods()
-    if (!methods.hasEmail && !methods.hasPasskey) {
+    if (!methods.hasEmail && !methods.has2FA && !methods.hasPasskey) {
       // The first Passkey is the fallback credential itself, so there is no
       // existing Passkey available for a step-up proof yet.
       await register()
@@ -121,7 +121,9 @@ export function PasskeyCard({ loading: pageLoading }: PasskeyCardProps) {
 
     const requiredMethod: VerificationMethod = methods.hasEmail
       ? 'email'
-      : 'passkey'
+      : methods.has2FA
+        ? '2fa'
+        : 'passkey'
     setRestrictedMethod(requiredMethod)
     await startVerification(register, {
       scope: 'passkey.register',


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where a no-email account with 2FA enabled could register a first Passkey without providing a 2FA proof. 

### Description
- Update `PreferredSecurityProofMethods` to prefer an enabled `2fa` method when the account has 2FA enabled (checked via `model.GetTwoFAByUserId`) before falling back to `passkey` in `apps/api-go/middleware/secure_verification.go`.
- Make the profile Passkey enrollment flow respect `has2FA` so the UI triggers a 2FA step-up instead of auto-registering when 2FA is available in `apps/web/src/features/profile/components/passkey-card.tsx`.
- Strengthen the controller test to exercise the first-passkey case for a user with enabled 2FA and no existing Passkey, and to issue a wrong-scope proof using the `2fa` method in `apps/api-go/controller/passkey_test.go`.

### Testing
- Ran the focused controller unit test with `go test ./controller -run '^TestPasskeyRegisterFinishRejectsMissingOrWrongProofWithoutConsumingFlow$' -count=1` and it passed.
- Ran web typechecking and formatting checks with `bun run typecheck` and `bunx oxfmt --check src/features/profile/components/passkey-card.tsx`, both succeeded. 
- Verified repository formatting and lint checks with `git diff --check` which produced no formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a94ede62c8320990873ef897aaeff)

## Summary by Sourcery

在可用的情况下，要求在首次注册通行密钥（passkey）以及相关敏感控制台操作时提供 2FA 安全验证凭证。

Bug Fixes:
- 确保已启用 2FA 的账户在未提供匹配的 2FA 验证凭证时，无法注册其首个通行密钥。

Enhancements:
- 更新安全验证方式选择逻辑，优先使用邮箱，其次使用已启用的 2FA，最后才回退到通行密钥。
- 调整个人资料中的通行密钥注册 UI，当存在可用的 2FA 因子时，改为请求执行 2FA 提升验证步骤，而不是自动注册。
- 强化通行密钥注册控制器测试，用于覆盖在已启用 2FA 的情况下首次注册通行密钥，以及不正确 2FA 验证范围（proof scopes）的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Require 2FA security proof when available for first passkey enrollment and related sensitive dashboard actions.

Bug Fixes:
- Ensure accounts with enabled 2FA cannot register their first passkey without providing a matching 2FA proof.

Enhancements:
- Update security proof method selection to prefer email, then enabled 2FA, before falling back to passkey.
- Adjust profile passkey enrollment UI to request a 2FA step-up when a 2FA factor is available instead of auto-registering.
- Strengthen passkey registration controller tests to cover first-passkey enrollment with enabled 2FA and incorrect 2FA proof scopes.

</details>