### PR TITLE
Harden advanced security guardrails

### DIFF
--- a/apps/api-go/common/email.go
+++ b/apps/api-go/common/email.go
@@ -213,9 +213,9 @@ func buildEmailMessage(toHeader, fromHeader, encodedSubject, date, messageID, co
 	writeEmailHeader(&message, "Date", date)
 	writeEmailHeader(&message, "Message-ID", messageID)
 	writeEmailHeader(&message, "Content-Type", "text/html; charset=UTF-8")
+	writeEmailHeader(&message, "Content-Transfer-Encoding", "base64")
 	message.WriteString("\r\n")
-	message.WriteString(content)
-	message.WriteString("\r\n")
+	writeEmailBodyBase64(&message, content)
 	return message.Bytes(), nil
 }
 
@@ -224,6 +224,26 @@ func writeEmailHeader(message *bytes.Buffer, name, value string) {
 	message.WriteString(": ")
 	message.WriteString(value)
 	message.WriteString("\r\n")
+}
+
+// writeEmailBodyBase64 keeps the MIME body opaque to the SMTP transport. In
+// particular, user-controlled CRLF sequences can never become new MIME lines
+// or headers after the message has been assembled. Mail clients decode the
+// body back to the original UTF-8 HTML before rendering it.
+func writeEmailBodyBase64(message *bytes.Buffer, content string) {
+	encoded := base64.StdEncoding.EncodeToString([]byte(content))
+	for len(encoded) > 0 {
+		lineLength := 76
+		if len(encoded) < lineLength {
+			lineLength = len(encoded)
+		}
+		message.WriteString(encoded[:lineLength])
+		message.WriteString("\r\n")
+		encoded = encoded[lineLength:]
+	}
+	if len(content) == 0 {
+		message.WriteString("\r\n")
+	}
 }
 
 var allowedEmailHTMLTags = map[string]struct{}{

--- a/apps/api-go/common/email_security_test.go
+++ b/apps/api-go/common/email_security_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
 )
@@ -68,8 +69,13 @@ func TestBuildEmailMessageKeepsHTMLBodyAfterHeaders(t *testing.T) {
 	if strings.Contains(parts[0], "Bcc:") {
 		t.Fatalf("body content became a message header: %q", parts[0])
 	}
-	if !strings.HasPrefix(parts[1], content) {
-		t.Fatalf("HTML body was not preserved: %q", parts[1])
+	encodedBody := strings.ReplaceAll(parts[1], "\r\n", "")
+	decodedBody, err := base64.StdEncoding.DecodeString(encodedBody)
+	if err != nil {
+		t.Fatalf("encoded MIME body is invalid: %v", err)
+	}
+	if string(decodedBody) != content {
+		t.Fatalf("HTML body was not preserved after MIME decoding: %q", decodedBody)
 	}
 }
 

--- a/apps/api-go/common/email_test.go
+++ b/apps/api-go/common/email_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
 	"fmt"
 	"math/big"
@@ -267,6 +268,16 @@ func withSMTPSettings(t *testing.T) {
 	})
 }
 
+func requireEmailHTMLBody(t *testing.T, message, expected string) {
+	t.Helper()
+	parts := strings.SplitN(message, "\r\n\r\n", 2)
+	require.Len(t, parts, 2)
+	encoded := strings.ReplaceAll(strings.TrimSpace(parts[1]), "\r\n", "")
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	require.Equal(t, expected, string(decoded))
+}
+
 func TestSendEmailUsesExplicitStartTLSWithInsecureCertificate(t *testing.T) {
 	server := newFakeSMTPServer(t)
 	defer server.close()
@@ -289,7 +300,7 @@ func TestSendEmailUsesExplicitStartTLSWithInsecureCertificate(t *testing.T) {
 	select {
 	case message := <-server.messages:
 		require.Contains(t, message, "Subject: =?UTF-8?B?")
-		require.Contains(t, message, "<p>123456</p>")
+		requireEmailHTMLBody(t, message, "<p>123456</p>")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for SMTP DATA")
 	}
@@ -343,7 +354,7 @@ func TestSendEmailDoesNotAutoUpgradeWhenStartTLSDisabled(t *testing.T) {
 
 	select {
 	case message := <-server.messages:
-		require.Contains(t, message, "<p>123456</p>")
+		requireEmailHTMLBody(t, message, "<p>123456</p>")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for SMTP DATA")
 	}
@@ -446,7 +457,7 @@ func TestSendEmailSkipsAuthWhenCredentialsAreEmpty(t *testing.T) {
 
 	select {
 	case message := <-server.messages:
-		require.Contains(t, message, "<p>123456</p>")
+		requireEmailHTMLBody(t, message, "<p>123456</p>")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for SMTP DATA")
 	}
@@ -479,7 +490,7 @@ func TestSendEmailSkipsAuthWhenCredentialsAreIncomplete(t *testing.T) {
 
 	select {
 	case message := <-server.messages:
-		require.Contains(t, message, "<p>123456</p>")
+		requireEmailHTMLBody(t, message, "<p>123456</p>")
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for SMTP DATA")
 	}


### PR DESCRIPTION
## Summary

- separate security-scannable request text from token-counting metadata, covering OpenAI, Responses, Claude, Gemini, audio, task, Midjourney, and WebSocket paths
- enforce advanced-security rules on OpenAI Realtime events before upstream forwarding while excluding binary media and declared tool schemas
- return protocol-appropriate block feedback with the stable `advanced_security_guardrail` code
- save the complete advanced-security configuration in one database transaction and one runtime swap
- expose the active enforcement state in the public policy UI and add regression coverage

## Root cause

The guardrail reused token-count text, which omitted some prompt-bearing fields while including tool schemas, and Realtime client events bypassed the HTTP-only check. The settings page also persisted four related values independently, allowing partial updates after a failed request.

## Impact

Blocking behavior is consistent across supported request formats, users receive actionable protocol-native feedback, tool declarations create fewer false positives, and administrators no longer see partially saved guardrail policies. Audit mode remains available for false-positive calibration before enabling blocking.

## Validation

- `go test ./...` in `apps/api-go` from the clean publish worktree
- `go test ./...` in `apps/api-go/relaykit` from the clean publish worktree
- targeted Go race tests for advanced-security settings, matching, relays, and protocol errors
- frontend typecheck, focused lint/format checks, and 469 frontend tests

## Summary by Sourcery

将 HTML 邮件正文编码为 base64 MIME 内容，以防止用户可控的换行被解释为新的邮件头。

Bug Fixes:
- 通过让正文对 SMTP 传输保持不透明，确保 HTML 邮件正文无法引入意外的 MIME 头。

Tests:
- 添加帮助方法和断言，对 MIME 正文进行解码，以验证在 base64 编码后 HTML 内容仍被正确保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encode HTML email bodies as base64 MIME content to prevent user-controlled line breaks from being interpreted as new headers.

Bug Fixes:
- Ensure HTML email bodies cannot introduce unintended MIME headers by keeping the body opaque to the SMTP transport.

Tests:
- Add helper and assertions that decode the MIME body to verify the HTML content is preserved after base64 encoding.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 HTML 邮件正文编码为 base64 MIME 内容，以防止用户可控的换行被解释为新的邮件头。

Bug Fixes:
- 通过让正文对 SMTP 传输保持不透明，确保 HTML 邮件正文无法引入意外的 MIME 头。

Tests:
- 添加帮助方法和断言，对 MIME 正文进行解码，以验证在 base64 编码后 HTML 内容仍被正确保留。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Encode HTML email bodies as base64 MIME content to prevent user-controlled line breaks from being interpreted as new headers.

Bug Fixes:
- Ensure HTML email bodies cannot introduce unintended MIME headers by keeping the body opaque to the SMTP transport.

Tests:
- Add helper and assertions that decode the MIME body to verify the HTML content is preserved after base64 encoding.

</details>

</details>