### PR TITLE
fix: bind Waffo subscription webhook settlements

### DIFF
--- a/apps/api-go/service/waffo_pancake.go
+++ b/apps/api-go/service/waffo_pancake.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/LIghtJUNction/api.lmm.best/model"
 	"github.com/LIghtJUNction/api.lmm.best/setting"
+	"github.com/shopspring/decimal"
 	pancake "github.com/waffo-com/waffo-pancake-sdk-go"
 )
 
@@ -144,8 +145,11 @@ func WaffoPancakeWebhookActionForEvent(eventType string) WaffoPancakeWebhookActi
 	switch strings.TrimSpace(eventType) {
 	case "order.completed":
 		return WaffoPancakeWebhookActionOrderCompleted
+	// Activation does not prove that the order was paid. Pancake checkout uses
+	// one-time products for plans, so only definitive payment events may settle
+	// the pending local order.
 	case "subscription.activated":
-		return WaffoPancakeWebhookActionSubscriptionActivated
+		return WaffoPancakeWebhookActionIgnore
 	case "subscription.payment_succeeded":
 		return WaffoPancakeWebhookActionSubscriptionPaymentSucceeded
 	case "refund.succeeded":
@@ -569,6 +573,9 @@ func ResolveWaffoPancakeSubscriptionTradeNo(event *WaffoPancakeWebhookEvent) (st
 	if order == nil || order.PaymentProvider != model.PaymentProviderWaffoPancake {
 		return "", fmt.Errorf("waffo pancake subscription order not found for tradeNo=%s", tradeNo)
 	}
+	if err := validateWaffoPancakeSubscriptionSettlement(event, order.Money); err != nil {
+		return "", fmt.Errorf("waffo pancake subscription settlement mismatch for tradeNo=%s: %w", tradeNo, err)
+	}
 	expectedIdentity := WaffoPancakeBuyerIdentityFromUserID(order.UserId)
 	actualIdentity := strings.TrimSpace(event.Data.MerchantProvidedBuyerIdentity)
 	if actualIdentity != expectedIdentity {
@@ -580,6 +587,26 @@ func ResolveWaffoPancakeSubscriptionTradeNo(event *WaffoPancakeWebhookEvent) (st
 		)
 	}
 	return tradeNo, nil
+}
+
+func validateWaffoPancakeSubscriptionSettlement(event *WaffoPancakeWebhookEvent, expectedAmount float64) error {
+	expectedStore := strings.TrimSpace(setting.WaffoPancakeStoreID)
+	actualStore := strings.TrimSpace(event.StoreID)
+	if expectedStore == "" || actualStore != expectedStore {
+		return fmt.Errorf("store mismatch: expected=%q actual=%q", expectedStore, actualStore)
+	}
+	if currency := strings.ToUpper(strings.TrimSpace(event.Data.Currency)); currency != "USD" {
+		return fmt.Errorf("currency mismatch: expected=%q actual=%q", "USD", currency)
+	}
+	actualAmount, err := decimal.NewFromString(strings.TrimSpace(event.Data.Amount))
+	if err != nil {
+		return fmt.Errorf("invalid amount: %w", err)
+	}
+	expected := decimal.NewFromFloat(expectedAmount).Round(2)
+	if !actualAmount.Equal(expected) {
+		return fmt.Errorf("amount mismatch: expected=%s actual=%s", expected.StringFixed(2), actualAmount.String())
+	}
+	return nil
 }
 
 // ResolveWaffoPancakeRefundSubscriptionTradeNo is the refund counterpart of

--- a/apps/api-go/service/waffo_pancake_webhook_test.go
+++ b/apps/api-go/service/waffo_pancake_webhook_test.go
@@ -10,7 +10,7 @@ import (
 func TestWaffoPancakeWebhookActionForEvent(t *testing.T) {
 	tests := map[string]WaffoPancakeWebhookAction{
 		"order.completed":                WaffoPancakeWebhookActionOrderCompleted,
-		"subscription.activated":         WaffoPancakeWebhookActionSubscriptionActivated,
+		"subscription.activated":         WaffoPancakeWebhookActionIgnore,
 		"subscription.payment_succeeded": WaffoPancakeWebhookActionSubscriptionPaymentSucceeded,
 		"refund.succeeded":               WaffoPancakeWebhookActionRefundSucceeded,
 		"refund.failed":                  WaffoPancakeWebhookActionRefundFailed,
@@ -20,6 +20,36 @@ func TestWaffoPancakeWebhookActionForEvent(t *testing.T) {
 	for eventType, expected := range tests {
 		t.Run(eventType, func(t *testing.T) {
 			require.Equal(t, expected, WaffoPancakeWebhookActionForEvent(eventType))
+		})
+	}
+}
+
+func TestValidateWaffoPancakeSubscriptionSettlement(t *testing.T) {
+	originalStoreID := setting.WaffoPancakeStoreID
+	t.Cleanup(func() { setting.WaffoPancakeStoreID = originalStoreID })
+	setting.WaffoPancakeStoreID = "victim-store"
+
+	valid := &WaffoPancakeWebhookEvent{
+		StoreID: "victim-store",
+		Data:    WaffoPancakeWebhookData{Amount: "99.00", Currency: "USD"},
+	}
+	require.NoError(t, validateWaffoPancakeSubscriptionSettlement(valid, 99))
+
+	tests := []struct {
+		name      string
+		storeID   string
+		amount    string
+		currency  string
+		wantError string
+	}{
+		{name: "cross merchant store", storeID: "attacker-store", amount: "99.00", currency: "USD", wantError: "store mismatch"},
+		{name: "underpayment", storeID: "victim-store", amount: "0.01", currency: "USD", wantError: "amount mismatch"},
+		{name: "wrong currency", storeID: "victim-store", amount: "99.00", currency: "EUR", wantError: "currency mismatch"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			event := &WaffoPancakeWebhookEvent{StoreID: tt.storeID, Data: WaffoPancakeWebhookData{Amount: tt.amount, Currency: tt.currency}}
+			require.ErrorContains(t, validateWaffoPancakeSubscriptionSettlement(event, 99), tt.wantError)
 		})
 	}
 }


### PR DESCRIPTION
### Motivation

- Close a high-risk path where Waffo subscription webhooks could complete local subscription orders without verifying provider-level evidence (store, currency, amount). 
- Ensure only explicit, provably-settled provider events can settle a pending subscription order so cross-merchant or underpaid signed events cannot grant access.

### Description

- Treat `subscription.activated` as non-settling by mapping it to `Ignore` in `WaffoPancakeWebhookActionForEvent`, so activation alone will not complete an order. (changed in `apps/api-go/service/waffo_pancake.go`).
- Add `validateWaffoPancakeSubscriptionSettlement` and invoke it from `ResolveWaffoPancakeSubscriptionTradeNo` to require the webhook's `StoreID` to match the configured `WaffoPancakeStoreID`, the event currency to be `USD`, and the settled amount to equal the pending order amount (uses `decimal` for precise comparison). (new code in `apps/api-go/service/waffo_pancake.go`).
- Add unit tests to cover the updated dispatch and settlement checks, including cross-merchant, underpayment, and wrong-currency cases, and update the event-dispatch test expectations. (tests added/updated in `apps/api-go/service/waffo_pancake_webhook_test.go`).

### Testing

- `go test ./service -run '^$' -timeout 60s` completed successfully. 
- `go test ./service -run 'Test(WaffoPancakeWebhookActionForEvent|ValidateWaffoPancakeSubscriptionSettlement|ValidateWaffoPancakeWebhookEvent)' -timeout 60s` ran the new and affected tests and passed. 
- `git diff --check` reported no issues after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7fb0d5ba7c8320803b36b365dd5b2c)

## Summary by Sourcery

收紧 Waffo Pancake 订阅 webhook 结算处理逻辑，防止未经验证或跨商户的事件导致本地订阅订单被错误完成。

Bug Fixes:
- 不再将 `subscription.activated` 事件视为结算动作，从而避免仅凭激活事件就完成订阅订单。
- 要求 Waffo Pancake 订阅 webhook 结算必须匹配已配置的商店、使用美元（USD）货币，并且支付金额与订单金额完全一致，才会解析订阅交易号。

Tests:
- 添加针对订阅结算校验的单元测试，覆盖跨商户、少付金额以及错误货币等场景，并更新对 `subscription.activated` 事件的分发行为预期。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten Waffo Pancake subscription webhook settlement handling to prevent unverified or cross-merchant events from completing local subscription orders.

Bug Fixes:
- Stop treating `subscription.activated` events as settling actions so activation alone cannot complete subscription orders.
- Require Waffo Pancake subscription webhook settlements to match the configured store, use USD currency, and pay the exact order amount before resolving subscription trade numbers.

Tests:
- Add unit tests covering subscription settlement validation, including cross-merchant, underpayment, and wrong-currency scenarios, and update event-dispatch expectations for `subscription.activated` events.

</details>