### PR TITLE
Harden web releases against untrusted tags

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   web:
     name: Test, build, sign, and publish web package
+    if: ${{ github.ref_protected }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -33,10 +34,16 @@ jobs:
 
       - name: Verify web release identity
         id: identity
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           revision=$(git rev-parse HEAD)
           [[ "$revision" == "$GITHUB_SHA" ]]
+          git merge-base --is-ancestor "$revision" "origin/$DEFAULT_BRANCH" || {
+            echo "$revision is not reachable from default branch $DEFAULT_BRANCH" >&2
+            exit 1
+          }
           version=${GITHUB_REF_NAME#web-v}
           [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
           [[ $(sed -n 's/^pkgver=//p' packaging/aur/lmm-api-web-bin/PKGBUILD) == "$version" ]]


### PR DESCRIPTION
### Motivation
- The web release job previously ran for any pushed `web-v*.*.*` tag and was granted `contents: write` and `id-token: write`, allowing an attacker with tag-push rights to publish signed artifacts from arbitrary revisions that are not review-protected.
- Downstream AUR packaging and install hooks trust the workflow-signed artifacts and execute installed activation scripts as root, creating a high-severity supply-chain risk unless tag-triggered publishing is gated to protected history.

### Description
- Require the web job to run only for protected refs by adding `if: ${{ github.ref_protected }}` to the `web` job in `.github/workflows/release-web.yml`.
- Add an ancestry gate that sets `DEFAULT_BRANCH` from `github.event.repository.default_branch` and fails the identity check unless `git merge-base --is-ancestor "$revision" "origin/$DEFAULT_BRANCH"` succeeds, preventing builds/signing of tagged revisions not reachable from the default branch.
- Improve the identity-gate failure message to reference the default branch when a revision is not reachable.

### Testing
- Ran `git diff --check` and static YAML parse with `ruby -e "require 'yaml'; YAML.parse_file('.github/workflows/release-web.yml')"`, both succeeded.
- Exercised the ancestry gate in a temporary Git repository to confirm `git merge-base --is-ancestor` accepts a default-branch revision and rejects an unrelated/unmerged revision, and the gate behaved as expected.
- `actionlint` was not available in the environment and was therefore not run, and the local MCP `make_pr` invocation failed to start due to missing `mcp` runtime packages (networked PyPI install blocked), which prevented exercising the PR helper end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dcafd9178832091f732fc0deb0c4d)

## 由 Sourcery 提供的总结

将 Web 发布工作流限定在受保护且可由默认分支到达的标签上，以降低来自不受信任标签的供应链风险。

CI：
- 通过工作流 Job 条件限制 Web 发布任务仅在受保护的引用（refs）上运行。
- 添加 Git 祖先检查，确保打标签的修订版本可从仓库默认分支到达，并在失败信息中更清晰地引用该默认分支。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate web release workflow to protected, default-branch-reachable tags to mitigate untrusted tag supply-chain risk.

CI:
- Restrict the web release job to run only on protected refs via a workflow job condition.
- Add a Git ancestry check ensuring tagged revisions are reachable from the repository default branch, with clearer failure messaging referencing that branch.

</details>