### PR TITLE
Harden web release default-branch ancestry check

### DIFF
--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -40,7 +40,10 @@ jobs:
           set -euo pipefail
           revision=$(git rev-parse HEAD)
           [[ "$revision" == "$GITHUB_SHA" ]]
-          git merge-base --is-ancestor "$revision" "origin/$DEFAULT_BRANCH" || {
+          default_branch_ref="refs/remotes/origin/$DEFAULT_BRANCH"
+          git fetch --no-tags origin \
+            "refs/heads/$DEFAULT_BRANCH:$default_branch_ref"
+          git merge-base --is-ancestor "$revision" "${default_branch_ref}^{commit}" || {
             echo "$revision is not reachable from default branch $DEFAULT_BRANCH" >&2
             exit 1
           }


### PR DESCRIPTION
### Motivation
- The web release workflow performed an ancestry check against the ambiguous shorthand `origin/$DEFAULT_BRANCH`, which Git can resolve to a tag named `origin/<default_branch>` and thus be shadowed by an attacker-controlled tag.
- The change prevents tag-shadowing from allowing an attacker-controlled tag to satisfy the default-branch ancestry gate before signing/publishing web artifacts.

### Description
- Updated `./github/workflows/release-web.yml` to compute and use a fully-qualified remote-tracking ref `refs/remotes/origin/$DEFAULT_BRANCH` for the default branch check.
- Explicitly fetched the repository default branch (without tags) into that qualified ref using `git fetch --no-tags origin "refs/heads/$DEFAULT_BRANCH:$default_branch_ref"`.
- Replaced the ambiguous ancestry test with `git merge-base --is-ancestor "$revision" "${default_branch_ref}^{commit}"` to ensure Git resolves the actual branch commit rather than any tag.

### Testing
- Ran `git diff --check` and verified the workflow file diff is clean and syntactically updated (passed).
- Executed a targeted Git ref-shadowing regression proof in a temporary repo and confirmed the qualified check rejects an attacker commit that would previously have been accepted (passed).
- Confirmed working tree status with `git status --short --branch` and that the change was committed locally (clean).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a804be611f0832087ac97d1d8023dd1)

## Summary by Sourcery

CI:
- 更新 release-web 工作流程，以获取并验证完整限定的远程跟踪默认分支引用，而不是含糊不清的 `origin/$DEFAULT_BRANCH` 简写形式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the release-web workflow to fetch and verify against a fully-qualified remote-tracking default-branch ref instead of the ambiguous origin/$DEFAULT_BRANCH shorthand.

</details>