### PR TITLE
fix: add missing return in RelayTaskFetch to prevent nil pointer panic

### DIFF
--- a/apps/api-go/relay/relay_task.go
+++ b/apps/api-go/relay/relay_task.go
@@ -386,6 +386,7 @@ func RelayTaskFetch(c *gin.Context, relayMode int) (taskResp *dto.TaskError) {
 	respBuilder, ok := fetchRespBuilders[relayMode]
 	if !ok {
 		taskResp = service.TaskErrorWrapperLocal(errors.New("invalid_relay_mode"), "invalid_relay_mode", http.StatusBadRequest)
+		return taskResp
 	}
 
 	respBody, taskErr := respBuilder(c)


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic in `RelayTaskFetch` caused by a missing `return` statement.

## Root Cause

In `apps/api-go/relay/relay_task.go`, function `RelayTaskFetch`:

```go
respBuilder, ok := fetchRespBuilders[relayMode]
if !ok {
    taskResp = service.TaskErrorWrapperLocal(...)
}
// ← missing return; falls through to respBuilder(c) with nil respBuilder
respBody, taskErr := respBuilder(c)  // nil pointer panic
```

When `relayMode` is not in `fetchRespBuilders`, the error response is constructed but never returned, so execution continues to call `respBuilder(c)` where `respBuilder` is `nil`.

## Fix

Add `return taskResp` after setting the error response.

## Reproduction

Call any route handled by `controller.RelayTaskFetch` with a `relay_mode` that is not `RelayModeSunoFetch`, `RelayModeSunoFetchByID`, or `RelayModeVideoFetchByID` (e.g. `RelayModeUnknown` = 0). The server goroutine will panic with a nil pointer dereference instead of returning a 400 error.

## Testing

- Verified the fix compiles: `go build ./...`
- The fix is a single-line addition (`return taskResp`) with no behavioral change for valid relay modes

Fixes #88

## Summary by Sourcery

Bug Fixes:
- 在 `RelayTaskFetch` 中，当提供了无效的 relay 模式时，返回构造好的错误响应，以避免由于空指针解引用导致的崩溃（panic）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Return the constructed error response in RelayTaskFetch when an invalid relay mode is provided to avoid a nil pointer dereference panic.

</details>