### PR TITLE
Prepare web 0.1.14 release

### DIFF
--- a/packaging/aur/lmm-api-web-bin/.SRCINFO
+++ b/packaging/aur/lmm-api-web-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-web-bin
 	pkgdesc = LMM API production web frontend (prebuilt)
-	pkgver = 0.1.13
+	pkgver = 0.1.14
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	install = lmm-api-web.install
@@ -17,13 +17,13 @@ pkgbase = lmm-api-web-bin
 	depends = sed
 	depends = systemd
 	depends = util-linux
-	provides = lmm-api-web=0.1.13
+	provides = lmm-api-web=0.1.14
 	conflicts = lmm-api-web
-	noextract = lmm-api-web-0.1.13.tar.gz
-	source = lmm-api-web-0.1.13.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.13/lmm-api-web-0.1.13.tar.gz
-	source = lmm-api-web-0.1.13.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.13/lmm-api-web-0.1.13.tar.gz.sha256
-	source = lmm-api-web-0.1.13.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.13/lmm-api-web-0.1.13.tar.gz.sigstore.json
-	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.13/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
+	noextract = lmm-api-web-0.1.14.tar.gz
+	source = lmm-api-web-0.1.14.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.14/lmm-api-web-0.1.14.tar.gz
+	source = lmm-api-web-0.1.14.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.14/lmm-api-web-0.1.14.tar.gz.sha256
+	source = lmm-api-web-0.1.14.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.14/lmm-api-web-0.1.14.tar.gz.sigstore.json
+	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.14/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
 	sha256sums = c9960f2be7bab04e1af5cf5375207c4572fbe6e1797944e7d7e2e86a7c08d8e0
 	sha256sums = 201f3e93acd95f95d63d3fdd8cacc5c6e2688fd4da1294d7f79a1d10bd6c4d17
 	sha256sums = 30cfa73e0d997ad5ac4b2f12ba72174f4a25d74541a3d914169231b9a53d838b

--- a/packaging/aur/lmm-api-web-bin/PKGBUILD
+++ b/packaging/aur/lmm-api-web-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction <support@lmm.best>
 
 pkgname=lmm-api-web-bin
-pkgver=0.1.13
+pkgver=0.1.14
 pkgrel=1
 pkgdesc='LMM API production web frontend (prebuilt)'
 arch=('any')


### PR DESCRIPTION
Prepare the independent Web package metadata for the signed `web-v0.1.14` release.

- bump `lmm-api-web-bin` to 0.1.14
- regenerate tracked `.SRCINFO`
- keep existing hashes until immutable signed release assets are published and pinned

Validation: `makepkg --printsrcinfo`, `packaging/aur/test-matrix.sh`, `git diff --check`

## Summary by Sourcery

为 0.1.14 版本准备独立的 Web 软件包元数据。

Enhancements:
- 将独立的 AUR Web 软件包元数据更新到 0.1.14 版本，以便进行即将到来的签名发行。

Chores:
- 在保留现有哈希值的前提下重新生成已跟踪的 AUR 源元数据，直到不可变的发行资产可用为止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the independent Web package metadata for the 0.1.14 release.

Enhancements:
- Update the independent AUR Web package metadata to version 0.1.14 for the upcoming signed release.

Chores:
- Regenerate the tracked AUR source metadata while retaining existing hashes until immutable release assets are available.

</details>

增强功能：
- 将独立的 Web 包元数据更新到 0.1.14 版本，以用于即将发布的签名版本。

日常维护：
- 为新包版本重新生成已跟踪的 AUR 源元数据，同时在发布资源变为不可变并被固定之前保留现有的哈希值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为 0.1.14 版本准备独立的 Web 软件包元数据。

Enhancements:
- 将独立的 AUR Web 软件包元数据更新到 0.1.14 版本，以便进行即将到来的签名发行。

Chores:
- 在保留现有哈希值的前提下重新生成已跟踪的 AUR 源元数据，直到不可变的发行资产可用为止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prepare the independent Web package metadata for the 0.1.14 release.

Enhancements:
- Update the independent AUR Web package metadata to version 0.1.14 for the upcoming signed release.

Chores:
- Regenerate the tracked AUR source metadata while retaining existing hashes until immutable release assets are available.

</details>

</details>