### PR TITLE
fix: resolve open CodeQL security findings

### DIFF
--- a/apps/api-go/common/limit.go
+++ b/apps/api-go/common/limit.go
@@ -30,20 +30,23 @@ func NewLimitBuffer(limit int) *LimitBuffer {
 }
 
 func (b *LimitBuffer) reserve(size int) ([]byte, error) {
-	if size < 0 || size > b.limit-len(b.data) {
+	if b == nil || size < 0 {
 		return nil, ErrLimitExceeded
 	}
 	start := len(b.data)
+	// Check the subtraction before adding size so end cannot wrap around on
+	// platforms where int is narrower than the caller's input.
+	if start > b.limit || size > b.limit-start {
+		return nil, ErrLimitExceeded
+	}
 	end := start + size
 	if cap(b.data) < end {
-		newCap := cap(b.data) * 2
-		if newCap < end {
-			newCap = end
-		}
-		if newCap > b.limit {
-			newCap = b.limit
-		}
-		next := make([]byte, start, newCap)
+		// Grow exactly to the checked end. Avoid multiplying a potentially
+		// attacker-influenced capacity, which can overflow before the limit
+		// clamp is applied.
+
+		// lgtm [go/allocation-size-overflow]
+		next := make([]byte, start, end)
 		copy(next, b.data)
 		b.data = next
 	}

--- a/apps/api-go/controller/oauth.go
+++ b/apps/api-go/controller/oauth.go
@@ -39,7 +39,9 @@ func setOAuthStateCookie(c *gin.Context, provider, state string) {
 		Path:     "/",
 		MaxAge:   int(oauthAuthFlowTTL / time.Second),
 		HttpOnly: true,
-		Secure:   common.SessionCookieSecure,
+		// OAuth state is a bearer CSRF token. It must never be sent over
+		// cleartext HTTP, even when other development cookies are relaxed.
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 }
@@ -52,7 +54,7 @@ func clearOAuthStateCookie(c *gin.Context, provider string) {
 		MaxAge:   -1,
 		Expires:  time.Unix(1, 0),
 		HttpOnly: true,
-		Secure:   common.SessionCookieSecure,
+		Secure:   true,
 		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/apps/api-go/controller/option.go
+++ b/apps/api-go/controller/option.go
@@ -258,7 +258,7 @@ func UpdateOption(c *gin.Context) {
 			return
 		}
 	case "WeChatAuthEnabled":
-		if option.Value == "true" && common.WeChatServerAddress == "" {
+		if option.Value == "true" && strings.TrimSpace(common.WeChatServerAddress) == "" {
 			c.JSON(http.StatusOK, gin.H{
 				"success": false,
 				"message": "无法启用微信登录，请先填入微信登录相关配置信息！",

--- a/apps/api-go/controller/social_oauth_state_test.go
+++ b/apps/api-go/controller/social_oauth_state_test.go
@@ -41,7 +41,9 @@ func TestWeChatLoginStartPersistsLegalConsentInBrowserBoundFlow(t *testing.T) {
 	require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &response))
 	require.True(t, response.Success)
 	require.NotEmpty(t, response.Data.FlowToken)
-	assert.Contains(t, recorder.Header().Get("Set-Cookie"), oauthStateCookieName("wechat")+"="+response.Data.FlowToken)
+	setCookie := recorder.Header().Get("Set-Cookie")
+	assert.Contains(t, setCookie, oauthStateCookieName("wechat")+"="+response.Data.FlowToken)
+	assert.Contains(t, setCookie, "; Secure")
 
 	flow, err := model.GetAuthFlow(response.Data.FlowToken, model.AuthFlowMatch{
 		Purpose: model.AuthFlowPurposeWeChatLogin, Provider: "wechat", Intent: model.AuthFlowIntentLogin,
@@ -73,6 +75,8 @@ func TestWeChatProviderErrorDoesNotEchoUpstreamMessage(t *testing.T) {
 	previousEnabled := common.WeChatAuthEnabled
 	previousAddress := common.WeChatServerAddress
 	previousToken := common.WeChatServerToken
+	previousValidator := validateWeChatProviderURL
+	previousClientFactory := newWeChatHTTPClient
 	common.WeChatAuthEnabled = true
 	providerMessage := "upstream database password leaked"
 	provider := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -81,11 +85,17 @@ func TestWeChatProviderErrorDoesNotEchoUpstreamMessage(t *testing.T) {
 	}))
 	common.WeChatServerAddress = provider.URL
 	common.WeChatServerToken = "wechat-test-token"
+	// The production validator rejects loopback addresses; this test server is
+	// intentionally local and exercises the response-redaction contract.
+	validateWeChatProviderURL = func(string) error { return nil }
+	newWeChatHTTPClient = func() *http.Client { return &http.Client{Timeout: 5 * time.Second} }
 	t.Cleanup(func() {
 		provider.Close()
 		common.WeChatAuthEnabled = previousEnabled
 		common.WeChatServerAddress = previousAddress
 		common.WeChatServerToken = previousToken
+		validateWeChatProviderURL = previousValidator
+		newWeChatHTTPClient = previousClientFactory
 	})
 
 	state, _, err := model.CreateAuthFlow(model.AuthFlowCreate{
@@ -113,20 +123,39 @@ func TestWeChatProviderErrorDoesNotEchoUpstreamMessage(t *testing.T) {
 func TestWeChatProviderResponseIsBounded(t *testing.T) {
 	previousAddress := common.WeChatServerAddress
 	previousToken := common.WeChatServerToken
+	previousValidator := validateWeChatProviderURL
+	previousClientFactory := newWeChatHTTPClient
 	provider := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
 		writer.Header().Set("Content-Type", "application/json")
 		_, _ = writer.Write([]byte(`{"success":false,"message":"` + strings.Repeat("x", int(wechatProviderResponseMaxBytes)) + `"}`))
 	}))
 	common.WeChatServerAddress = provider.URL
 	common.WeChatServerToken = "wechat-test-token"
+	validateWeChatProviderURL = func(string) error { return nil }
+	newWeChatHTTPClient = func() *http.Client { return &http.Client{Timeout: 5 * time.Second} }
 	t.Cleanup(func() {
 		provider.Close()
 		common.WeChatServerAddress = previousAddress
 		common.WeChatServerToken = previousToken
+		validateWeChatProviderURL = previousValidator
+		newWeChatHTTPClient = previousClientFactory
 	})
 
 	_, err := getWeChatIdByCode("provider-code")
 	assert.ErrorIs(t, err, common.ErrLimitExceeded)
+}
+
+func TestValidateWeChatProviderURLRejectsPrivateAndMalformedTargets(t *testing.T) {
+	for _, rawURL := range []string{
+		"http://127.0.0.1:8080",
+		"http://169.254.169.254/latest/meta-data",
+		"file:///etc/passwd",
+		"https://user:password@example.com",
+	} {
+		t.Run(rawURL, func(t *testing.T) {
+			assert.Error(t, validateWeChatProviderURL(rawURL))
+		})
+	}
 }
 
 func TestTelegramLoginStartPersistsBrowserBoundFlow(t *testing.T) {

--- a/apps/api-go/controller/wechat.go
+++ b/apps/api-go/controller/wechat.go
@@ -1,11 +1,14 @@
 package controller
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
@@ -24,6 +27,91 @@ type wechatLoginResponse struct {
 // The WeChat identity response is a small fixed-shape JSON document. Keep
 // provider-controlled error text bounded before json.Decoder can buffer it.
 const wechatProviderResponseMaxBytes int64 = 64 << 10
+
+const wechatProviderPath = "/api/wechat/user"
+
+func newWeChatProviderSSRFProtection() *common.SSRFProtection {
+	return &common.SSRFProtection{
+		DomainFilterMode:       false,
+		IpFilterMode:           false,
+		ApplyIPFilterForDomain: true,
+	}
+}
+
+// validateWeChatProviderURL applies an independent outbound request policy.
+// WeChatServerAddress is editable through the admin option API, so it must
+// not be allowed to target loopback, link-local, private, or reserved hosts.
+// DNS is resolved as part of validation to prevent a hostname from bypassing
+// the address policy.
+var validateWeChatProviderURL = func(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme == "" || parsed.Hostname() == "" {
+		return errors.New("微信服务器地址无效")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("微信服务器地址仅支持 HTTP 或 HTTPS")
+	}
+	if parsed.User != nil || parsed.Fragment != "" {
+		return errors.New("微信服务器地址不得包含用户信息或片段")
+	}
+	protection := newWeChatProviderSSRFProtection()
+	if err := protection.ValidateURL(rawURL); err != nil {
+		return fmt.Errorf("微信服务器地址被出站安全策略拒绝: %w", err)
+	}
+	return nil
+}
+
+// dialWeChatProvider resolves a hostname and dials the exact validated IP.
+// The request URL keeps the original hostname for TLS SNI, but the connection
+// never asks the default transport to resolve it a second time. This closes
+// the DNS-rebinding window between validation and connect.
+func dialWeChatProvider(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, fmt.Errorf("微信服务器地址无效: %w", err)
+	}
+	protection := newWeChatProviderSSRFProtection()
+	dialer := &net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}
+	ips := []net.IP{}
+	if ip := net.ParseIP(host); ip != nil {
+		ips = append(ips, ip)
+	} else {
+		ips, err = net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("微信服务器 DNS 解析失败: %w", err)
+		}
+	}
+	var lastErr error
+	for _, ip := range ips {
+		if err := protection.ValidateResolvedIP(host, ip); err != nil {
+			lastErr = err
+			continue
+		}
+		conn, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		if dialErr == nil {
+			return conn, nil
+		}
+		lastErr = dialErr
+	}
+	if lastErr == nil {
+		lastErr = errors.New("微信服务器没有可用地址")
+	}
+	return nil, lastErr
+}
+
+var newWeChatHTTPClient = func() *http.Client {
+	transport := &http.Transport{
+		Proxy:                 nil,
+		DialContext:           dialWeChatProvider,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          4,
+		MaxIdleConnsPerHost:   2,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: time.Second,
+	}
+	return &http.Client{Transport: transport, Timeout: 5 * time.Second}
+}
 
 type wechatLoginStartRequest struct {
 	AcceptedLegal bool `json:"accepted_legal"`
@@ -77,14 +165,39 @@ func getWeChatIdByCode(code string) (string, error) {
 	if code == "" {
 		return "", errors.New("无效的参数")
 	}
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/wechat/user?code=%s", common.WeChatServerAddress, url.QueryEscape(code)), nil)
+	baseURL, err := url.Parse(strings.TrimSpace(common.WeChatServerAddress))
+	if err != nil || baseURL.Scheme == "" || baseURL.Hostname() == "" {
+		return "", errors.New("微信服务器地址无效")
+	}
+	if baseURL.RawQuery != "" || baseURL.Fragment != "" || baseURL.User != nil {
+		return "", errors.New("微信服务器地址不得包含用户信息、查询参数或片段")
+	}
+	if err := validateWeChatProviderURL(baseURL.String()); err != nil {
+		return "", err
+	}
+	query := baseURL.Query()
+	query.Set("code", code)
+	baseURL.Path = strings.TrimRight(baseURL.Path, "/") + wechatProviderPath
+	baseURL.RawPath = ""
+	baseURL.RawQuery = query.Encode()
+	providerURL := baseURL.String()
+	if err := validateWeChatProviderURL(providerURL); err != nil {
+		return "", err
+	}
+	req, err := http.NewRequest(http.MethodGet, providerURL, nil)
 	if err != nil {
 		return "", err
 	}
 	req.Header.Set("Authorization", common.WeChatServerToken)
-	client := http.Client{
-		Timeout: 5 * time.Second,
+	client := newWeChatHTTPClient()
+	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) > 0 {
+			return errors.New("微信服务器不允许重定向")
+		}
+		return validateWeChatProviderURL(req.URL.String())
 	}
+	// Strict scheme, host, DNS, and private-address validation precedes this sink.
+	// lgtm [go/request-forgery]
 	httpResponse, err := client.Do(req)
 	if err != nil {
 		return "", err

--- a/apps/api-go/model/advanced_security_event.go
+++ b/apps/api-go/model/advanced_security_event.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -290,9 +291,9 @@ func advancedSecurityEventQuery(db *gorm.DB, filter AdvancedSecurityEventFilter)
 		query = query.Where("category = ?", filter.Category)
 	}
 	if filter.Group != "" {
-		// Use a map predicate so GORM quotes the column for PostgreSQL, where
-		// GROUP is a reserved keyword.
-		query = query.Where(map[string]any{"group": filter.Group})
+		// clause.Column lets GORM quote GROUP for the active dialect while the
+		// value remains a bound query argument.
+		query = query.Where(clause.Eq{Column: clause.Column{Name: "group"}, Value: filter.Group})
 	}
 	if filter.Decision != "" {
 		query = query.Where("decision = ?", filter.Decision)

--- a/apps/api-go/model/assistant_request_review.go
+++ b/apps/api-go/model/assistant_request_review.go
@@ -217,7 +217,9 @@ func ListAssistantRequestReviewsForSecurity(filter AssistantRequestReviewFilter)
 		query = query.Where("1 = 0")
 	}
 	if filter.Group != "" {
-		query = query.Where(map[string]any{"group": filter.Group})
+		// clause.Column lets GORM quote GROUP for the active dialect while the
+		// value remains a bound query argument.
+		query = query.Where(clause.Eq{Column: clause.Column{Name: "group"}, Value: filter.Group})
 	}
 	if filter.Decision != "" && filter.Decision != "violation" && filter.Decision != "clear" {
 		query = query.Where("1 = 0")


### PR DESCRIPTION
Closes the current open CodeQL findings on main.

- Rejects WeChat provider SSRF targets (private/reserved IPs, malformed bases, and redirects) before outbound requests.
- Uses bound parameters for security-event group filters.
- Forces Secure on OAuth state cookies.
- Prevents LimitBuffer capacity arithmetic overflow.
- Adds regression coverage for the provider boundary, cookie flag, and response limits.

Validation: go test ./common ./controller ./model

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

Bug 修复：
- 在发出外部请求之前，阻止不安全、格式错误以及发生重定向的微信提供商目标。
- 防止响应缓冲区容量溢出，并对提供商响应施加边界限制。
- 始终将 OAuth state Cookie 标记为 Secure。
- 对安全事件分组过滤使用绑定参数。

增强：
- 在认证请求之前，验证并规范可配置的微信提供商 URL。
- 在启用微信认证时，将空白的微信服务器地址视为不可用。

测试：
- 为提供商目标验证、Secure OAuth Cookie 以及有边界的提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

</details>

Bug 修复：
- 阻止 WeChat 提供商请求访问私有、保留、格式错误或发生重定向的目标地址。
- 防止 limit-buffer 容量运算溢出，并强制执行安全的响应边界。
- 始终将 OAuth 状态 Cookie 标记为 Secure。
- 对安全事件组过滤使用绑定参数。

增强功能：
- 在发起外部认证请求之前，对可配置的 WeChat 提供商地址进行验证和规范化处理。

测试：
- 为 WeChat 提供商目标验证、安全 OAuth Cookie 以及有边界的提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

Bug 修复：
- 在发出外部请求之前，阻止不安全、格式错误以及发生重定向的微信提供商目标。
- 防止响应缓冲区容量溢出，并对提供商响应施加边界限制。
- 始终将 OAuth state Cookie 标记为 Secure。
- 对安全事件分组过滤使用绑定参数。

增强：
- 在认证请求之前，验证并规范可配置的微信提供商 URL。
- 在启用微信认证时，将空白的微信服务器地址视为不可用。

测试：
- 为提供商目标验证、Secure OAuth Cookie 以及有边界的提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

Bug 修复：
- 在发出外部请求之前，阻止不安全、格式错误以及发生重定向的微信提供商目标。
- 防止响应缓冲区容量溢出，并对提供商响应施加边界限制。
- 始终将 OAuth state Cookie 标记为 Secure。
- 对安全事件分组过滤使用绑定参数。

增强：
- 在认证请求之前，验证并规范可配置的微信提供商 URL。
- 在启用微信认证时，将空白的微信服务器地址视为不可用。

测试：
- 为提供商目标验证、Secure OAuth Cookie 以及有边界的提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

</details>

Bug 修复：
- 阻止 WeChat 提供商请求访问私有、保留、格式错误或发生重定向的目标地址。
- 防止 limit-buffer 容量运算溢出，并强制执行安全的响应边界。
- 始终将 OAuth 状态 Cookie 标记为 Secure。
- 对安全事件组过滤使用绑定参数。

增强功能：
- 在发起外部认证请求之前，对可配置的 WeChat 提供商地址进行验证和规范化处理。

测试：
- 为 WeChat 提供商目标验证、安全 OAuth Cookie 以及有边界的提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

Bug 修复：
- 在发出外部请求之前，阻止不安全、格式错误以及发生重定向的微信提供商目标。
- 防止响应缓冲区容量溢出，并对提供商响应施加边界限制。
- 始终将 OAuth state Cookie 标记为 Secure。
- 对安全事件分组过滤使用绑定参数。

增强：
- 在认证请求之前，验证并规范可配置的微信提供商 URL。
- 在启用微信认证时，将空白的微信服务器地址视为不可用。

测试：
- 为提供商目标验证、Secure OAuth Cookie 以及有边界的提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

Bug 修复：
- 在发起出站请求前，拦截并阻止不安全、格式错误、私有、保留及被重定向的 WeChat 提供方目标地址。
- 防止响应缓冲区容量溢出，并对 WeChat 提供方响应强制实施有界限制。
- 始终将 OAuth state cookies 标记为 Secure。
- 在安全事件分组过滤中使用绑定参数。

增强项：
- 在认证请求之前，校验并规范化可配置的 WeChat 提供方 URL。
- 在启用 WeChat 认证时，将仅由空白字符组成的 WeChat 服务器地址视为不可用。

测试：
- 为提供方目标校验、Secure OAuth cookies 以及有界提供方响应新增回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

解决与微信认证、OAuth Cookie、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

错误修复：
- 加固微信提供商请求，防御 SSRF、格式错误或被重定向的目标、超大响应以及 DNS 重绑定。
- 始终将 OAuth state Cookie 标记为 Secure。
- 防止 limit-buffer 容量计算溢出。
- 在安全事件分组过滤中使用绑定参数。

增强：
- 在发送认证请求之前验证并规范化可配置的微信提供商地址，并在启用微信认证时拒绝空白地址。

测试：
- 为提供商目标验证、Secure OAuth Cookie 和有界提供商响应添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

解决与微信认证、OAuth state 处理、查询过滤以及响应缓冲相关的剩余 CodeQL 安全问题。

Bug 修复：
- 加强微信服务提供方请求的安全性，防范 SSRF、不安全或格式错误的目标、DNS 重绑定、重定向以及超大响应。
- 防止 limit-buffer 容量计算出现算术溢出。
- 始终将 OAuth state cookie 标记为 Secure。
- 在安全相关的分组过滤中使用绑定参数。

增强：
- 在认证请求之前验证并规范化可配置的微信服务提供方地址，并在启用微信认证时拒绝空白地址。

测试：
- 增加对微信目标验证、Secure OAuth cookie 以及受限服务提供方响应的回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve the remaining CodeQL security findings across WeChat authentication, OAuth state handling, query filtering, and response buffering.

Bug Fixes:
- Harden WeChat provider requests against SSRF, unsafe or malformed targets, DNS rebinding, redirects, and oversized responses.
- Prevent limit-buffer capacity arithmetic overflow.
- Always mark OAuth state cookies as Secure.
- Use bound parameters for security-related group filters.

Enhancements:
- Validate and normalize configurable WeChat provider addresses before authentication requests and reject blank addresses when enabling WeChat authentication.

Tests:
- Add regression coverage for WeChat target validation, Secure OAuth cookies, and bounded provider responses.

</details>

</details>

</details>

</details>

</details>

</details>