### PR TITLE
chore(release): prepare web 0.1.15 metadata

### DIFF
--- a/packaging/aur/lmm-api-web-bin/.SRCINFO
+++ b/packaging/aur/lmm-api-web-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-web-bin
 	pkgdesc = LMM API production web frontend (prebuilt)
-	pkgver = 0.1.14
+	pkgver = 0.1.15
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	install = lmm-api-web.install
@@ -17,13 +17,13 @@ pkgbase = lmm-api-web-bin
 	depends = sed
 	depends = systemd
 	depends = util-linux
-	provides = lmm-api-web=0.1.14
+	provides = lmm-api-web=0.1.15
 	conflicts = lmm-api-web
-	noextract = lmm-api-web-0.1.14.tar.gz
-	source = lmm-api-web-0.1.14.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.14/lmm-api-web-0.1.14.tar.gz
-	source = lmm-api-web-0.1.14.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.14/lmm-api-web-0.1.14.tar.gz.sha256
-	source = lmm-api-web-0.1.14.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.14/lmm-api-web-0.1.14.tar.gz.sigstore.json
-	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.14/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
+	noextract = lmm-api-web-0.1.15.tar.gz
+	source = lmm-api-web-0.1.15.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.15/lmm-api-web-0.1.15.tar.gz
+	source = lmm-api-web-0.1.15.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.15/lmm-api-web-0.1.15.tar.gz.sha256
+	source = lmm-api-web-0.1.15.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.15/lmm-api-web-0.1.15.tar.gz.sigstore.json
+	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.15/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
 	sha256sums = e8a11d83517ddd3738e054e506aed4349c2f5ed8c0aace60d368f5dd8480cc02
 	sha256sums = 96f0771796deefaa322ad11a1f5ea465ae076f40519d97484c28b7297d124501
 	sha256sums = bcf35fa1b8cf7ce9a611402f4053c78f5e37f565022d349151c1f2316433da3e

--- a/packaging/aur/lmm-api-web-bin/PKGBUILD
+++ b/packaging/aur/lmm-api-web-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction <support@lmm.best>
 
 pkgname=lmm-api-web-bin
-pkgver=0.1.14
+pkgver=0.1.15
 pkgrel=1
 pkgdesc='LMM API production web frontend (prebuilt)'
 arch=('any')


### PR DESCRIPTION
Prepare the independent web release metadata for `web-v0.1.15` on the merged security-fixed main revision. The signed archive and sidecar hashes will be pinned only after the immutable release workflow publishes them.

## 由 Sourcery 提供的摘要

改进：
- 将网页前端的 AUR 软件包元数据更新到版本 0.1.15。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update the AUR package metadata for the web frontend to version 0.1.15.

</details>