### PR TITLE
fix: show active leaderboard preference

### DIFF
--- a/apps/web/src/features/profile/components/tabs/notification-tab.tsx
+++ b/apps/web/src/features/profile/components/tabs/notification-tab.tsx
@@ -18,6 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import {
   Bell,
+  Check,
   Eye,
   EyeOff,
   Loader2,
@@ -31,12 +32,14 @@ import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
 import { PasswordInput } from '@/components/password-input'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { ROLE } from '@/lib/roles'
+import { cn } from '@/lib/utils'
 
 import { updateUserSettings } from '../../api'
 import {
@@ -433,14 +436,34 @@ export function NotificationTab({ profile, onUpdate }: NotificationTabProps) {
           >
             {USAGE_LEADERBOARD_VISIBILITY_OPTIONS.map((option) => {
               const Icon = option.icon
+              const isSelected =
+                normalizeUsageLeaderboardVisibility(
+                  settings.usage_leaderboard_visibility
+                ) === option.value
               return (
                 <ToggleGroupItem
                   key={option.value}
                   value={option.value}
-                  className='h-auto min-h-14 w-full gap-2 px-3 py-3 text-xs font-medium sm:min-h-16 sm:text-sm'
+                  aria-pressed={isSelected}
+                  className={cn(
+                    'h-auto min-h-14 w-full justify-between gap-2 px-3 py-3 text-xs font-medium transition-[transform,background-color,border-color,box-shadow] duration-150 active:scale-[0.99] sm:min-h-16 sm:text-sm',
+                    isSelected &&
+                      'border-primary bg-primary/10 text-primary shadow-sm ring-1 ring-primary/30 data-[state=on]:bg-primary/10'
+                  )}
                 >
-                  <Icon className='h-4 w-4 shrink-0' />
-                  <span className='truncate'>{t(option.label)}</span>
+                  <span className='flex min-w-0 items-center gap-2'>
+                    <Icon className='h-4 w-4 shrink-0' />
+                    <span className='truncate'>{t(option.label)}</span>
+                  </span>
+                  {isSelected ? (
+                    <Badge
+                      variant='secondary'
+                      className='shrink-0 gap-1 px-2 py-0.5 text-[11px] font-medium'
+                    >
+                      <Check className='size-3.5' aria-hidden='true' />
+                      {t('Current')}
+                    </Badge>
+                  ) : null}
                 </ToggleGroupItem>
               )
             })}


### PR DESCRIPTION
Improve the usage leaderboard preference controls.

- Add an explicit Current badge to the selected visibility option.
- Add selected border/background/ring, hover, focus, and press feedback.
- Preserve the existing save flow and accessibility labels.

Validation: profile target test, typecheck, format check.

## Summary by Sourcery

使“活跃使用排行榜”可见性偏好更加清晰且响应更及时。

New Features:
- 为“活跃使用排行榜”可见性选项添加明确的“当前 (Current)”指示器。

Enhancements:
- 改进可见性偏好控制：在保留现有保存行为和无障碍语义的前提下，增加选中状态样式和交互反馈，以提升使用体验。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make the active usage leaderboard visibility preference clearer and more responsive.

New Features:
- Add an explicit “Current” indicator to the active usage leaderboard visibility option.

Enhancements:
- Improve visibility preference controls with selected-state styling and interaction feedback while preserving existing save behavior and accessibility semantics.

</details>