### PR TITLE
chore(release): prepare Web 0.1.17 metadata

### DIFF
--- a/packaging/aur/lmm-api-web-bin/.SRCINFO
+++ b/packaging/aur/lmm-api-web-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-web-bin
 	pkgdesc = LMM API production web frontend (prebuilt)
-	pkgver = 0.1.16
+	pkgver = 0.1.17
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	install = lmm-api-web.install
@@ -17,13 +17,13 @@ pkgbase = lmm-api-web-bin
 	depends = sed
 	depends = systemd
 	depends = util-linux
-	provides = lmm-api-web=0.1.16
+	provides = lmm-api-web=0.1.17
 	conflicts = lmm-api-web
-	noextract = lmm-api-web-0.1.16.tar.gz
-	source = lmm-api-web-0.1.16.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.16/lmm-api-web-0.1.16.tar.gz
-	source = lmm-api-web-0.1.16.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.16/lmm-api-web-0.1.16.tar.gz.sha256
-	source = lmm-api-web-0.1.16.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.16/lmm-api-web-0.1.16.tar.gz.sigstore.json
-	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.16/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
+	noextract = lmm-api-web-0.1.17.tar.gz
+	source = lmm-api-web-0.1.17.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.17/lmm-api-web-0.1.17.tar.gz
+	source = lmm-api-web-0.1.17.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.17/lmm-api-web-0.1.17.tar.gz.sha256
+	source = lmm-api-web-0.1.17.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.17/lmm-api-web-0.1.17.tar.gz.sigstore.json
+	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.17/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
 	sha256sums = 039510464af961278e4586ac791c79e30be5b4245ae098d7b904728385718c43
 	sha256sums = e8a05cf6470be0634f11f517ee86cb4d69c94f48bd5f315c8da5cfca1193e1df
 	sha256sums = 257e73243bed966bf8263e6a3617e36f2bd31a4d20bb4ea62907022cf137c03e

--- a/packaging/aur/lmm-api-web-bin/PKGBUILD
+++ b/packaging/aur/lmm-api-web-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction <support@lmm.best>
 
 pkgname=lmm-api-web-bin
-pkgver=0.1.16
+pkgver=0.1.17
 pkgrel=1
 pkgdesc='LMM API production web frontend (prebuilt)'
 arch=('any')


### PR DESCRIPTION
Prepare the independent Web release metadata for the latest merged wallet and preference optimizations. Signed artifact and sidecar hashes will be pinned after `web-v0.1.17` publication.

## Summary by Sourcery

Build:
- 将 Web 前端的 AUR 软件包元数据从版本 0.1.16 更新到 0.1.17。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update the AUR package metadata for the Web frontend from version 0.1.16 to 0.1.17.

</details>