### PR TITLE
fix: ship edge policy in Go release payload

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -221,6 +221,16 @@ jobs:
           cp -a frontend-dist/. "$bundle/frontend-dist/"
           cp packaging/common/lmm-api/lmm-api.service "$bundle/"
           cp packaging/common/lmm-api/lmm-api-go.env "$bundle/"
+          mkdir -p "$bundle/edge-policy/nginx"
+          cp deploy/nginx/http-map.conf \
+            deploy/nginx/lmm-api-locations.conf \
+            deploy/nginx/mime.types \
+            deploy/nginx/new-api.conf \
+            deploy/nginx/lmm-api-region-policy.conf \
+            "$bundle/edge-policy/nginx/"
+          cp packaging/common/lmm-api/geoip2-country-update.service \
+            packaging/common/lmm-api/geoip2-country-update.timer \
+            "$bundle/edge-policy/"
           cp LICENSE NOTICE THIRD-PARTY-LICENSES.md "$bundle/"
           printf '%s\n' "$RELEASE_REVISION" >"$bundle/REVISION"
           tar -czf "release-go/${artifact}.tar.gz" -C release-go "$artifact"

--- a/packaging/aur/lmm-api-go-bin/PKGBUILD
+++ b/packaging/aur/lmm-api-go-bin/PKGBUILD
@@ -84,6 +84,12 @@ package() {
   find "${pkgdir}/usr/share/lmm-api-go/frontend-dist" -type d -exec chmod 0755 {} +
   find "${pkgdir}/usr/share/lmm-api-go/frontend-dist" -type f -exec chmod 0644 {} +
 
+  install -d -m0755 "${pkgdir}/usr/share/lmm-api-go/edge-policy"
+  cp -R --no-preserve=ownership,mode,timestamps -- "${bundle}/edge-policy/." \
+    "${pkgdir}/usr/share/lmm-api-go/edge-policy/"
+  find "${pkgdir}/usr/share/lmm-api-go/edge-policy" -type d -exec chmod 0755 {} +
+  find "${pkgdir}/usr/share/lmm-api-go/edge-policy" -type f -exec chmod 0644 {} +
+
   for file in LICENSE NOTICE THIRD-PARTY-LICENSES.md; do
     install -Dm0644 "${bundle}/${file}" "${pkgdir}/usr/share/licenses/${pkgname}/${file}"
   done


### PR DESCRIPTION
Carry the managed Nginx/GeoIP edge-policy assets through the signed Go release archive and install them from the AUR package. This closes the packaging gap found during the 0.1.25 deployment reconciliation.

## Summary by Sourcery

Bug Fixes:
- 在 Go 发布归档中包含受管的 edge-policy 资产，并在 AUR 软件包中安装它们。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Include managed edge-policy assets in Go release archives and install them in the AUR package.

</details>