### PR TITLE
fix: unblock registration capability loading

### DIFF
--- a/apps/web/public/lmm-forge-mark.svg
+++ b/apps/web/public/lmm-forge-mark.svg
@@ -1,6 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 56 56" role="img" aria-label="LMM Forge">
-  <rect x="4" y="4" width="48" height="48" rx="14" fill="#bcd1ca"/>
-  <path d="M15 38V18l13 13 13-13v20" fill="none" stroke="#141413" stroke-width="4.25" stroke-linecap="round" stroke-linejoin="round"/>
-  <path d="M16 41h24" fill="none" stroke="#d97757" stroke-width="3.5" stroke-linecap="round"/>
-  <rect x="4.75" y="4.75" width="46.5" height="46.5" rx="13.25" fill="none" stroke="#141413" stroke-opacity="0.16" stroke-width="1.5"/>
+  <path d="M10 39V16l18 18 18-18v23" fill="none" stroke="#141413" stroke-width="3.5" stroke-linecap="square" stroke-linejoin="round"/>
+  <path d="M12 45h32" fill="none" stroke="#b8634c" stroke-width="2.5" stroke-linecap="square"/>
 </svg>

--- a/apps/web/src/components/lmm-brand-mark.tsx
+++ b/apps/web/src/components/lmm-brand-mark.tsx
@@ -26,7 +26,7 @@ type LmmBrandMarkProps = SVGProps<SVGSVGElement> & {
   title?: string
 }
 
-/** A compact angular monogram: an M-shaped forge frame over a hot base. */
+/** A quiet angular monogram for the editorial Forge shell. */
 export function LmmBrandMark({
   className,
   title,
@@ -43,39 +43,20 @@ export function LmmBrandMark({
       className={cn('shrink-0', className)}
       {...props}
     >
-      <rect
-        x='4'
-        y='4'
-        width='48'
-        height='48'
-        rx='14'
-        fill='var(--forge-brand-mark-surface)'
-      />
       <path
-        d='M15 38V18l13 13 13-13v20'
+        d='M10 39V16l18 18 18-18v23'
         fill='none'
         stroke='var(--forge-brand-mark-ink)'
-        strokeWidth='4.25'
-        strokeLinecap='round'
+        strokeWidth='3.5'
+        strokeLinecap='square'
         strokeLinejoin='round'
       />
       <path
-        d='M16 41h24'
+        d='M12 45h32'
         fill='none'
         stroke='var(--forge-brand-mark-accent)'
-        strokeWidth='3.5'
-        strokeLinecap='round'
-      />
-      <rect
-        x='4.75'
-        y='4.75'
-        width='46.5'
-        height='46.5'
-        rx='13.25'
-        fill='none'
-        stroke='var(--forge-brand-mark-ink)'
-        strokeOpacity='0.16'
-        strokeWidth='1.5'
+        strokeWidth='2.5'
+        strokeLinecap='square'
       />
     </svg>
   )

--- a/apps/web/src/features/auth/components/auth-art-panel.tsx
+++ b/apps/web/src/features/auth/components/auth-art-panel.tsx
@@ -87,12 +87,8 @@ export function AuthArtPanel() {
 
   return (
     <aside className='bg-card text-card-foreground flex h-full flex-col overflow-hidden rounded-[1.75rem] border p-8 xl:p-10'>
-      <div className='flex items-center justify-between gap-4 text-xs font-semibold tracking-[0.14em] uppercase'>
+      <div className='flex items-center gap-4 text-xs font-semibold tracking-[0.14em] uppercase'>
         <span className='text-muted-foreground'>{t('LMM API Console')}</span>
-        <span className='text-success flex items-center gap-2 tracking-normal normal-case'>
-          <span className='bg-success size-2 rounded-full' aria-hidden='true' />
-          {t('Operational')}
-        </span>
       </div>
 
       <div className='my-auto max-w-2xl py-10'>

--- a/apps/web/src/hooks/use-status.ts
+++ b/apps/web/src/hooks/use-status.ts
@@ -50,65 +50,88 @@ export function useStatus() {
     if (!user) return 'anonymous'
     return `user:${user.id}:docs:${user.permissions?.docs_access === true ? 1 : 0}`
   })
-  const { data, isFetchedAfterMount, isFetching, isLoading, error, refetch } =
-    useQuery({
-      queryKey: ['status', statusScope],
-      queryFn: async () => {
-        const rawStatus = await getStatus()
-        const status = rawStatus
-          ? normalizeBackendCapabilities(rawStatus as SystemStatus)
-          : null
-        try {
-          if (status) {
-            const { setConfig } = useSystemConfigStore.getState()
-            setConfig(
-              mapStatusDataToConfig(
-                status as Parameters<typeof mapStatusDataToConfig>[0]
-              )
+  const {
+    data,
+    dataUpdatedAt,
+    isFetchedAfterMount,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey: ['status', statusScope],
+    queryFn: async () => {
+      const rawStatus = await getStatus()
+      const status = rawStatus
+        ? normalizeBackendCapabilities(rawStatus as SystemStatus)
+        : null
+      try {
+        if (status) {
+          const { setConfig } = useSystemConfigStore.getState()
+          setConfig(
+            mapStatusDataToConfig(
+              status as Parameters<typeof mapStatusDataToConfig>[0]
             )
-          }
-        } catch (err) {
-          if (import.meta.env.DEV) {
-            // eslint-disable-next-line no-console
-            console.warn(
-              '[useStatus] Failed to sync status to system config',
-              err
-            )
-          }
+          )
         }
-        // Save to localStorage
-        try {
-          if (typeof window !== 'undefined' && status) {
-            window.localStorage.setItem('status', JSON.stringify(status))
-          }
-        } catch {
-          /* empty */
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[useStatus] Failed to sync status to system config',
+            err
+          )
         }
-        return status as SystemStatus | null
-      },
-      // Use localStorage data as initial data
-      placeholderData: getInitialStatus(),
-      // Capability decisions require a live response for this observer mount.
-      staleTime: 0,
-      refetchOnMount: 'always',
-      refetchOnWindowFocus: 'always',
-      refetchOnReconnect: 'always',
-      refetchInterval: 30_000,
-      refetchIntervalInBackground: true,
-      retry: 1,
-      retryDelay: 1_000,
-      // Cache expires after 30 minutes
-      gcTime: 30 * 60 * 1000,
-    })
+      }
+      // Save to localStorage
+      try {
+        if (typeof window !== 'undefined' && status) {
+          window.localStorage.setItem('status', JSON.stringify(status))
+        }
+      } catch {
+        /* empty */
+      }
+      return status as SystemStatus | null
+    },
+    // Use localStorage data as initial data
+    placeholderData: getInitialStatus(),
+    // The status payload is shared public capability data. Treat it as a
+    // short-lived snapshot instead of refetching on every focus event: a
+    // tab switch must not spend the global API rate-limit budget or leave
+    // registration waiting behind a burst of duplicate requests.
+    staleTime: 30_000,
+    // A live response must advance the query timestamp even when the server
+    // returns the same capability values; this distinguishes it from a
+    // pre-populated cache used for layout-only placeholders.
+    structuralSharing: false,
+    // A fresh page must verify capabilities even when another observer left
+    // a cached snapshot behind; this is the one intentional mount fetch.
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: true,
+    refetchInterval: 5 * 60_000,
+    refetchIntervalInBackground: false,
+    retry: 1,
+    retryDelay: 1_000,
+    // Cache expires after 30 minutes
+    gcTime: 30 * 60 * 1000,
+  })
 
+  // `dataUpdatedAt` is zero for placeholder/localStorage data and becomes
+  // non-zero after the server has answered at least once. Pair it with
+  // `isFetchedAfterMount` so a query pre-populated by another observer or a
+  // test cannot be mistaken for a live capability response. Keep a previously
+  // confirmed snapshot usable while a background refresh is transiently
+  // rate-limited or unavailable; otherwise the sign-up page regresses to an
+  // indefinite loading state even though it already has valid capabilities.
   const capabilitiesReady =
-    Boolean(data) && isFetchedAfterMount && !isFetching && !error
+    Boolean(data) && isFetchedAfterMount && dataUpdatedAt > 0
+  const liveError = capabilitiesReady ? null : error
 
   return {
     status: getCapabilitySafeStatus(data, capabilitiesReady),
     loading: isLoading,
     capabilitiesReady,
-    error,
+    error: liveError,
     refetch,
   }
 }


### PR DESCRIPTION
## What changed

- Stop registration capability polling on every focus event and use a bounded refresh interval.
- Keep the last confirmed capability snapshot usable during transient 429/5xx refreshes.
- Remove the Operational badge from the auth artwork and align the LMM Forge mark with the editorial shell.

## Validation

- bun run build:check
- bun test src/lib/status-api.test.ts src/features/auth/components/auth-art-panel.test.tsx
- bash deploy/check-frontend-split.sh
- Impeccable detector: clean

## Summary by Sourcery

在刷新 Forge 身份验证品牌时，稳定注册功能的加载行为。

Bug Fixes（错误修复）:
- 在短暂的限流或服务器错误导致刷新失败期间，保留最后一次已确认的功能快照，使注册不会退回到无限加载状态。

Enhancements（增强改进）:
- 将原先由焦点触发的功能轮询替换为有界缓存和周期性刷新机制。
- 通过移除“Operational”徽章来简化身份验证的艺术化呈现，并更新用于编辑外壳的 Forge 标识。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize registration capability loading while refreshing the Forge authentication branding.

Bug Fixes:
- Keep the last confirmed capability snapshot available during transient rate-limit or server-error refresh failures so registration does not regress to an indefinite loading state.

Enhancements:
- Replace focus-triggered capability polling with bounded caching and periodic refresh behavior.
- Simplify the authentication artwork by removing the Operational badge and update the Forge mark for the editorial shell.

</details>

Bug Fixes（错误修复）:
- 通过保留上一次已确认的能力快照，防止在短暂的限流或服务器错误导致的刷新过程中，注册能力的加载出现回退问题。

Enhancements（功能改进）:
- 使用有边界、短期的能力缓存和周期性刷新机制，替代基于窗口聚焦触发的状态轮询。
- 更新 Forge 品牌形象，并通过移除 Operational 徽章来简化认证界面的视觉素材。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在刷新 Forge 身份验证品牌时，稳定注册功能的加载行为。

Bug Fixes（错误修复）:
- 在短暂的限流或服务器错误导致刷新失败期间，保留最后一次已确认的功能快照，使注册不会退回到无限加载状态。

Enhancements（增强改进）:
- 将原先由焦点触发的功能轮询替换为有界缓存和周期性刷新机制。
- 通过移除“Operational”徽章来简化身份验证的艺术化呈现，并更新用于编辑外壳的 Forge 标识。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize registration capability loading while refreshing the Forge authentication branding.

Bug Fixes:
- Keep the last confirmed capability snapshot available during transient rate-limit or server-error refresh failures so registration does not regress to an indefinite loading state.

Enhancements:
- Replace focus-triggered capability polling with bounded caching and periodic refresh behavior.
- Simplify the authentication artwork by removing the Operational badge and update the Forge mark for the editorial shell.

</details>

</details>