### PR TITLE
chore(release): prepare Web 0.1.20 metadata

### DIFF
--- a/packaging/aur/lmm-api-web-bin/.SRCINFO
+++ b/packaging/aur/lmm-api-web-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-web-bin
 	pkgdesc = LMM API production web frontend (prebuilt)
-	pkgver = 0.1.19
+	pkgver = 0.1.20
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	install = lmm-api-web.install
@@ -17,13 +17,13 @@ pkgbase = lmm-api-web-bin
 	depends = sed
 	depends = systemd
 	depends = util-linux
-	provides = lmm-api-web=0.1.19
+	provides = lmm-api-web=0.1.20
 	conflicts = lmm-api-web
-	noextract = lmm-api-web-0.1.19.tar.gz
-	source = lmm-api-web-0.1.19.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.19/lmm-api-web-0.1.19.tar.gz
-	source = lmm-api-web-0.1.19.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.19/lmm-api-web-0.1.19.tar.gz.sha256
-	source = lmm-api-web-0.1.19.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.19/lmm-api-web-0.1.19.tar.gz.sigstore.json
-	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.19/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
+	noextract = lmm-api-web-0.1.20.tar.gz
+	source = lmm-api-web-0.1.20.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.20/lmm-api-web-0.1.20.tar.gz
+	source = lmm-api-web-0.1.20.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.20/lmm-api-web-0.1.20.tar.gz.sha256
+	source = lmm-api-web-0.1.20.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/web-v0.1.20/lmm-api-web-0.1.20.tar.gz.sigstore.json
+	source = lmm-api-web-activate::https://github.com/LIghtJUNction/api.lmm.best/raw/refs/tags/web-v0.1.20/packaging/aur/lmm-api-web-bin/lmm-api-web-activate
 	sha256sums = 8c4b7f0d93456af018613d566d1475702f3db16f62b73510da6b77ae3bfc8500
 	sha256sums = b2109883919b6ff1aece941d011be95d3a9e9846265ceba7ba47bbb804727187
 	sha256sums = 45fe29de048a52eea6e7ba4affe81c08fbd1a0e5a98845e918339829f5333331

--- a/packaging/aur/lmm-api-web-bin/PKGBUILD
+++ b/packaging/aur/lmm-api-web-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction <support@lmm.best>
 
 pkgname=lmm-api-web-bin
-pkgver=0.1.19
+pkgver=0.1.20
 pkgrel=1
 pkgdesc='LMM API production web frontend (prebuilt)'
 arch=('any')


### PR DESCRIPTION
Prepare the independent Web 0.1.20 package metadata for the registration-loading fix.

Validation:
- makepkg --printsrcinfo
- bash packaging/aur/test-matrix.sh (marker-owned TMPDIR)
- local Web build and tests passed on the source revision

## Summary by Sourcery

构建：
- 更新 Web 前端的 AUR 软件包元数据，以发布版本 0.1.20。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update the AUR package metadata for the Web frontend to release version 0.1.20.

</details>