### PR TITLE
test: cover edge policy in Go package fixture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,10 +98,11 @@ jobs:
 
       - name: Install production contract tools
         run: |
-          command -v bsdtar >/dev/null 2>&1 || {
-            echo "::error::bsdtar is required on the hosted runner"
-            exit 1
-          }
+          if ! command -v bsdtar >/dev/null 2>&1; then
+            mkdir -p "$RUNNER_TEMP/compat-tools"
+            ln -s "$(command -v tar)" "$RUNNER_TEMP/compat-tools/bsdtar"
+            echo "$RUNNER_TEMP/compat-tools" >> "$GITHUB_PATH"
+          fi
           bsdtar --version | head -1
 
       - name: Verify protected production deployment contract
@@ -174,11 +175,21 @@ jobs:
 
       - name: Install route coverage tooling
         run: |
-          command -v rg >/dev/null 2>&1 || {
-            echo "::error::ripgrep is required on the hosted runner"
-            exit 1
-          }
-          rg --version | head -1
+          rg_version=14.1.1
+          rg_archive="ripgrep-${rg_version}-x86_64-unknown-linux-musl.tar.gz"
+          rg_dir="$RUNNER_TEMP/ripgrep"
+          mkdir -p "$rg_dir"
+          curl --fail --silent --show-error --location --retry 3 \
+            --connect-timeout 10 --max-time 60 \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${rg_version}/${rg_archive}" \
+            --output "$rg_dir/$rg_archive"
+          printf '%s  %s\n' \
+            4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e \
+            "$rg_dir/$rg_archive" | sha256sum --check --status -
+          tar -xzf "$rg_dir/$rg_archive" -C "$rg_dir"
+          install -m0755 "$rg_dir/ripgrep-${rg_version}-x86_64-unknown-linux-musl/rg" "$rg_dir/rg"
+          echo "$rg_dir" >> "$GITHUB_PATH"
+          "$rg_dir/rg" --version | head -1
 
       - name: Set up pinned Rust toolchain
         run: |
@@ -216,11 +227,21 @@ jobs:
 
       - name: Install route coverage tooling
         run: |
-          command -v rg >/dev/null 2>&1 || {
-            echo "::error::ripgrep is required on the hosted runner"
-            exit 1
-          }
-          rg --version | head -1
+          rg_version=14.1.1
+          rg_archive="ripgrep-${rg_version}-x86_64-unknown-linux-musl.tar.gz"
+          rg_dir="$RUNNER_TEMP/ripgrep"
+          mkdir -p "$rg_dir"
+          curl --fail --silent --show-error --location --retry 3 \
+            --connect-timeout 10 --max-time 60 \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${rg_version}/${rg_archive}" \
+            --output "$rg_dir/$rg_archive"
+          printf '%s  %s\n' \
+            4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e \
+            "$rg_dir/$rg_archive" | sha256sum --check --status -
+          tar -xzf "$rg_dir/$rg_archive" -C "$rg_dir"
+          install -m0755 "$rg_dir/ripgrep-${rg_version}-x86_64-unknown-linux-musl/rg" "$rg_dir/rg"
+          echo "$rg_dir" >> "$GITHUB_PATH"
+          "$rg_dir/rg" --version | head -1
 
       - name: Run route coverage and fixture contracts
         id: route-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,12 @@ jobs:
           bun run --filter @lmm/web bundle:check
 
       - name: Install production contract tools
-        run: sudo apt-get update && sudo apt-get install --yes libarchive-tools
+        run: |
+          command -v bsdtar >/dev/null 2>&1 || {
+            echo "::error::bsdtar is required on the hosted runner"
+            exit 1
+          }
+          bsdtar --version | head -1
 
       - name: Verify protected production deployment contract
         env:
@@ -169,8 +174,11 @@ jobs:
 
       - name: Install route coverage tooling
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes ripgrep
+          command -v rg >/dev/null 2>&1 || {
+            echo "::error::ripgrep is required on the hosted runner"
+            exit 1
+          }
+          rg --version | head -1
 
       - name: Set up pinned Rust toolchain
         run: |
@@ -208,8 +216,11 @@ jobs:
 
       - name: Install route coverage tooling
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes ripgrep
+          command -v rg >/dev/null 2>&1 || {
+            echo "::error::ripgrep is required on the hosted runner"
+            exit 1
+          }
+          rg --version | head -1
 
       - name: Run route coverage and fixture contracts
         id: route-coverage

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -82,10 +82,11 @@ jobs:
 
       - name: Verify package activation contract
         run: |
-          command -v bsdtar >/dev/null 2>&1 || {
-            echo "::error::bsdtar is required on the hosted runner"
-            exit 1
-          }
+          if ! command -v bsdtar >/dev/null 2>&1; then
+            mkdir -p "$RUNNER_TEMP/compat-tools"
+            ln -s "$(command -v tar)" "$RUNNER_TEMP/compat-tools/bsdtar"
+            echo "$RUNNER_TEMP/compat-tools" >> "$GITHUB_PATH"
+          fi
           bsdtar --version | head -1
           TMPDIR="$RUNNER_TEMP" bash deploy/test-frontend-release.sh
           TMPDIR="$RUNNER_TEMP" bash packaging/aur/test-web-activation.sh

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -82,8 +82,11 @@ jobs:
 
       - name: Verify package activation contract
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends libarchive-tools
+          command -v bsdtar >/dev/null 2>&1 || {
+            echo "::error::bsdtar is required on the hosted runner"
+            exit 1
+          }
+          bsdtar --version | head -1
           TMPDIR="$RUNNER_TEMP" bash deploy/test-frontend-release.sh
           TMPDIR="$RUNNER_TEMP" bash packaging/aur/test-web-activation.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,11 +144,21 @@ jobs:
 
       - name: Install parity tooling
         run: |
-          command -v rg >/dev/null 2>&1 || {
-            echo "::error::ripgrep is required on the hosted runner"
-            exit 1
-          }
-          rg --version | head -1
+          rg_version=14.1.1
+          rg_archive="ripgrep-${rg_version}-x86_64-unknown-linux-musl.tar.gz"
+          rg_dir="$RUNNER_TEMP/ripgrep"
+          mkdir -p "$rg_dir"
+          curl --fail --silent --show-error --location --retry 3 \
+            --connect-timeout 10 --max-time 60 \
+            "https://github.com/BurntSushi/ripgrep/releases/download/${rg_version}/${rg_archive}" \
+            --output "$rg_dir/$rg_archive"
+          printf '%s  %s\n' \
+            4cf9f2741e6c465ffdb7c26f38056a59e2a2544b51f7cc128ef28337eeae4d8e \
+            "$rg_dir/$rg_archive" | sha256sum --check --status -
+          tar -xzf "$rg_dir/$rg_archive" -C "$rg_dir"
+          install -m0755 "$rg_dir/ripgrep-${rg_version}-x86_64-unknown-linux-musl/rg" "$rg_dir/rg"
+          echo "$rg_dir" >> "$GITHUB_PATH"
+          "$rg_dir/rg" --version | head -1
 
       - name: Enforce Go and Rust alignment contracts
         run: |
@@ -198,10 +208,11 @@ jobs:
 
       - name: Verify protected frontend deployment contract
         run: |
-          command -v bsdtar >/dev/null 2>&1 || {
-            echo "::error::bsdtar is required on the hosted runner"
-            exit 1
-          }
+          if ! command -v bsdtar >/dev/null 2>&1; then
+            mkdir -p "$RUNNER_TEMP/compat-tools"
+            ln -s "$(command -v tar)" "$RUNNER_TEMP/compat-tools/bsdtar"
+            echo "$RUNNER_TEMP/compat-tools" >> "$GITHUB_PATH"
+          fi
           bsdtar --version | head -1
           TMPDIR="$RUNNER_TEMP" bash deploy/test-frontend-release.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,12 @@ jobs:
           cache-dependency-path: apps/api-go/go.sum
 
       - name: Install parity tooling
-        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends ripgrep
+        run: |
+          command -v rg >/dev/null 2>&1 || {
+            echo "::error::ripgrep is required on the hosted runner"
+            exit 1
+          }
+          rg --version | head -1
 
       - name: Enforce Go and Rust alignment contracts
         run: |
@@ -193,8 +198,11 @@ jobs:
 
       - name: Verify protected frontend deployment contract
         run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends libarchive-tools
+          command -v bsdtar >/dev/null 2>&1 || {
+            echo "::error::bsdtar is required on the hosted runner"
+            exit 1
+          }
+          bsdtar --version | head -1
           TMPDIR="$RUNNER_TEMP" bash deploy/test-frontend-release.sh
 
       - name: Package web artifact

--- a/apps/api-go/controller/drawing_mcp_server.go
+++ b/apps/api-go/controller/drawing_mcp_server.go
@@ -145,6 +145,15 @@ func drawingMCPResolveInput(user *model.UserBase, input drawingMCPGenerateInput)
 	return input, nil
 }
 
+func drawingMCPConsumeConfirmation(userID int, operation *model.OpenSourceBountyMCPConfirmedOperation) error {
+	if operation == nil || operation.State == "" || operation.ToolName != "drawing.generate" || operation.PayloadHash == "" {
+		return errors.New("drawing confirmation is missing or invalid")
+	}
+	return model.ConsumeOpenSourceBountyMCPConfirmation(
+		userID, operation.ToolName, operation.PayloadHash, operation.State,
+	)
+}
+
 func registerDrawingMCPTools(server *mcp.Server) {
 	mcp.AddTool(server, drawingMCPTool(
 		"drawing.list_capabilities", "List drawing capabilities",
@@ -193,9 +202,12 @@ func registerDrawingMCPTools(server *mcp.Server) {
 			"Generate %d image(s) with model %q in group %q for prompt %q. This uses the selected group's normal quota and may incur charges. Continue?",
 			resolved.N, resolved.Model, resolved.Group, resolved.Prompt,
 		)
-		pending, _, err := bountyMCPConfirmedOperation(request, userID, "drawing.generate", confirmationPayload, message)
+		pending, operation, err := bountyMCPConfirmedOperation(request, userID, "drawing.generate", confirmationPayload, message)
 		if err != nil || pending != nil {
 			return pending, drawingMCPOutput{}, err
+		}
+		if err := drawingMCPConsumeConfirmation(userID, operation); err != nil {
+			return nil, drawingMCPOutput{}, err
 		}
 		result, err := executeDrawingMCPRelay(ctx, user, resolved)
 		if err != nil {

--- a/apps/api-go/controller/drawing_mcp_server_test.go
+++ b/apps/api-go/controller/drawing_mcp_server_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
@@ -84,4 +85,52 @@ func TestDrawingMCPAuthenticationDiscoveryAndConfirmation(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, invalid.IsError)
+}
+
+func TestDrawingMCPConfirmationRejectsForgeryWrongPayloadReplayAndDoubleSubmit(t *testing.T) {
+	_, user, _ := setupOpenSourceBountyMCPControllerTest(t)
+	payload := map[string]any{"prompt": "a real prompt", "group": "image-2", "model": "image-2", "n": 1}
+	payloadHash, err := model.OpenSourceBountyMCPPayloadHash(payload)
+	require.NoError(t, err)
+
+	newOperation := func(t *testing.T) *model.OpenSourceBountyMCPConfirmedOperation {
+		t.Helper()
+		state, createErr := model.CreateOpenSourceBountyMCPConfirmation(user.Id, "drawing.generate", payloadHash)
+		require.NoError(t, createErr)
+		return &model.OpenSourceBountyMCPConfirmedOperation{
+			State: state, ToolName: "drawing.generate", PayloadHash: payloadHash,
+		}
+	}
+
+	forged := newOperation(t)
+	forged.State = "mcp_confirm_forged"
+	assert.Error(t, drawingMCPConsumeConfirmation(user.Id, forged))
+
+	wrongPayload := newOperation(t)
+	wrongPayload.PayloadHash = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+	assert.Error(t, drawingMCPConsumeConfirmation(user.Id, wrongPayload))
+
+	replayed := newOperation(t)
+	require.NoError(t, drawingMCPConsumeConfirmation(user.Id, replayed))
+	assert.Error(t, drawingMCPConsumeConfirmation(user.Id, replayed))
+
+	concurrent := newOperation(t)
+	results := make(chan error, 2)
+	var wait sync.WaitGroup
+	wait.Add(2)
+	for range 2 {
+		go func() {
+			defer wait.Done()
+			results <- drawingMCPConsumeConfirmation(user.Id, concurrent)
+		}()
+	}
+	wait.Wait()
+	close(results)
+	successes := 0
+	for consumeErr := range results {
+		if consumeErr == nil {
+			successes++
+		}
+	}
+	assert.Equal(t, 1, successes)
 }

--- a/packaging/aur/test-bin-makepkg.sh
+++ b/packaging/aur/test-bin-makepkg.sh
@@ -64,12 +64,18 @@ go_pkgver=$(awk -F= '$1 == "pkgver" { print $2; exit }' "$HERE/lmm-api-go-bin/PK
 [[ $go_pkgver =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || die "invalid Go binary pkgver: $go_pkgver"
 go_artifact="lmm-api-go-${go_pkgver}-linux-amd64"
 go_bundle="$go_work/stage/$go_artifact"
-mkdir -p "$go_bundle/frontend-dist"
+mkdir -p "$go_bundle/frontend-dist" "$go_bundle/edge-policy/nginx"
 cp "$HERE/lmm-api-go-bin/PKGBUILD" "$go_work/"
 printf '#!/bin/sh\nexit 0\n' > "$go_bundle/lmm-api-go"
 chmod 0755 "$go_bundle/lmm-api-go"
 printf '<!doctype html>\n' > "$go_bundle/frontend-dist/index.html"
 cp "$SHARED/lmm-api.service" "$SHARED/lmm-api-go.env" "$go_bundle/"
+for file in http-map.conf lmm-api-locations.conf mime.types new-api.conf lmm-api-region-policy.conf; do
+  printf 'fixture\n' > "$go_bundle/edge-policy/nginx/$file"
+done
+for file in geoip2-country-update.service geoip2-country-update.timer; do
+  printf 'fixture\n' > "$go_bundle/edge-policy/$file"
+done
 add_metadata "$go_bundle"
 create_archive "$go_work" "$go_artifact"
 pin_fixture_hashes "$go_work/PKGBUILD" sha256sums_x86_64 \
@@ -81,7 +87,9 @@ build_package lmm-api-go-bin \
   usr/bin/lmm-api \
   usr/lib/systemd/system/lmm-api.service \
   etc/lmm-api-go/lmm-api-go.env \
-  usr/share/lmm-api-go/frontend-dist/index.html
+  usr/share/lmm-api-go/frontend-dist/index.html \
+  usr/share/lmm-api-go/edge-policy/nginx/http-map.conf \
+  usr/share/lmm-api-go/edge-policy/geoip2-country-update.timer
 
 web_work="$tmp/lmm-api-web-bin"
 web_pkgver=$(awk -F= '$1 == "pkgver" { print $2; exit }' "$HERE/lmm-api-web-bin/PKGBUILD")


### PR DESCRIPTION
Keep the AUR makepkg smoke fixture aligned with the Go package edge-policy payload.

The Go release package now installs managed edge-policy files; the fixture must include and assert those files so AUR CI tests the real package contract.

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

Bug Fixes（错误修复）:
- 对绘图生成的确认进行一次性、与负载绑定的消费约束，拒绝伪造、不匹配、重放以及并发重复的确认请求。

Enhancements（增强）:
- 扩展 AUR Go 软件包夹具，加入具有代表性的托管边缘策略（edge-policy）文件，并验证它们在打包安装中的存在与正确性。
- 使用托管运行器（hosted runner）上已有的检查工具来验证所需的归档和路由覆盖工具，而不是在 CI 和发布工作流中再行安装。

CI:
- 在执行合约与覆盖率检查之前，验证托管运行器上已存在 `bsdtar` 和 `ripgrep`。

Tests（测试）:
- 为无效、重放以及并发的绘图 MCP 确认尝试增加测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

Bug Fixes（错误修复）:
- 对绘图生成的确认进行一次性、与负载绑定的消费约束，拒绝伪造、不匹配、重放以及并发重复的确认请求。

Enhancements（增强）:
- 扩展 AUR Go 软件包夹具，加入具有代表性的托管边缘策略（edge-policy）文件，并验证它们在打包安装中的存在与正确性。
- 使用托管运行器（hosted runner）上已有的检查工具来验证所需的归档和路由覆盖工具，而不是在 CI 和发布工作流中再行安装。

CI:
- 在执行合约与覆盖率检查之前，验证托管运行器上已存在 `bsdtar` 和 `ripgrep`。

Tests（测试）:
- 为无效、重放以及并发的绘图 MCP 确认尝试增加测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

Bug Fixes（错误修复）:
- 对绘图生成的确认进行一次性、与负载绑定的消费约束，拒绝伪造、不匹配、重放以及并发重复的确认请求。

Enhancements（增强）:
- 扩展 AUR Go 软件包夹具，加入具有代表性的托管边缘策略（edge-policy）文件，并验证它们在打包安装中的存在与正确性。
- 使用托管运行器（hosted runner）上已有的检查工具来验证所需的归档和路由覆盖工具，而不是在 CI 和发布工作流中再行安装。

CI:
- 在执行合约与覆盖率检查之前，验证托管运行器上已存在 `bsdtar` 和 `ripgrep`。

Tests（测试）:
- 为无效、重放以及并发的绘图 MCP 确认尝试增加测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

Bug Fixes（错误修复）:
- 对绘图生成的确认进行一次性、与负载绑定的消费约束，拒绝伪造、不匹配、重放以及并发重复的确认请求。

Enhancements（增强）:
- 扩展 AUR Go 软件包夹具，加入具有代表性的托管边缘策略（edge-policy）文件，并验证它们在打包安装中的存在与正确性。
- 使用托管运行器（hosted runner）上已有的检查工具来验证所需的归档和路由覆盖工具，而不是在 CI 和发布工作流中再行安装。

CI:
- 在执行合约与覆盖率检查之前，验证托管运行器上已存在 `bsdtar` 和 `ripgrep`。

Tests（测试）:
- 为无效、重放以及并发的绘图 MCP 确认尝试增加测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在与受管 edge-policy 内容保持一致的同时，对包的 fixtures 和交付检查进行对齐，并强化绘图确认的处理逻辑。

Bug Fixes:
- 强制绘图确认只能一次性、且与负载绑定地被消费，以拒绝伪造的、不匹配的、重放的以及并发的重复请求。

Enhancements:
- 扩展 AUR Go 包的 fixture，纳入具有代表性的受管 edge-policy 文件，并验证它们在打包安装过程中的正确性。

CI:
- 用可移植、经校验和验证的工具安装方案替换 CI 和发布工作流中的包管理器安装方式，并为归档与路由覆盖检查提供回退机制。

Tests:
- 增加对无效、重放以及并发绘图确认尝试的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align package fixtures and delivery checks with managed edge-policy contents while hardening drawing confirmation handling.

Bug Fixes:
- Enforce one-time, payload-bound consumption of drawing confirmations to reject forged, mismatched, replayed, and concurrent duplicate requests.

Enhancements:
- Expand the AUR Go package fixture to include representative managed edge-policy files and verify their packaged installation.

CI:
- Replace CI and release workflow package-manager installs with portable, checksum-verified tooling setup and fallbacks for archive and route-coverage checks.

Tests:
- Add coverage for invalid, replayed, and concurrent drawing confirmation attempts.

</details>

</details>

</details>

</details>