### PR TITLE
fix(web): distinguish tiered pricing from dynamic profit

### DIFF
--- a/apps/web/src/features/pricing/components/dynamic-pricing-breakdown.tsx
+++ b/apps/web/src/features/pricing/components/dynamic-pricing-breakdown.tsx
@@ -259,7 +259,7 @@ export function DynamicPricingBreakdown({
           </span>
           <div>
             <div className='text-foreground text-base font-medium'>
-              {t('Dynamic Pricing')}
+              {t('Tiered pricing')}
             </div>
             <div className='text-muted-foreground text-xs'>
               {t('Prices vary by usage tier and request conditions')}

--- a/apps/web/src/features/pricing/components/model-billing-mode-badge.tsx
+++ b/apps/web/src/features/pricing/components/model-billing-mode-badge.tsx
@@ -35,7 +35,7 @@ export function ModelBillingModeBadge(props: ModelBillingModeBadgeProps) {
   let variant: StatusVariant = 'purple'
 
   if (isDynamicPricingModel(props.model)) {
-    label = t('Dynamic Pricing')
+    label = t('Tiered (billing expression)')
     variant = 'warning'
   } else if (isTokenBasedModel(props.model)) {
     label = t('Token-based')

--- a/apps/web/src/features/pricing/components/model-card.tsx
+++ b/apps/web/src/features/pricing/components/model-card.tsx
@@ -123,7 +123,7 @@ export const ModelCard = memo(function ModelCard(props: ModelCardProps) {
     } else {
       priceSummary = (
         <span className='text-muted-foreground text-sm'>
-          {t('Dynamic Pricing')}
+          {t('Tiered pricing')}
         </span>
       )
     }

--- a/apps/web/src/features/pricing/components/model-details.tsx
+++ b/apps/web/src/features/pricing/components/model-details.tsx
@@ -688,9 +688,7 @@ function PriceSection(props: {
             ))}
           </div>
         ) : (
-          <p className='text-muted-foreground text-sm'>
-            {t('Dynamic Pricing')}
-          </p>
+          <p className='text-muted-foreground text-sm'>{t('Tiered pricing')}</p>
         )}
         {dynamicSummary.secondaryEntries.length > 0 && (
           <div className='bg-muted/20 mt-3 rounded-lg border px-3 py-2.5'>

--- a/apps/web/src/features/pricing/components/pricing-columns.tsx
+++ b/apps/web/src/features/pricing/components/pricing-columns.tsx
@@ -146,7 +146,7 @@ export function usePricingColumns(
           if (primaryEntries.length === 0) {
             return (
               <span className='text-muted-foreground text-xs'>
-                {t('Dynamic Pricing')}
+                {t('Tiered pricing')}
               </span>
             )
           }

--- a/apps/web/src/features/system-settings/models/dynamic-pricing-section.tsx
+++ b/apps/web/src/features/system-settings/models/dynamic-pricing-section.tsx
@@ -294,6 +294,7 @@ export function DynamicPricingSection({
     }
   }
   const safetyReady = status?.safety.ready ?? false
+  const livePricingEnabled = status?.enabled === true
 
   return (
     <SettingsSection title={t('Dynamic Profit Pricing')}>
@@ -678,16 +679,28 @@ export function DynamicPricingSection({
                       ) : null}
                     </TableCell>
                     <TableCell className='font-medium'>
-                      {factorText([
-                        model.request_factor_min,
-                        model.request_factor_max,
-                      ])}
+                      {livePricingEnabled
+                        ? factorText([
+                            model.request_factor_min,
+                            model.request_factor_max,
+                          ])
+                        : '—'}
                     </TableCell>
-                    <TableCell>{model.hard_cost_floor.toFixed(3)}×</TableCell>
-                    <TableCell>{model.load_ema.toFixed(3)}</TableCell>
-                    <TableCell>${model.cost_ema.toFixed(4)}</TableCell>
+                    <TableCell>
+                      {livePricingEnabled
+                        ? `${model.hard_cost_floor.toFixed(3)}×`
+                        : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {livePricingEnabled ? model.load_ema.toFixed(3) : '—'}
+                    </TableCell>
+                    <TableCell>
+                      {livePricingEnabled
+                        ? `$${model.cost_ema.toFixed(4)}`
+                        : '—'}
+                    </TableCell>
                     <TableCell className='text-muted-foreground'>
-                      {model.updated_at > 0
+                      {livePricingEnabled && model.updated_at > 0
                         ? dayjs(model.updated_at * 1000).format('HH:mm:ss')
                         : '—'}
                     </TableCell>

--- a/apps/web/src/features/usage-logs/components/columns/common-logs-columns.tsx
+++ b/apps/web/src/features/usage-logs/components/columns/common-logs-columns.tsx
@@ -94,6 +94,14 @@ function getGroupRatio(other: LogOtherData | null): number | null {
   return null
 }
 
+function getDynamicProfitMultiplier(other: LogOtherData | null): number | null {
+  const multiplier = other?.dynamic_pricing
+  if (multiplier == null || !Number.isFinite(multiplier) || multiplier <= 0) {
+    return null
+  }
+  return multiplier
+}
+
 function buildDetailSegments(
   log: UsageLog,
   other: LogOtherData | null,
@@ -209,7 +217,7 @@ function buildTypeDetailSegments(
       }
     } else {
       segments.push({
-        text: `${t('Dynamic Pricing')} · ${t('No matching results')}`,
+        text: `${t('Tiered pricing')} · ${t('No matching results')}`,
         muted: true,
       })
     }
@@ -551,6 +559,7 @@ export function useCommonLogsColumns(isAdmin: boolean): ColumnDef<UsageLog>[] {
       let group = log.group
       if (!group) group = other?.group || ''
       const groupRatio = getGroupRatio(other)
+      const dynamicProfitMultiplier = getDynamicProfitMultiplier(other)
 
       return (
         <div className='flex max-w-[200px] flex-col gap-0.5'>
@@ -573,8 +582,8 @@ export function useCommonLogsColumns(isAdmin: boolean): ColumnDef<UsageLog>[] {
               )}
             </Tooltip>
           </TooltipProvider>
-          {(group || groupRatio != null) && (
-            <span className='block max-w-full truncate text-xs leading-none'>
+          {(group || groupRatio != null || dynamicProfitMultiplier != null) && (
+            <span className='flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs leading-none'>
               {group ? (
                 <GroupBadge
                   group={group}
@@ -586,8 +595,22 @@ export function useCommonLogsColumns(isAdmin: boolean): ColumnDef<UsageLog>[] {
               ) : null}
               {group && groupRatio != null ? ' ' : null}
               {groupRatio != null ? (
-                <span className='text-muted-foreground/60 relative top-px align-baseline tabular-nums'>
-                  {formatRatioCompact(groupRatio)}x
+                <span
+                  className='text-muted-foreground/60 relative top-px align-baseline tabular-nums'
+                  title={t('Cost multiplier')}
+                  aria-label={`${t('Cost multiplier')}: ${formatRatioCompact(groupRatio)}x`}
+                >
+                  {t('Cost multiplier')} {formatRatioCompact(groupRatio)}x
+                </span>
+              ) : null}
+              {dynamicProfitMultiplier != null ? (
+                <span
+                  className='text-primary/80 relative top-px align-baseline tabular-nums'
+                  title={t('Profit multiplier')}
+                  aria-label={`${t('Profit multiplier')}: ${formatRatioCompact(dynamicProfitMultiplier)}x`}
+                >
+                  {t('Profit multiplier')}{' '}
+                  {formatRatioCompact(dynamicProfitMultiplier)}x
                 </span>
               ) : null}
             </span>

--- a/apps/web/src/features/usage-logs/components/dialogs/details-dialog.tsx
+++ b/apps/web/src/features/usage-logs/components/dialogs/details-dialog.tsx
@@ -233,7 +233,7 @@ function BillingBreakdown(props: {
   if (isTieredExpr) {
     rows.push({
       label: t('Billing Mode'),
-      value: t('Dynamic Pricing'),
+      value: t('Tiered pricing'),
     })
     if (tieredSummary) {
       if (tieredSummary.tier.label) {
@@ -1079,7 +1079,7 @@ export function DetailsDialog(props: DetailsDialogProps) {
 
         {/* Tiered pricing breakdown (when billing_mode is tiered_expr) */}
         {isTieredBilling && other?.expr_b64 && (
-          <DetailSection label={t('Dynamic Pricing')}>
+          <DetailSection label={t('Tiered pricing')}>
             <DynamicPricingBreakdown
               compact
               billingExpr={decodeBillingExprB64(other.expr_b64)}

--- a/apps/web/src/features/usage-logs/types.ts
+++ b/apps/web/src/features/usage-logs/types.ts
@@ -180,6 +180,10 @@ export interface LogOtherData {
   model_price?: number
   group_ratio?: number
   user_group_ratio?: number
+  // The live profit multiplier is recorded separately from the static
+  // pricing-group cost multiplier. It is absent when dynamic pricing was
+  // disabled for the request.
+  dynamic_pricing?: number
   cache_ratio?: number
   cache_creation_ratio?: number
   cache_creation_ratio_5m?: number


### PR DESCRIPTION
## What changed
- Rename model-square and usage-detail labels for `billing_mode=tiered_expr` from “Dynamic Pricing” to “Tiered pricing”.
- Keep static pricing-group ratios labeled as cost multipliers.
- Show a profit multiplier only when the request actually carries dynamic-pricing metadata.
- Hide stale live-factor/cost-EMA values in the dynamic-profit settings table while the feature is disabled.

## Why
The model square's usage-tier billing expression was being conflated with the separate dynamic profit-pricing switch. This made a static group ratio such as GPT-Auto 0.2x look like a live dynamic multiplier.

## Validation
- Web format and format:check
- i18n sync (all locales complete)
- Model-details and pricing-toolbar tests
- Usage-log cost display tests
- Web typecheck

## Summary by Sourcery

在整个 web 界面中澄清分级计费和动态利润定价。

新功能：
- 当存在动态定价元数据时，在使用日志（usage-log）显示中区分实时利润倍数与静态成本倍数。

错误修复：
- 防止在模型、定价和使用日志界面中将分级计费表达式误标为动态利润定价。
- 当实时动态定价被禁用时，隐藏过期的动态利润指标和时间戳。

增强：
- 在保留静态定价组成本倍数标签的同时，澄清分级表达式的计费模式和定价标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify tiered billing and dynamic profit pricing throughout the web interface.

New Features:
- Distinguish live profit multipliers from static cost multipliers in usage-log displays when dynamic pricing metadata is present.

Bug Fixes:
- Prevent tiered billing expressions from being mislabeled as dynamic profit pricing across model, pricing, and usage-log interfaces.
- Hide stale dynamic-profit metrics and timestamps when live dynamic pricing is disabled.

Enhancements:
- Clarify billing-mode and pricing labels for tiered expressions while preserving cost-multiplier labeling for static pricing groups.

</details>