### PR TITLE
remove version updates settings section

### DIFF
--- a/apps/web/src/features/system-settings/content/section-registry.tsx
+++ b/apps/web/src/features/system-settings/content/section-registry.tsx
@@ -25,7 +25,6 @@ import { ChatSettingsSection } from './chat-settings-section'
 import { DashboardSection } from './dashboard-section'
 import { DrawingSettingsSection } from './drawing-settings-section'
 import { FAQSection } from './faq-section'
-import { ReleaseNotesSection } from './release-notes-section'
 import { UptimeKumaSection } from './uptime-kuma-section'
 
 /**
@@ -64,11 +63,6 @@ const CONTENT_SECTIONS = [
         data={settings['console_setting.announcements']}
       />
     ),
-  },
-  {
-    id: 'release-notes',
-    titleKey: 'Version updates',
-    build: () => <ReleaseNotesSection />,
   },
   {
     id: 'api-info',


### PR DESCRIPTION
## Summary

- Remove the Version updates section from the system settings content navigation.
- Keep existing release-note APIs and user-facing notification data unchanged.

## Validation

- `bun run --filter @lmm/web typecheck`
- `bun run --filter @lmm/web format:check`
- `git diff --check`

## Summary by Sourcery

Enhancements:
- 从系统设置内容导航中移除“Version updates”（版本更新）部分，同时保留现有的发布说明 API 和面向用户的通知数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove the Version updates section from the system settings content navigation while preserving existing release-note APIs and user-facing notification data.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- 从系统设置内容导航中移除“Version updates”（版本更新）部分，同时保留现有的发布说明 API 和面向用户的通知数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Remove the Version updates section from the system settings content navigation while preserving existing release-note APIs and user-facing notification data.

</details>

</details>