### PR TITLE
Prevent public relay API key disclosure

### DIFF
--- a/apps/api-go/model/public_relay_contribution.go
+++ b/apps/api-go/model/public_relay_contribution.go
@@ -44,16 +44,16 @@ var (
 	ErrPublicRelayGroupMismatch   = errors.New("channel is not in the configured public group")
 )
 
-// PublicRelayContribution is a user-submitted channel candidate. The complete
-// configuration is available only to the owner and administrators while the
-// public view remains strictly limited to the fields in PublicRelayView.
+// PublicRelayContribution is a user-submitted channel candidate. ChannelConfig
+// is retained for server-side processing but must never be serialized because
+// it contains upstream credentials.
 type PublicRelayContribution struct {
 	Id               int     `json:"id" gorm:"primaryKey"`
 	UserId           int     `json:"user_id" gorm:"not null;index"`
 	ContributorEmail string  `json:"contributor_email" gorm:"type:varchar(255);not null"`
 	Name             string  `json:"name" gorm:"type:varchar(120);not null"`
 	BaseURL          string  `json:"base_url" gorm:"type:varchar(512);not null"`
-	ChannelConfig    string  `json:"channel_config,omitempty" gorm:"type:text;not null;default:''"`
+	ChannelConfig    string  `json:"-" gorm:"type:text;not null;default:''"`
 	Group            string  `json:"group" gorm:"type:varchar(64);not null;index"`
 	Models           string  `json:"models" gorm:"type:text"`
 	Description      string  `json:"description" gorm:"type:text"`

--- a/apps/api-go/model/public_relay_contribution_test.go
+++ b/apps/api-go/model/public_relay_contribution_test.go
@@ -54,6 +54,18 @@ func TestPublicRelayPublicViewDoesNotExposeChannelConfig(t *testing.T) {
 	assert.NotContains(t, string(encoded), "secret-key")
 }
 
+func TestPublicRelayContributionDoesNotSerializeChannelConfig(t *testing.T) {
+	item := PublicRelayContribution{
+		Name:          "shared relay",
+		ChannelConfig: `{"channel":{"key":"secret-key"}}`,
+	}
+
+	encoded, err := json.Marshal(item)
+	require.NoError(t, err)
+	assert.NotContains(t, string(encoded), "channel_config")
+	assert.NotContains(t, string(encoded), "secret-key")
+}
+
 func TestPublicRelayTipsRemainPendingUntilWithdrawal(t *testing.T) {
 	db := setupConsoleActivationTestDB(t)
 	require.NoError(t, db.AutoMigrate(&PublicRelayContribution{}, &PublicRelayTip{}))


### PR DESCRIPTION
### Motivation
- The admin listing could serialize user-submitted `channel_config` (including upstream API keys) because `PublicRelayContribution.ChannelConfig` had a public JSON tag, allowing secrets to be exposed to any account with `AdminAuth`; this change prevents accidental serialization.

### Description
- Stop JSON serialization of the stored channel config by changing `PublicRelayContribution.ChannelConfig` to `json:"-"` while preserving the `gorm` DB tag, and add `TestPublicRelayContributionDoesNotSerializeChannelConfig` to assert serializing `PublicRelayContribution` does not include `channel_config` or the secret (files modified: `apps/api-go/model/public_relay_contribution.go`, `apps/api-go/model/public_relay_contribution_test.go`).

### Testing
- Ran `go test ./model -run 'TestPublicRelay(ChannelConfigPreservesFullConfiguration|PublicViewDoesNotExposeChannelConfig|ContributionDoesNotSerializeChannelConfig)$' -count=1` and `go test ./model -count=1`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a86d6dc50708320bba61bb842bd83d8)

## Summary by Sourcery

防止公共中继贡献在序列化时泄露已存储的频道配置机密信息。

Bug Fixes:
- 防止通过 JSON 序列化暴露已存储的公共中继频道配置（包括上游 API 凭证）。

Tests:
- 增加测试覆盖，验证公共中继贡献在序列化时会省略频道配置及其机密信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent public relay contribution serialization from disclosing stored channel configuration secrets.

Bug Fixes:
- Prevent stored public relay channel configurations, including upstream API credentials, from being exposed through JSON serialization.

Tests:
- Add coverage verifying that public relay contributions omit channel configuration and secrets when serialized.

</details>