### PR TITLE
Cache public user usage rankings

### DIFF
--- a/apps/api-go/controller/rankings.go
+++ b/apps/api-go/controller/rankings.go
@@ -24,7 +24,7 @@ func GetRankings(c *gin.Context) {
 }
 
 func GetUserUsageRankings(c *gin.Context) {
-	result, err := service.GetUserUsageRankingsSnapshot(c.DefaultQuery("period", "week"))
+	result, err := service.GetUserUsageRankingsSnapshot(c.Request.Context(), c.DefaultQuery("period", "week"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"success": false,

--- a/apps/api-go/model/main.go
+++ b/apps/api-go/model/main.go
@@ -253,6 +253,11 @@ func initDBWithMigrationSession(chooser databaseChooser) (*StartupMigrationSessi
 		sqlDB.SetConnMaxLifetime(time.Second * time.Duration(common.GetEnvOrDefault("SQL_MAX_LIFETIME", 60)))
 
 		if mode == DBMigrationModeApply && !common.IsMasterNode {
+			// Register before the master migration finishes so relevant writes
+			// fail closed until the shared revision singleton exists.
+			if err := RegisterUserRankingRevisionCallbacks(DB); err != nil {
+				return nil, errors.Join(session.closeOnFailure(err), closeDB(DB))
+			}
 			return session, nil
 		}
 		if mode == DBMigrationModeApply && common.UsingMainDatabase(common.DatabaseTypeMySQL) {
@@ -266,6 +271,12 @@ func initDBWithMigrationSession(chooser databaseChooser) (*StartupMigrationSessi
 			return verifyPostgresRuntimeAndSchema(DB)
 		})
 		if err != nil {
+			return nil, errors.Join(session.closeOnFailure(err), closeDB(DB))
+		}
+		if err := VerifyUserRankingRevisionState(DB); err != nil {
+			return nil, errors.Join(session.closeOnFailure(err), closeDB(DB))
+		}
+		if err := RegisterUserRankingRevisionCallbacks(DB); err != nil {
 			return nil, errors.Join(session.closeOnFailure(err), closeDB(DB))
 		}
 		return session, nil
@@ -332,7 +343,7 @@ func InitLogDB(session *StartupMigrationSession) (err error) {
 
 func mainMigrationModels() []interface{} {
 	return []interface{}{
-		&Channel{}, &Token{}, &User{}, &UserSession{}, &AuthFlow{}, &ExternalIdentityClaim{},
+		&Channel{}, &Token{}, &UserRankingRevision{}, &User{}, &UserSession{}, &AuthFlow{}, &ExternalIdentityClaim{},
 		&PasskeyCredential{}, &Option{}, &Redemption{}, &Ability{}, &Log{}, &Midjourney{},
 		&DiscountCode{},
 		&TopUp{}, &QuotaData{}, &Task{}, &Model{}, &Vendor{}, &PrefillGroup{}, &Setup{}, &TwoFA{},
@@ -364,6 +375,9 @@ func migrateDB() error {
 
 	err := DB.AutoMigrate(mainMigrationModels()...)
 	if err != nil {
+		return err
+	}
+	if err := EnsureUserRankingRevisionState(DB); err != nil {
 		return err
 	}
 	if err := BackfillDeveloperAccessRecommendationArchives(); err != nil {
@@ -410,6 +424,7 @@ func migrateDBFast() error {
 	}{
 		{&Channel{}, "Channel"},
 		{&Token{}, "Token"},
+		{&UserRankingRevision{}, "UserRankingRevision"},
 		{&User{}, "User"},
 		{&UserSession{}, "UserSession"},
 		{&AuthFlow{}, "AuthFlow"},
@@ -506,6 +521,9 @@ func migrateDBFast() error {
 		if err != nil {
 			return err
 		}
+	}
+	if err := EnsureUserRankingRevisionState(DB); err != nil {
+		return err
 	}
 	if err := BackfillDeveloperAccessRecommendationArchives(); err != nil {
 		return err

--- a/apps/api-go/model/usedata_rankings.go
+++ b/apps/api-go/model/usedata_rankings.go
@@ -2,10 +2,7 @@ package model
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
-	"encoding/json"
 	"fmt"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
@@ -45,64 +42,6 @@ type UserRankingRow struct {
 	DisplayName string
 	Status      int
 	Setting     string
-}
-
-type userRankingVisibilityFingerprintRow struct {
-	ID          int    `json:"id"`
-	Username    string `json:"username"`
-	DisplayName string `json:"display_name"`
-	Status      int    `json:"status"`
-	Setting     string `json:"setting"`
-	Deleted     bool   `json:"deleted"`
-}
-
-// UserRankingVisibilityFingerprint returns a stable digest of every user field
-// that can affect the public leaderboard. Cache hits compare this digest before
-// serving a snapshot so privacy changes made by another API instance take
-// effect without waiting for the usage-aggregation TTL.
-func UserRankingVisibilityFingerprint(ctx context.Context) (string, error) {
-	if DB == nil {
-		return "", fmt.Errorf("fingerprint user ranking visibility: %w", gorm.ErrInvalidData)
-	}
-	if ctx == nil {
-		return "", fmt.Errorf("fingerprint user ranking visibility: nil context")
-	}
-
-	rows, err := DB.WithContext(ctx).
-		Unscoped().
-		Model(&User{}).
-		Select("id, username, display_name, status, setting, deleted_at").
-		Order("id ASC").
-		Rows()
-	if err != nil {
-		return "", fmt.Errorf("query user ranking visibility: %w", err)
-	}
-	defer rows.Close()
-
-	digest := sha256.New()
-	encoder := json.NewEncoder(digest)
-	for rows.Next() {
-		var id, status int
-		var username, displayName, setting sql.NullString
-		var deletedAt gorm.DeletedAt
-		if err := rows.Scan(&id, &username, &displayName, &status, &setting, &deletedAt); err != nil {
-			return "", fmt.Errorf("scan user ranking visibility: %w", err)
-		}
-		if err := encoder.Encode(userRankingVisibilityFingerprintRow{
-			ID:          id,
-			Username:    username.String,
-			DisplayName: displayName.String,
-			Status:      status,
-			Setting:     setting.String,
-			Deleted:     deletedAt.Valid,
-		}); err != nil {
-			return "", fmt.Errorf("encode user ranking visibility: %w", err)
-		}
-	}
-	if err := rows.Err(); err != nil {
-		return "", fmt.Errorf("iterate user ranking visibility: %w", err)
-	}
-	return hex.EncodeToString(digest.Sum(nil)), nil
 }
 
 func GetRankingQuotaTotals(startTime int64, endTime int64) ([]RankingQuotaTotal, error) {

--- a/apps/api-go/model/usedata_rankings.go
+++ b/apps/api-go/model/usedata_rankings.go
@@ -1,7 +1,11 @@
 package model
 
 import (
+	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
@@ -43,6 +47,64 @@ type UserRankingRow struct {
 	Setting     string
 }
 
+type userRankingVisibilityFingerprintRow struct {
+	ID          int    `json:"id"`
+	Username    string `json:"username"`
+	DisplayName string `json:"display_name"`
+	Status      int    `json:"status"`
+	Setting     string `json:"setting"`
+	Deleted     bool   `json:"deleted"`
+}
+
+// UserRankingVisibilityFingerprint returns a stable digest of every user field
+// that can affect the public leaderboard. Cache hits compare this digest before
+// serving a snapshot so privacy changes made by another API instance take
+// effect without waiting for the usage-aggregation TTL.
+func UserRankingVisibilityFingerprint(ctx context.Context) (string, error) {
+	if DB == nil {
+		return "", fmt.Errorf("fingerprint user ranking visibility: %w", gorm.ErrInvalidData)
+	}
+	if ctx == nil {
+		return "", fmt.Errorf("fingerprint user ranking visibility: nil context")
+	}
+
+	rows, err := DB.WithContext(ctx).
+		Unscoped().
+		Model(&User{}).
+		Select("id, username, display_name, status, setting, deleted_at").
+		Order("id ASC").
+		Rows()
+	if err != nil {
+		return "", fmt.Errorf("query user ranking visibility: %w", err)
+	}
+	defer rows.Close()
+
+	digest := sha256.New()
+	encoder := json.NewEncoder(digest)
+	for rows.Next() {
+		var id, status int
+		var username, displayName, setting sql.NullString
+		var deletedAt gorm.DeletedAt
+		if err := rows.Scan(&id, &username, &displayName, &status, &setting, &deletedAt); err != nil {
+			return "", fmt.Errorf("scan user ranking visibility: %w", err)
+		}
+		if err := encoder.Encode(userRankingVisibilityFingerprintRow{
+			ID:          id,
+			Username:    username.String,
+			DisplayName: displayName.String,
+			Status:      status,
+			Setting:     setting.String,
+			Deleted:     deletedAt.Valid,
+		}); err != nil {
+			return "", fmt.Errorf("encode user ranking visibility: %w", err)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return "", fmt.Errorf("iterate user ranking visibility: %w", err)
+	}
+	return hex.EncodeToString(digest.Sum(nil)), nil
+}
+
 func GetRankingQuotaTotals(startTime int64, endTime int64) ([]RankingQuotaTotal, error) {
 	var rows []RankingQuotaTotal
 	query := DB.Table("quota_data").
@@ -79,7 +141,7 @@ func GetRankingQuotaBuckets(startTime int64, endTime int64, bucketSize int64) ([
 // of those rows, so callers can consume the ordered result incrementally.
 func IterateRankingQuotaBuckets(startTime int64, endTime int64, bucketSize int64, visit func(RankingQuotaBucket) error) error {
 	if DB == nil || visit == nil {
-		return gorm.ErrInvalidData
+		return fmt.Errorf("iterate ranking quota buckets: %w", gorm.ErrInvalidData)
 	}
 	if bucketSize <= 0 {
 		bucketSize = 3600
@@ -94,19 +156,22 @@ func IterateRankingQuotaBuckets(startTime int64, endTime int64, bucketSize int64
 	query = applyRankingQuotaTimeRange(query, startTime, endTime)
 	rows, err := query.Rows()
 	if err != nil {
-		return err
+		return fmt.Errorf("query ranking quota buckets: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
 		var row RankingQuotaBucket
 		if err := rows.Scan(&row.ModelName, &row.Bucket, &row.Tokens); err != nil {
-			return err
+			return fmt.Errorf("scan ranking quota bucket: %w", err)
 		}
 		if err := visit(row); err != nil {
-			return err
+			return fmt.Errorf("visit ranking quota bucket: %w", err)
 		}
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate ranking quota buckets: %w", err)
+	}
+	return nil
 }
 
 func GetUserRankingTotals(startTime int64, endTime int64) ([]UserRankingTotal, error) {
@@ -125,13 +190,16 @@ func GetUserRankingTotals(startTime int64, endTime int64) ([]UserRankingTotal, e
 // IterateUserRankingRows streams grouped usage rows directly from the
 // database. The slice-returning helper above remains for compatibility, while
 // the public leaderboard uses this bounded path for large installations.
-func IterateUserRankingRows(startTime int64, endTime int64, visit func(UserRankingRow) error) error {
+func IterateUserRankingRows(ctx context.Context, startTime int64, endTime int64, visit func(UserRankingRow) error) error {
 	if DB == nil || visit == nil {
-		return gorm.ErrInvalidData
+		return fmt.Errorf("iterate user ranking rows: %w", gorm.ErrInvalidData)
 	}
-	query := DB.Table("quota_data").
+	if ctx == nil {
+		return fmt.Errorf("iterate user ranking rows: nil context")
+	}
+	query := DB.WithContext(ctx).Table("quota_data").
 		Select("quota_data.user_id, COALESCE(SUM(quota_data.count), 0) AS requests, COALESCE(SUM(quota_data.token_used), 0) AS total_tokens, users.username, users.display_name, users.status, users.setting").
-		Joins("JOIN users ON users.id = quota_data.user_id").
+		Joins("JOIN users ON users.id = quota_data.user_id AND users.deleted_at IS NULL").
 		Where("quota_data.user_id > ?", 0).
 		Group("quota_data.user_id, users.username, users.display_name, users.status, users.setting").
 		Having("COALESCE(SUM(quota_data.count), 0) > 0 OR COALESCE(SUM(quota_data.token_used), 0) > 0").
@@ -139,7 +207,7 @@ func IterateUserRankingRows(startTime int64, endTime int64, visit func(UserRanki
 	query = applyRankingQuotaTimeRange(query, startTime, endTime)
 	rows, err := query.Rows()
 	if err != nil {
-		return err
+		return fmt.Errorf("query user ranking rows: %w", err)
 	}
 	defer rows.Close()
 	for rows.Next() {
@@ -154,16 +222,19 @@ func IterateUserRankingRows(startTime int64, endTime int64, visit func(UserRanki
 			&row.Status,
 			&setting,
 		); err != nil {
-			return err
+			return fmt.Errorf("scan user ranking row: %w", err)
 		}
 		row.Username = username.String
 		row.DisplayName = displayName.String
 		row.Setting = setting.String
 		if err := visit(row); err != nil {
-			return err
+			return fmt.Errorf("visit user ranking row: %w", err)
 		}
 	}
-	return rows.Err()
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate user ranking rows: %w", err)
+	}
+	return nil
 }
 
 func GetUsersForUsageRanking(userIDs []int) ([]*User, error) {

--- a/apps/api-go/model/user_ranking_revision.go
+++ b/apps/api-go/model/user_ranking_revision.go
@@ -1,0 +1,181 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	userRankingRevisionSingletonID = 1
+	userRankingCreateCallback      = "lmm:user-ranking-revision:create"
+	userRankingUpdateCallback      = "lmm:user-ranking-revision:update"
+	userRankingDeleteCallback      = "lmm:user-ranking-revision:delete"
+)
+
+var userRankingVisibilityFields = []string{
+	"Status",
+	"Setting",
+	"Username",
+	"DisplayName",
+	"DeletedAt",
+}
+
+// UserRankingRevision is a transactionally monotonic invalidation source for
+// public user-ranking snapshots. All API instances read the same singleton.
+type UserRankingRevision struct {
+	ID       int   `gorm:"primaryKey;autoIncrement:false"`
+	Revision int64 `gorm:"not null"`
+}
+
+// EnsureUserRankingRevisionState creates and seeds the singleton during the
+// migration apply phase. Runtime verify mode must only call the verifier.
+func EnsureUserRankingRevisionState(db *gorm.DB) error {
+	if db == nil {
+		return gorm.ErrInvalidDB
+	}
+	if err := db.AutoMigrate(&UserRankingRevision{}); err != nil {
+		return fmt.Errorf("migrate user ranking revision: %w", err)
+	}
+	seed := UserRankingRevision{ID: userRankingRevisionSingletonID, Revision: 1}
+	if err := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&seed).Error; err != nil {
+		return fmt.Errorf("seed user ranking revision: %w", err)
+	}
+	return VerifyUserRankingRevisionState(db)
+}
+
+// VerifyUserRankingRevisionState proves the singleton exists without writing.
+func VerifyUserRankingRevisionState(db *gorm.DB) error {
+	if db == nil {
+		return gorm.ErrInvalidDB
+	}
+	var state UserRankingRevision
+	if err := db.Where("id = ?", userRankingRevisionSingletonID).Take(&state).Error; err != nil {
+		return fmt.Errorf("read user ranking revision: %w", err)
+	}
+	if state.Revision <= 0 {
+		return errors.New("user ranking revision must be positive")
+	}
+	return nil
+}
+
+// RegisterUserRankingRevisionCallbacks installs fail-closed callbacks on the
+// active GORM connection. Relevant user writes and the revision increment run
+// in the same database transaction.
+func RegisterUserRankingRevisionCallbacks(db *gorm.DB) error {
+	if db == nil {
+		return gorm.ErrInvalidDB
+	}
+	if db.Callback().Create().Get(userRankingCreateCallback) == nil {
+		if err := db.Callback().Create().After("gorm:after_create").Before("gorm:commit_or_rollback_transaction").Register(userRankingCreateCallback, bumpUserRankingRevisionAfterCreate); err != nil {
+			return fmt.Errorf("register user ranking create callback: %w", err)
+		}
+	}
+	if db.Callback().Update().Get(userRankingUpdateCallback) == nil {
+		if err := db.Callback().Update().After("gorm:after_update").Before("gorm:commit_or_rollback_transaction").Register(userRankingUpdateCallback, bumpUserRankingRevisionAfterUpdate); err != nil {
+			return fmt.Errorf("register user ranking update callback: %w", err)
+		}
+	}
+	if db.Callback().Delete().Get(userRankingDeleteCallback) == nil {
+		if err := db.Callback().Delete().After("gorm:after_delete").Before("gorm:commit_or_rollback_transaction").Register(userRankingDeleteCallback, bumpUserRankingRevisionAfterDelete); err != nil {
+			return fmt.Errorf("register user ranking delete callback: %w", err)
+		}
+	}
+	return nil
+}
+
+// CurrentUserRankingRevision performs one indexed singleton read. It is safe
+// on the anonymous hot path and replaces the previous O(number of users) scan.
+func CurrentUserRankingRevision(ctx context.Context) (int64, error) {
+	return currentUserRankingRevision(DB, ctx)
+}
+
+func currentUserRankingRevision(db *gorm.DB, ctx context.Context) (int64, error) {
+	if db == nil {
+		return 0, gorm.ErrInvalidDB
+	}
+	if ctx == nil {
+		return 0, errors.New("read user ranking revision: nil context")
+	}
+	var revision int64
+	if err := db.WithContext(ctx).
+		Model(&UserRankingRevision{}).
+		Where("id = ?", userRankingRevisionSingletonID).
+		Select("revision").
+		Scan(&revision).Error; err != nil {
+		return 0, fmt.Errorf("read user ranking revision: %w", err)
+	}
+	if revision <= 0 {
+		return 0, errors.New("user ranking revision is missing")
+	}
+	return revision, nil
+}
+
+func bumpUserRankingRevisionAfterCreate(tx *gorm.DB) {
+	if userRankingStatement(tx) && tx.RowsAffected > 0 {
+		bumpUserRankingRevision(tx)
+	}
+}
+
+func bumpUserRankingRevisionAfterUpdate(tx *gorm.DB) {
+	if userRankingStatement(tx) && tx.RowsAffected > 0 && userRankingUpdateTouchesVisibility(tx) {
+		bumpUserRankingRevision(tx)
+	}
+}
+
+func bumpUserRankingRevisionAfterDelete(tx *gorm.DB) {
+	if userRankingStatement(tx) && tx.RowsAffected > 0 {
+		bumpUserRankingRevision(tx)
+	}
+}
+
+func userRankingStatement(tx *gorm.DB) bool {
+	return tx != nil && tx.Error == nil && tx.Statement != nil && tx.Statement.Schema != nil &&
+		tx.Statement.Schema.ModelType == reflect.TypeOf(User{})
+}
+
+func userRankingUpdateTouchesVisibility(tx *gorm.DB) bool {
+	if values, ok := tx.Statement.Dest.(map[string]interface{}); ok {
+		for key := range values {
+			if userRankingVisibilityField(key) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, selected := range tx.Statement.Selects {
+		if selected == "*" || userRankingVisibilityField(selected) {
+			return true
+		}
+	}
+	return tx.Statement.Changed(userRankingVisibilityFields...)
+}
+
+func userRankingVisibilityField(name string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(name, "_", ""))
+	switch normalized {
+	case "status", "setting", "username", "displayname", "deletedat":
+		return true
+	default:
+		return false
+	}
+}
+
+func bumpUserRankingRevision(tx *gorm.DB) {
+	result := tx.Session(&gorm.Session{NewDB: true, SkipHooks: true}).
+		Model(&UserRankingRevision{}).
+		Where("id = ?", userRankingRevisionSingletonID).
+		UpdateColumn("revision", gorm.Expr("revision + 1"))
+	if result.Error != nil {
+		tx.AddError(fmt.Errorf("increment user ranking revision: %w", result.Error))
+		return
+	}
+	if result.RowsAffected != 1 {
+		tx.AddError(errors.New("increment user ranking revision: singleton missing"))
+	}
+}

--- a/apps/api-go/model/user_ranking_revision.go
+++ b/apps/api-go/model/user_ranking_revision.go
@@ -12,10 +12,12 @@ import (
 )
 
 const (
-	userRankingRevisionSingletonID = 1
-	userRankingCreateCallback      = "lmm:user-ranking-revision:create"
-	userRankingUpdateCallback      = "lmm:user-ranking-revision:update"
-	userRankingDeleteCallback      = "lmm:user-ranking-revision:delete"
+	userRankingRevisionSingletonID       = 1
+	userRankingCreateCallback            = "lmm:user-ranking-revision:create"
+	userRankingCaptureUpdateCallback     = "lmm:user-ranking-revision:capture-update"
+	userRankingBumpUpdateCallback        = "lmm:user-ranking-revision:bump-update"
+	userRankingDeleteCallback            = "lmm:user-ranking-revision:delete"
+	userRankingUpdateRelevantInstanceKey = "lmm:user-ranking-revision:update-relevant"
 )
 
 var userRankingVisibilityFields = []string{
@@ -76,8 +78,13 @@ func RegisterUserRankingRevisionCallbacks(db *gorm.DB) error {
 			return fmt.Errorf("register user ranking create callback: %w", err)
 		}
 	}
-	if db.Callback().Update().Get(userRankingUpdateCallback) == nil {
-		if err := db.Callback().Update().After("gorm:after_update").Before("gorm:commit_or_rollback_transaction").Register(userRankingUpdateCallback, bumpUserRankingRevisionAfterUpdate); err != nil {
+	if db.Callback().Update().Get(userRankingCaptureUpdateCallback) == nil {
+		if err := db.Callback().Update().After("gorm:before_update").Before("gorm:update").Register(userRankingCaptureUpdateCallback, captureUserRankingRevisionUpdate); err != nil {
+			return fmt.Errorf("register user ranking update capture callback: %w", err)
+		}
+	}
+	if db.Callback().Update().Get(userRankingBumpUpdateCallback) == nil {
+		if err := db.Callback().Update().After("gorm:after_update").Before("gorm:commit_or_rollback_transaction").Register(userRankingBumpUpdateCallback, bumpUserRankingRevisionAfterUpdate); err != nil {
 			return fmt.Errorf("register user ranking update callback: %w", err)
 		}
 	}
@@ -122,8 +129,18 @@ func bumpUserRankingRevisionAfterCreate(tx *gorm.DB) {
 	}
 }
 
+func captureUserRankingRevisionUpdate(tx *gorm.DB) {
+	if userRankingStatement(tx) && userRankingUpdateTouchesVisibility(tx) {
+		tx.InstanceSet(userRankingUpdateRelevantInstanceKey, true)
+	}
+}
+
 func bumpUserRankingRevisionAfterUpdate(tx *gorm.DB) {
-	if userRankingStatement(tx) && tx.RowsAffected > 0 && userRankingUpdateTouchesVisibility(tx) {
+	if !userRankingStatement(tx) || tx.RowsAffected <= 0 {
+		return
+	}
+	relevant, ok := tx.InstanceGet(userRankingUpdateRelevantInstanceKey)
+	if ok && relevant == true {
 		bumpUserRankingRevision(tx)
 	}
 }

--- a/apps/api-go/model/user_ranking_revision_test.go
+++ b/apps/api-go/model/user_ranking_revision_test.go
@@ -1,0 +1,140 @@
+package model
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/LIghtJUNction/api.lmm.best/common"
+	"github.com/glebarez/sqlite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestUserRankingRevisionTracksOnlyVisibilityWrites(t *testing.T) {
+	db := openUserRankingRevisionTestDB(t, "file:user-ranking-revision?mode=memory&cache=shared")
+	ctx := context.Background()
+	initial, err := currentUserRankingRevision(db, ctx)
+	require.NoError(t, err)
+
+	user := User{
+		Username: "ranking-revision-user",
+		AffCode:  "ranking-revision-aff",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, db.Create(&user).Error)
+	created := requireUserRankingRevision(t, db)
+	assert.Equal(t, initial+1, created)
+
+	require.NoError(t, db.Model(&User{}).Where("id = ?", user.Id).Update("quota", 10).Error)
+	assert.Equal(t, created, requireUserRankingRevision(t, db), "unrelated quota updates must not invalidate rankings")
+
+	for index, update := range []map[string]interface{}{
+		{"setting": `{"usage_leaderboard_visibility":"public"}`},
+		{"setting": `{"usage_leaderboard_visibility":"hidden"}`},
+		{"setting": `{"usage_leaderboard_visibility":"public"}`},
+		{"setting": `{"usage_leaderboard_visibility":"hidden"}`},
+		{"display_name": "Visible name"},
+		{"username": "ranking-revision-renamed"},
+		{"status": common.UserStatusDisabled},
+	} {
+		before := requireUserRankingRevision(t, db)
+		require.NoError(t, db.Model(&User{}).Where("id = ?", user.Id).Updates(update).Error)
+		assert.Equal(t, before+1, requireUserRankingRevision(t, db), "visibility update %d must advance monotonically", index)
+	}
+
+	beforeDelete := requireUserRankingRevision(t, db)
+	require.NoError(t, db.Delete(&user).Error)
+	assert.Equal(t, beforeDelete+1, requireUserRankingRevision(t, db))
+}
+
+func TestUserRankingRevisionRollsBackWithUserMutation(t *testing.T) {
+	db := openUserRankingRevisionTestDB(t, "file:user-ranking-revision-rollback?mode=memory&cache=shared")
+	user := User{
+		Username: "ranking-revision-rollback-user",
+		AffCode:  "ranking-revision-rollback-aff",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, db.Create(&user).Error)
+	before := requireUserRankingRevision(t, db)
+
+	expected := errors.New("rollback sentinel")
+	err := db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&User{}).Where("id = ?", user.Id).Update("setting", `{"usage_leaderboard_visibility":"hidden"}`).Error; err != nil {
+			return err
+		}
+		assert.Equal(t, before+1, requireUserRankingRevision(t, tx))
+		return expected
+	})
+	require.ErrorIs(t, err, expected)
+	assert.Equal(t, before, requireUserRankingRevision(t, db))
+}
+
+func TestUserRankingRevisionCallbacksFailClosedWithoutSingleton(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:user-ranking-revision-missing?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, sqlDB.Close()) })
+	require.NoError(t, db.AutoMigrate(&User{}))
+	require.NoError(t, RegisterUserRankingRevisionCallbacks(db))
+
+	user := User{
+		Username: "ranking-revision-missing-user",
+		AffCode:  "ranking-revision-missing-aff",
+		Status:   common.UserStatusEnabled,
+	}
+	err = db.Create(&user).Error
+	require.Error(t, err)
+	var count int64
+	require.NoError(t, db.Model(&User{}).Count(&count).Error)
+	assert.Zero(t, count, "the user write must roll back when revision state is unavailable")
+}
+
+func TestUserRankingRevisionIsSharedAcrossDatabaseHandles(t *testing.T) {
+	dsn := "file:user-ranking-revision-shared?mode=memory&cache=shared"
+	first := openUserRankingRevisionTestDB(t, dsn)
+	second, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	secondSQLDB, err := second.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, secondSQLDB.Close()) })
+	require.NoError(t, RegisterUserRankingRevisionCallbacks(second))
+
+	user := User{
+		Username: "ranking-revision-shared-user",
+		AffCode:  "ranking-revision-shared-aff",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, first.Create(&user).Error)
+	before := requireUserRankingRevision(t, first)
+	require.Equal(t, before, requireUserRankingRevision(t, second))
+
+	require.NoError(t, second.Model(&User{}).Where("id = ?", user.Id).Update("setting", `{"usage_leaderboard_visibility":"hidden"}`).Error)
+	assert.Equal(t, before+1, requireUserRankingRevision(t, first))
+}
+
+func openUserRankingRevisionTestDB(t *testing.T, dsn string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&UserRankingRevision{}, &User{}))
+	require.NoError(t, EnsureUserRankingRevisionState(db))
+	require.NoError(t, RegisterUserRankingRevisionCallbacks(db))
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		if err == nil {
+			assert.NoError(t, sqlDB.Close())
+		}
+	})
+	return db
+}
+
+func requireUserRankingRevision(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	revision, err := currentUserRankingRevision(db, context.Background())
+	require.NoError(t, err, fmt.Sprintf("read revision from %p", db))
+	return revision
+}

--- a/apps/api-go/model/user_ranking_revision_test.go
+++ b/apps/api-go/model/user_ranking_revision_test.go
@@ -45,6 +45,27 @@ func TestUserRankingRevisionTracksOnlyVisibilityWrites(t *testing.T) {
 		assert.Equal(t, before+1, requireUserRankingRevision(t, db), "visibility update %d must advance monotonically", index)
 	}
 
+	var current User
+	require.NoError(t, db.First(&current, user.Id).Error)
+	beforeStructUpdate := requireUserRankingRevision(t, db)
+	require.NoError(t, db.Model(&current).Updates(User{DisplayName: "Struct update name"}).Error)
+	assert.Equal(t, beforeStructUpdate+1, requireUserRankingRevision(t, db), "struct Updates must be captured before GORM mutates Statement.Model")
+
+	var edited User
+	require.NoError(t, db.First(&edited, user.Id).Error)
+	edited.DisplayName = "UpdateWithTx name"
+	beforeUpdateWithTx := requireUserRankingRevision(t, db)
+	require.NoError(t, edited.UpdateWithTx(db, false))
+	assert.Equal(t, beforeUpdateWithTx+1, requireUserRankingRevision(t, db), "User.UpdateWithTx must invalidate cached public identity")
+
+	beforeUpdateColumn := requireUserRankingRevision(t, db)
+	require.NoError(t, db.Model(&User{}).Where("id = ?", user.Id).UpdateColumn("display_name", "").Error)
+	assert.Equal(t, beforeUpdateColumn+1, requireUserRankingRevision(t, db), "UpdateColumn must not bypass privacy invalidation")
+
+	beforeUnrelatedColumn := requireUserRankingRevision(t, db)
+	require.NoError(t, db.Model(&User{}).Where("id = ?", user.Id).UpdateColumn("quota", 20).Error)
+	assert.Equal(t, beforeUnrelatedColumn, requireUserRankingRevision(t, db), "unrelated UpdateColumn must not invalidate rankings")
+
 	beforeDelete := requireUserRankingRevision(t, db)
 	require.NoError(t, db.Delete(&user).Error)
 	assert.Equal(t, beforeDelete+1, requireUserRankingRevision(t, db))

--- a/apps/api-go/service/user_rankings.go
+++ b/apps/api-go/service/user_rankings.go
@@ -18,6 +18,8 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 package service
 
 import (
+	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"sync"
@@ -26,6 +28,7 @@ import (
 	"github.com/LIghtJUNction/api.lmm.best/common"
 	"github.com/LIghtJUNction/api.lmm.best/model"
 	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
+	"golang.org/x/sync/singleflight"
 )
 
 type UserUsageRankingsResponse struct {
@@ -56,30 +59,86 @@ type userUsageCandidate struct {
 }
 
 type userUsageRankingCacheItem struct {
-	expiresAt time.Time
-	data      *UserUsageRankingsResponse
+	expiresAt             time.Time
+	visibilityFingerprint string
+	data                  *UserUsageRankingsResponse
 }
 
+const userUsageRankingStabilityAttempts = 3
+
 var (
-	userUsageRankingCacheMu sync.Mutex
+	userUsageRankingCacheMu sync.RWMutex
 	userUsageRankingCache   = map[string]userUsageRankingCacheItem{}
+	userUsageRankingFlights singleflight.Group
 )
 
-func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, error) {
+func GetUserUsageRankingsSnapshot(ctx context.Context, period string) (*UserUsageRankingsResponse, error) {
 	config, err := rankingConfig(period)
 	if err != nil {
 		return nil, err
 	}
-
-	now := time.Now()
-	// Keep the lock while rebuilding so concurrent public requests cannot all
-	// trigger the same expensive database aggregation on a cache miss.
-	userUsageRankingCacheMu.Lock()
-	defer userUsageRankingCacheMu.Unlock()
-	if item, ok := userUsageRankingCache[config.id]; ok && now.Before(item.expiresAt) {
-		return item.data, nil
+	if ctx == nil {
+		return nil, fmt.Errorf("get user usage rankings: nil context")
 	}
 
+	resultChannel := userUsageRankingFlights.DoChan(config.id, func() (any, error) {
+		return getUserUsageRankingsSnapshot(ctx, config)
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultChannel:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		data, ok := result.Val.(*UserUsageRankingsResponse)
+		if !ok || data == nil {
+			return nil, fmt.Errorf("unexpected user rankings cache result")
+		}
+		return data, nil
+	}
+}
+
+func getUserUsageRankingsSnapshot(ctx context.Context, config rankingPeriodConfig) (*UserUsageRankingsResponse, error) {
+	for attempt := 0; attempt < userUsageRankingStabilityAttempts; attempt++ {
+		visibilityFingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("read user ranking visibility: %w", err)
+		}
+
+		now := time.Now()
+		userUsageRankingCacheMu.RLock()
+		item, ok := userUsageRankingCache[config.id]
+		userUsageRankingCacheMu.RUnlock()
+		if ok && now.Before(item.expiresAt) && item.visibilityFingerprint == visibilityFingerprint {
+			return item.data, nil
+		}
+
+		data, err := buildUserUsageRankingsSnapshot(ctx, config, now)
+		if err != nil {
+			return nil, fmt.Errorf("build user usage rankings: %w", err)
+		}
+		stableFingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("recheck user ranking visibility: %w", err)
+		}
+		if stableFingerprint != visibilityFingerprint {
+			continue
+		}
+
+		userUsageRankingCacheMu.Lock()
+		userUsageRankingCache[config.id] = userUsageRankingCacheItem{
+			expiresAt:             time.Now().Add(rankingCacheTTL),
+			visibilityFingerprint: stableFingerprint,
+			data:                  data,
+		}
+		userUsageRankingCacheMu.Unlock()
+		return data, nil
+	}
+	return nil, fmt.Errorf("user ranking visibility changed while building the snapshot")
+}
+
+func buildUserUsageRankingsSnapshot(ctx context.Context, config rankingPeriodConfig, now time.Time) (*UserUsageRankingsResponse, error) {
 	startTime, endTime := rankingTimeRange(config, now)
 	candidates := make([]userUsageCandidate, 0, rankingLeaderboardLimit)
 	var totalTokens int64
@@ -87,7 +146,7 @@ func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, er
 	participantCount := 0
 	anonymousParticipantCount := 0
 
-	err = model.IterateUserRankingRows(startTime, endTime, func(row model.UserRankingRow) error {
+	err := model.IterateUserRankingRows(ctx, startTime, endTime, func(row model.UserRankingRow) error {
 		if row.Status != common.UserStatusEnabled {
 			return nil
 		}
@@ -152,7 +211,7 @@ func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, er
 		})
 	}
 
-	data := &UserUsageRankingsResponse{
+	return &UserUsageRankingsResponse{
 		Period:                    config.id,
 		UpdatedAt:                 now.Unix(),
 		TotalTokens:               totalTokens,
@@ -160,12 +219,7 @@ func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, er
 		ParticipantCount:          participantCount,
 		AnonymousParticipantCount: anonymousParticipantCount,
 		Users:                     rows,
-	}
-	userUsageRankingCache[config.id] = userUsageRankingCacheItem{
-		expiresAt: now.Add(rankingCacheTTL),
-		data:      data,
-	}
-	return data, nil
+	}, nil
 }
 
 func userUsageCandidateBetter(left, right userUsageCandidate) bool {

--- a/apps/api-go/service/user_rankings.go
+++ b/apps/api-go/service/user_rankings.go
@@ -20,6 +20,7 @@ package service
 import (
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
@@ -54,6 +55,16 @@ type userUsageCandidate struct {
 	tokens    int64
 }
 
+type userUsageRankingCacheItem struct {
+	expiresAt time.Time
+	data      *UserUsageRankingsResponse
+}
+
+var (
+	userUsageRankingCacheMu sync.Mutex
+	userUsageRankingCache   = map[string]userUsageRankingCacheItem{}
+)
+
 func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, error) {
 	config, err := rankingConfig(period)
 	if err != nil {
@@ -61,6 +72,14 @@ func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, er
 	}
 
 	now := time.Now()
+	// Keep the lock while rebuilding so concurrent public requests cannot all
+	// trigger the same expensive database aggregation on a cache miss.
+	userUsageRankingCacheMu.Lock()
+	defer userUsageRankingCacheMu.Unlock()
+	if item, ok := userUsageRankingCache[config.id]; ok && now.Before(item.expiresAt) {
+		return item.data, nil
+	}
+
 	startTime, endTime := rankingTimeRange(config, now)
 	candidates := make([]userUsageCandidate, 0, rankingLeaderboardLimit)
 	var totalTokens int64
@@ -133,7 +152,7 @@ func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, er
 		})
 	}
 
-	return &UserUsageRankingsResponse{
+	data := &UserUsageRankingsResponse{
 		Period:                    config.id,
 		UpdatedAt:                 now.Unix(),
 		TotalTokens:               totalTokens,
@@ -141,7 +160,12 @@ func GetUserUsageRankingsSnapshot(period string) (*UserUsageRankingsResponse, er
 		ParticipantCount:          participantCount,
 		AnonymousParticipantCount: anonymousParticipantCount,
 		Users:                     rows,
-	}, nil
+	}
+	userUsageRankingCache[config.id] = userUsageRankingCacheItem{
+		expiresAt: now.Add(rankingCacheTTL),
+		data:      data,
+	}
+	return data, nil
 }
 
 func userUsageCandidateBetter(left, right userUsageCandidate) bool {

--- a/apps/api-go/service/user_rankings.go
+++ b/apps/api-go/service/user_rankings.go
@@ -59,12 +59,20 @@ type userUsageCandidate struct {
 }
 
 type userUsageRankingCacheItem struct {
-	expiresAt             time.Time
-	visibilityFingerprint string
-	data                  *UserUsageRankingsResponse
+	expiresAt time.Time
+	revision  int64
+	data      *UserUsageRankingsResponse
 }
 
-const userUsageRankingStabilityAttempts = 3
+type userUsageRankingFlightResult struct {
+	revision int64
+	data     *UserUsageRankingsResponse
+}
+
+const (
+	userUsageRankingStabilityAttempts = 3
+	userUsageRankingBuildTimeout      = 30 * time.Second
+)
 
 var (
 	userUsageRankingCacheMu sync.RWMutex
@@ -81,61 +89,80 @@ func GetUserUsageRankingsSnapshot(ctx context.Context, period string) (*UserUsag
 		return nil, fmt.Errorf("get user usage rankings: nil context")
 	}
 
-	resultChannel := userUsageRankingFlights.DoChan(config.id, func() (any, error) {
-		return getUserUsageRankingsSnapshot(ctx, config)
-	})
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case result := <-resultChannel:
-		if result.Err != nil {
-			return nil, result.Err
+	for attempt := 0; attempt < userUsageRankingStabilityAttempts; attempt++ {
+		resultChannel := userUsageRankingFlights.DoChan(config.id, func() (any, error) {
+			buildCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), userUsageRankingBuildTimeout)
+			defer cancel()
+			return getUserUsageRankingsSnapshot(buildCtx, config)
+		})
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case result := <-resultChannel:
+			if result.Err != nil {
+				return nil, result.Err
+			}
+			flightResult, ok := result.Val.(userUsageRankingFlightResult)
+			if !ok || flightResult.data == nil {
+				return nil, fmt.Errorf("unexpected user rankings cache result")
+			}
+			current, err := userUsageRankingFlightIsCurrent(ctx, flightResult)
+			if err != nil {
+				return nil, err
+			}
+			if current {
+				return flightResult.data, nil
+			}
 		}
-		data, ok := result.Val.(*UserUsageRankingsResponse)
-		if !ok || data == nil {
-			return nil, fmt.Errorf("unexpected user rankings cache result")
-		}
-		return data, nil
 	}
+	return nil, fmt.Errorf("user ranking visibility changed while returning the snapshot")
 }
 
-func getUserUsageRankingsSnapshot(ctx context.Context, config rankingPeriodConfig) (*UserUsageRankingsResponse, error) {
+func userUsageRankingFlightIsCurrent(ctx context.Context, result userUsageRankingFlightResult) (bool, error) {
+	currentRevision, err := model.CurrentUserRankingRevision(ctx)
+	if err != nil {
+		return false, fmt.Errorf("validate user ranking revision: %w", err)
+	}
+	return currentRevision == result.revision, nil
+}
+
+func getUserUsageRankingsSnapshot(ctx context.Context, config rankingPeriodConfig) (userUsageRankingFlightResult, error) {
 	for attempt := 0; attempt < userUsageRankingStabilityAttempts; attempt++ {
-		visibilityFingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+		revision, err := model.CurrentUserRankingRevision(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("read user ranking visibility: %w", err)
+			return userUsageRankingFlightResult{}, fmt.Errorf("read user ranking revision: %w", err)
 		}
 
 		now := time.Now()
 		userUsageRankingCacheMu.RLock()
 		item, ok := userUsageRankingCache[config.id]
 		userUsageRankingCacheMu.RUnlock()
-		if ok && now.Before(item.expiresAt) && item.visibilityFingerprint == visibilityFingerprint {
-			return item.data, nil
+		if ok && now.Before(item.expiresAt) && item.revision == revision {
+			return userUsageRankingFlightResult{revision: revision, data: item.data}, nil
 		}
 
 		data, err := buildUserUsageRankingsSnapshot(ctx, config, now)
 		if err != nil {
-			return nil, fmt.Errorf("build user usage rankings: %w", err)
+			return userUsageRankingFlightResult{}, fmt.Errorf("build user usage rankings: %w", err)
 		}
-		stableFingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+		stableRevision, err := model.CurrentUserRankingRevision(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("recheck user ranking visibility: %w", err)
+			return userUsageRankingFlightResult{}, fmt.Errorf("recheck user ranking revision: %w", err)
 		}
-		if stableFingerprint != visibilityFingerprint {
+		if stableRevision != revision {
 			continue
 		}
 
 		userUsageRankingCacheMu.Lock()
 		userUsageRankingCache[config.id] = userUsageRankingCacheItem{
-			expiresAt:             time.Now().Add(rankingCacheTTL),
-			visibilityFingerprint: stableFingerprint,
-			data:                  data,
+			expiresAt: time.Now().Add(rankingCacheTTL),
+			revision:  stableRevision,
+			data:      data,
 		}
 		userUsageRankingCacheMu.Unlock()
-		return data, nil
+		return userUsageRankingFlightResult{revision: stableRevision, data: data}, nil
 	}
-	return nil, fmt.Errorf("user ranking visibility changed while building the snapshot")
+	return userUsageRankingFlightResult{}, fmt.Errorf("user ranking visibility changed while building the snapshot")
 }
 
 func buildUserUsageRankingsSnapshot(ctx context.Context, config rankingPeriodConfig, now time.Time) (*UserUsageRankingsResponse, error) {

--- a/apps/api-go/service/user_rankings_test.go
+++ b/apps/api-go/service/user_rankings_test.go
@@ -12,8 +12,14 @@ import (
 )
 
 func TestGetUserUsageRankingsSnapshotHonorsVisibility(t *testing.T) {
+	userUsageRankingCacheMu.Lock()
+	userUsageRankingCache = map[string]userUsageRankingCacheItem{}
+	userUsageRankingCacheMu.Unlock()
 	require.NoError(t, model.DB.AutoMigrate(&model.QuotaData{}))
 	t.Cleanup(func() {
+		userUsageRankingCacheMu.Lock()
+		userUsageRankingCache = map[string]userUsageRankingCacheItem{}
+		userUsageRankingCacheMu.Unlock()
 		model.DB.Exec("DELETE FROM quota_data")
 		model.DB.Exec("DELETE FROM users")
 	})
@@ -95,4 +101,27 @@ func TestGetUserUsageRankingsSnapshotHonorsVisibility(t *testing.T) {
 	assert.Equal(t, int64(50), result.Users[2].TotalTokens)
 	assert.Equal(t, int64(1), result.Users[2].Requests)
 	assert.InDelta(t, 1.0/9.0, result.Users[2].Share, 0.0001)
+}
+
+func TestGetUserUsageRankingsSnapshotCachesPeriod(t *testing.T) {
+	userUsageRankingCacheMu.Lock()
+	userUsageRankingCache = map[string]userUsageRankingCacheItem{}
+	userUsageRankingCacheMu.Unlock()
+	t.Cleanup(func() {
+		userUsageRankingCacheMu.Lock()
+		userUsageRankingCache = map[string]userUsageRankingCacheItem{}
+		userUsageRankingCacheMu.Unlock()
+	})
+
+	cached := &UserUsageRankingsResponse{Period: "year", UpdatedAt: 123}
+	userUsageRankingCacheMu.Lock()
+	userUsageRankingCache["year"] = userUsageRankingCacheItem{
+		expiresAt: time.Now().Add(time.Minute),
+		data:      cached,
+	}
+	userUsageRankingCacheMu.Unlock()
+
+	result, err := GetUserUsageRankingsSnapshot("year")
+	require.NoError(t, err)
+	assert.Same(t, cached, result)
 }

--- a/apps/api-go/service/user_rankings_test.go
+++ b/apps/api-go/service/user_rankings_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -12,14 +13,9 @@ import (
 )
 
 func TestGetUserUsageRankingsSnapshotHonorsVisibility(t *testing.T) {
-	userUsageRankingCacheMu.Lock()
-	userUsageRankingCache = map[string]userUsageRankingCacheItem{}
-	userUsageRankingCacheMu.Unlock()
+	resetUserUsageRankingCache(t)
 	require.NoError(t, model.DB.AutoMigrate(&model.QuotaData{}))
 	t.Cleanup(func() {
-		userUsageRankingCacheMu.Lock()
-		userUsageRankingCache = map[string]userUsageRankingCacheItem{}
-		userUsageRankingCacheMu.Unlock()
 		model.DB.Exec("DELETE FROM quota_data")
 		model.DB.Exec("DELETE FROM users")
 	})
@@ -72,7 +68,7 @@ func TestGetUserUsageRankingsSnapshotHonorsVisibility(t *testing.T) {
 		{UserID: 105, CreatedAt: createdAt, Count: 1, TokenUsed: 50},
 	}).Error)
 
-	result, err := GetUserUsageRankingsSnapshot("week")
+	result, err := GetUserUsageRankingsSnapshot(context.Background(), "week")
 	require.NoError(t, err)
 	assert.Equal(t, "week", result.Period)
 	assert.Equal(t, int64(450), result.TotalTokens)
@@ -101,9 +97,72 @@ func TestGetUserUsageRankingsSnapshotHonorsVisibility(t *testing.T) {
 	assert.Equal(t, int64(50), result.Users[2].TotalTokens)
 	assert.Equal(t, int64(1), result.Users[2].Requests)
 	assert.InDelta(t, 1.0/9.0, result.Users[2].Share, 0.0001)
+
+	publicSettings := public.GetSetting()
+	publicSettings.UsageLeaderboardVisibility = dto.UsageLeaderboardVisibilityHidden
+	require.NoError(t, model.UpdateUserSetting(public.Id, publicSettings))
+
+	privateResult, err := GetUserUsageRankingsSnapshot(context.Background(), "week")
+	require.NoError(t, err)
+	assert.NotSame(t, result, privateResult)
+	assert.Equal(t, int64(150), privateResult.TotalTokens)
+	assert.Equal(t, int64(3), privateResult.TotalRequests)
+	assert.Equal(t, 2, privateResult.ParticipantCount)
+	assert.Equal(t, 2, privateResult.AnonymousParticipantCount)
+	require.Len(t, privateResult.Users, 2)
+	assert.NotContains(t, []string{privateResult.Users[0].Name, privateResult.Users[1].Name}, "Public user")
 }
 
 func TestGetUserUsageRankingsSnapshotCachesPeriod(t *testing.T) {
+	resetUserUsageRankingCache(t)
+	ctx := context.Background()
+	fingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+	require.NoError(t, err)
+
+	cached := &UserUsageRankingsResponse{Period: "year", UpdatedAt: 123}
+	userUsageRankingCacheMu.Lock()
+	userUsageRankingCache["year"] = userUsageRankingCacheItem{
+		expiresAt:             time.Now().Add(time.Minute),
+		visibilityFingerprint: fingerprint,
+		data:                  cached,
+	}
+	userUsageRankingCacheMu.Unlock()
+
+	result, err := GetUserUsageRankingsSnapshot(ctx, "year")
+	require.NoError(t, err)
+	assert.Same(t, cached, result)
+}
+
+func TestGetUserUsageRankingsSnapshotIgnoresExpiredCache(t *testing.T) {
+	resetUserUsageRankingCache(t)
+	require.NoError(t, model.DB.AutoMigrate(&model.QuotaData{}))
+	ctx := context.Background()
+	fingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+	require.NoError(t, err)
+
+	expired := &UserUsageRankingsResponse{Period: "today", UpdatedAt: 123}
+	userUsageRankingCacheMu.Lock()
+	userUsageRankingCache["today"] = userUsageRankingCacheItem{
+		expiresAt:             time.Now().Add(-time.Minute),
+		visibilityFingerprint: fingerprint,
+		data:                  expired,
+	}
+	userUsageRankingCacheMu.Unlock()
+
+	result, err := GetUserUsageRankingsSnapshot(ctx, "today")
+	require.NoError(t, err)
+	assert.NotSame(t, expired, result)
+
+	userUsageRankingCacheMu.RLock()
+	cached := userUsageRankingCache["today"]
+	userUsageRankingCacheMu.RUnlock()
+	assert.Same(t, result, cached.data)
+	assert.True(t, cached.expiresAt.After(time.Now()))
+	assert.Equal(t, fingerprint, cached.visibilityFingerprint)
+}
+
+func resetUserUsageRankingCache(t *testing.T) {
+	t.Helper()
 	userUsageRankingCacheMu.Lock()
 	userUsageRankingCache = map[string]userUsageRankingCacheItem{}
 	userUsageRankingCacheMu.Unlock()
@@ -112,16 +171,4 @@ func TestGetUserUsageRankingsSnapshotCachesPeriod(t *testing.T) {
 		userUsageRankingCache = map[string]userUsageRankingCacheItem{}
 		userUsageRankingCacheMu.Unlock()
 	})
-
-	cached := &UserUsageRankingsResponse{Period: "year", UpdatedAt: 123}
-	userUsageRankingCacheMu.Lock()
-	userUsageRankingCache["year"] = userUsageRankingCacheItem{
-		expiresAt: time.Now().Add(time.Minute),
-		data:      cached,
-	}
-	userUsageRankingCacheMu.Unlock()
-
-	result, err := GetUserUsageRankingsSnapshot("year")
-	require.NoError(t, err)
-	assert.Same(t, cached, result)
 }

--- a/apps/api-go/service/user_rankings_test.go
+++ b/apps/api-go/service/user_rankings_test.go
@@ -111,20 +111,91 @@ func TestGetUserUsageRankingsSnapshotHonorsVisibility(t *testing.T) {
 	assert.Equal(t, 2, privateResult.AnonymousParticipantCount)
 	require.Len(t, privateResult.Users, 2)
 	assert.NotContains(t, []string{privateResult.Users[0].Name, privateResult.Users[1].Name}, "Public user")
+
+	publicSettings.UsageLeaderboardVisibility = dto.UsageLeaderboardVisibilityPublic
+	require.NoError(t, model.UpdateUserSetting(public.Id, publicSettings))
+	publicAgain, err := GetUserUsageRankingsSnapshot(context.Background(), "week")
+	require.NoError(t, err)
+	require.Len(t, publicAgain.Users, 3)
+	assert.Equal(t, "Public user", publicAgain.Users[0].Name)
+
+	publicSettings.UsageLeaderboardVisibility = dto.UsageLeaderboardVisibilityHidden
+	require.NoError(t, model.UpdateUserSetting(public.Id, publicSettings))
+	hiddenAgain, err := GetUserUsageRankingsSnapshot(context.Background(), "week")
+	require.NoError(t, err)
+	require.Len(t, hiddenAgain.Users, 2)
+	assert.NotContains(t, []string{hiddenAgain.Users[0].Name, hiddenAgain.Users[1].Name}, "Public user")
+}
+
+func TestGetUserUsageRankingsSnapshotRejectsStaleSharedFlight(t *testing.T) {
+	resetUserUsageRankingCache(t)
+	require.NoError(t, model.DB.AutoMigrate(&model.QuotaData{}))
+	t.Cleanup(func() {
+		model.DB.Exec("DELETE FROM quota_data")
+		model.DB.Exec("DELETE FROM users")
+	})
+
+	public := model.User{
+		Id:          201,
+		Username:    "stale-flight-public-user",
+		AffCode:     "stale-flight-public-user-aff",
+		DisplayName: "Stale flight public user",
+		Status:      common.UserStatusEnabled,
+	}
+	public.SetSetting(dto.UserSetting{UsageLeaderboardVisibility: dto.UsageLeaderboardVisibilityPublic})
+	require.NoError(t, model.DB.Create(&public).Error)
+	require.NoError(t, model.DB.Create(&model.QuotaData{
+		UserID: public.Id, CreatedAt: time.Now().Add(-time.Hour).Unix(), Count: 1, TokenUsed: 100,
+	}).Error)
+
+	oldRevision, err := model.CurrentUserRankingRevision(context.Background())
+	require.NoError(t, err)
+	staleFlight := userUsageRankingFlightResult{
+		revision: oldRevision,
+		data: &UserUsageRankingsResponse{
+			Period: "week",
+			Users:  []RankedUserUsage{{Rank: 1, Name: public.DisplayName, TotalTokens: 100}},
+		},
+	}
+	settings := public.GetSetting()
+	settings.UsageLeaderboardVisibility = dto.UsageLeaderboardVisibilityHidden
+	require.NoError(t, model.UpdateUserSetting(public.Id, settings))
+	current, err := userUsageRankingFlightIsCurrent(context.Background(), staleFlight)
+	require.NoError(t, err)
+	assert.False(t, current, "a request after privacy revocation must reject an older shared-flight result")
+
+	result, err := GetUserUsageRankingsSnapshot(context.Background(), "week")
+	require.NoError(t, err)
+	assert.Empty(t, result.Users)
+	assert.Zero(t, result.TotalTokens)
+	assert.Zero(t, result.ParticipantCount)
+}
+
+func TestGetUserUsageRankingsSnapshotCanceledCallerDoesNotCancelSharedBuild(t *testing.T) {
+	resetUserUsageRankingCache(t)
+	require.NoError(t, model.DB.AutoMigrate(&model.QuotaData{}))
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := GetUserUsageRankingsSnapshot(canceled, "month")
+	require.ErrorIs(t, err, context.Canceled)
+	result, err := GetUserUsageRankingsSnapshot(context.Background(), "month")
+	require.NoError(t, err)
+	assert.Equal(t, "month", result.Period)
 }
 
 func TestGetUserUsageRankingsSnapshotCachesPeriod(t *testing.T) {
 	resetUserUsageRankingCache(t)
 	ctx := context.Background()
-	fingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+	revision, err := model.CurrentUserRankingRevision(ctx)
 	require.NoError(t, err)
 
 	cached := &UserUsageRankingsResponse{Period: "year", UpdatedAt: 123}
 	userUsageRankingCacheMu.Lock()
 	userUsageRankingCache["year"] = userUsageRankingCacheItem{
-		expiresAt:             time.Now().Add(time.Minute),
-		visibilityFingerprint: fingerprint,
-		data:                  cached,
+		expiresAt: time.Now().Add(time.Minute),
+		revision:  revision,
+		data:      cached,
 	}
 	userUsageRankingCacheMu.Unlock()
 
@@ -137,15 +208,15 @@ func TestGetUserUsageRankingsSnapshotIgnoresExpiredCache(t *testing.T) {
 	resetUserUsageRankingCache(t)
 	require.NoError(t, model.DB.AutoMigrate(&model.QuotaData{}))
 	ctx := context.Background()
-	fingerprint, err := model.UserRankingVisibilityFingerprint(ctx)
+	revision, err := model.CurrentUserRankingRevision(ctx)
 	require.NoError(t, err)
 
 	expired := &UserUsageRankingsResponse{Period: "today", UpdatedAt: 123}
 	userUsageRankingCacheMu.Lock()
 	userUsageRankingCache["today"] = userUsageRankingCacheItem{
-		expiresAt:             time.Now().Add(-time.Minute),
-		visibilityFingerprint: fingerprint,
-		data:                  expired,
+		expiresAt: time.Now().Add(-time.Minute),
+		revision:  revision,
+		data:      expired,
 	}
 	userUsageRankingCacheMu.Unlock()
 
@@ -158,17 +229,25 @@ func TestGetUserUsageRankingsSnapshotIgnoresExpiredCache(t *testing.T) {
 	userUsageRankingCacheMu.RUnlock()
 	assert.Same(t, result, cached.data)
 	assert.True(t, cached.expiresAt.After(time.Now()))
-	assert.Equal(t, fingerprint, cached.visibilityFingerprint)
+	assert.Equal(t, revision, cached.revision)
 }
 
 func resetUserUsageRankingCache(t *testing.T) {
 	t.Helper()
+	require.NoError(t, model.EnsureUserRankingRevisionState(model.DB))
+	require.NoError(t, model.RegisterUserRankingRevisionCallbacks(model.DB))
 	userUsageRankingCacheMu.Lock()
 	userUsageRankingCache = map[string]userUsageRankingCacheItem{}
 	userUsageRankingCacheMu.Unlock()
+	for _, period := range []string{"today", "week", "month", "year"} {
+		userUsageRankingFlights.Forget(period)
+	}
 	t.Cleanup(func() {
 		userUsageRankingCacheMu.Lock()
 		userUsageRankingCache = map[string]userUsageRankingCacheItem{}
 		userUsageRankingCacheMu.Unlock()
+		for _, period := range []string{"today", "week", "month", "year"} {
+			userUsageRankingFlights.Forget(period)
+		}
 	})
 }


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated requests to `/api/rankings/users` from triggering expensive live aggregations and unbounded allocations on every request by adding a server-side snapshot cache and serialization for cache rebuilds.

### Description
- Add a period-keyed, in-memory cache for user usage leaderboard snapshots with the existing `rankingCacheTTL` TTL and a mutex to serialize cache rebuilds; new types/vars: `userUsageRankingCacheItem`, `userUsageRankingCacheMu`, and `userUsageRankingCache`. (modified `apps/api-go/service/user_rankings.go`).
- Check the cache at the start of `GetUserUsageRankingsSnapshot(period string)` and return a cached snapshot when fresh, otherwise build the snapshot and store it under the period key; rebuilding is serialized to avoid concurrent duplicate aggregations. (modified `apps/api-go/service/user_rankings.go`).
- Add test isolation and a new test that seeds the cache and verifies `GetUserUsageRankingsSnapshot` returns the cached object without recomputing. (modified `apps/api-go/service/user_rankings_test.go`).
- Preserve the existing bounded candidate retention and ranking logic so public behavior and response limits remain unchanged. (unchanged core ranking algorithm in `apps/api-go/service/user_rankings.go`).

### Testing
- `go test ./service -run 'TestGetUserUsageRankingsSnapshot(CachesPeriod|HonorsVisibility)$'` — succeeded. 
- Formatting and lightweight checks (`gofmt` and `git diff --check`) were run and passed as part of the change verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a870ca7f4048320ac62b1a39a98da0c)

## 由 Sourcery 提供的总结

缓存公开的用户使用情况排名快照，以减少重复的聚合工作，并防止在缓存未命中时并发重建。

新功能：
- 按周期缓存用户使用情况排名快照，在无需每次请求都重新计算聚合结果的前提下，提供最新的公开排行榜结果。

改进：
- 将快照重建过程串行化，并保持现有的排名行为和响应结果限制不变。

测试：
- 增加测试覆盖，确认会返回已缓存的快照，并在测试之间隔离缓存状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

缓存公开用户使用排名，并在多个 API 实例间协调快照的新鲜度。

New Features:
- 按周期缓存公开用户使用排名快照，并根据共享的数据库修订版本进行刷新。

Bug Fixes:
- 将已删除用户从公开排名中排除，并在可见性变更后防止返回陈旧结果。
- 在构建排名快照时正确响应请求取消。

Enhancements:
- 协调并发快照生成，在保留现有排名限制和行为的前提下添加带上下文的错误信息。

Build:
- 为共享的用户排名修订状态添加数据迁移和启动时验证。

Tests:
- 增加对缓存命中与过期、可见性失效、并发陈旧结果、请求取消、事务性修订更新以及缺失修订状态等场景的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache public user usage rankings and coordinate snapshot freshness across API instances.

New Features:
- Cache public user usage ranking snapshots by period and refresh them according to a shared database revision.

Bug Fixes:
- Exclude deleted users from public rankings and prevent stale results after visibility changes.
- Honor request cancellation while building ranking snapshots.

Enhancements:
- Coordinate concurrent snapshot generation and add contextual errors while preserving existing ranking limits and behavior.

Build:
- Add migration and startup validation for the shared user-ranking revision state.

Tests:
- Add coverage for cache hits and expiry, visibility invalidation, stale concurrent results, cancellation, transactional revision updates, and missing revision state.

</details>

新功能：
- 按时间区间缓存公共用户使用排行榜快照，并在相关用户可见性数据发生变化时使其失效。
- 新增共享的、事务性的用户排名修订状态，用于在基于数据库的 API 实例之间协调缓存的新鲜度。

错误修复：
- 将软删除用户从公共使用排行榜中排除，并在排行榜查询和快照生成过程中遵守请求取消。

改进：
- 协调并发快照请求，并拒绝因可见性变更而变得过期的结果。
- 改进排行榜查询的错误上下文，同时保持现有的排名行为和响应限制。

测试：
- 增加对缓存命中、过期、可见性失效、并发过期结果、取消行为、事务性修订更新以及缺失修订状态等场景的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

缓存公开用户使用排名，并在多个 API 实例间协调快照的新鲜度。

New Features:
- 按周期缓存公开用户使用排名快照，并根据共享的数据库修订版本进行刷新。

Bug Fixes:
- 将已删除用户从公开排名中排除，并在可见性变更后防止返回陈旧结果。
- 在构建排名快照时正确响应请求取消。

Enhancements:
- 协调并发快照生成，在保留现有排名限制和行为的前提下添加带上下文的错误信息。

Build:
- 为共享的用户排名修订状态添加数据迁移和启动时验证。

Tests:
- 增加对缓存命中与过期、可见性失效、并发陈旧结果、请求取消、事务性修订更新以及缺失修订状态等场景的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache public user usage rankings and coordinate snapshot freshness across API instances.

New Features:
- Cache public user usage ranking snapshots by period and refresh them according to a shared database revision.

Bug Fixes:
- Exclude deleted users from public rankings and prevent stale results after visibility changes.
- Honor request cancellation while building ranking snapshots.

Enhancements:
- Coordinate concurrent snapshot generation and add contextual errors while preserving existing ranking limits and behavior.

Build:
- Add migration and startup validation for the shared user-ranking revision state.

Tests:
- Add coverage for cache hits and expiry, visibility invalidation, stale concurrent results, cancellation, transactional revision updates, and missing revision state.

</details>

</details>

新功能：
- 按周期缓存公共用户使用排行快照，避免重复执行高成本的聚合计算。
- 当用户可见性数据发生变化时使缓存的排行失效，使隐私更新能够被及时反映。

缺陷修复：
- 将软删除用户从公共使用排行中排除。
- 在查询和构建排行快照时正确响应请求取消。

改进：
- 协调并发的快照请求，防止重复重建，并改进数据库错误上下文信息。

测试：
- 增加对已缓存、已过期以及受可见性影响的排行快照的测试覆盖，并保证测试之间的缓存相互隔离。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

缓存公开用户使用排名，并在多个 API 实例间协调快照的新鲜度。

New Features:
- 按周期缓存公开用户使用排名快照，并根据共享的数据库修订版本进行刷新。

Bug Fixes:
- 将已删除用户从公开排名中排除，并在可见性变更后防止返回陈旧结果。
- 在构建排名快照时正确响应请求取消。

Enhancements:
- 协调并发快照生成，在保留现有排名限制和行为的前提下添加带上下文的错误信息。

Build:
- 为共享的用户排名修订状态添加数据迁移和启动时验证。

Tests:
- 增加对缓存命中与过期、可见性失效、并发陈旧结果、请求取消、事务性修订更新以及缺失修订状态等场景的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache public user usage rankings and coordinate snapshot freshness across API instances.

New Features:
- Cache public user usage ranking snapshots by period and refresh them according to a shared database revision.

Bug Fixes:
- Exclude deleted users from public rankings and prevent stale results after visibility changes.
- Honor request cancellation while building ranking snapshots.

Enhancements:
- Coordinate concurrent snapshot generation and add contextual errors while preserving existing ranking limits and behavior.

Build:
- Add migration and startup validation for the shared user-ranking revision state.

Tests:
- Add coverage for cache hits and expiry, visibility invalidation, stale concurrent results, cancellation, transactional revision updates, and missing revision state.

</details>

新功能：
- 按时间区间缓存公共用户使用排行榜快照，并在相关用户可见性数据发生变化时使其失效。
- 新增共享的、事务性的用户排名修订状态，用于在基于数据库的 API 实例之间协调缓存的新鲜度。

错误修复：
- 将软删除用户从公共使用排行榜中排除，并在排行榜查询和快照生成过程中遵守请求取消。

改进：
- 协调并发快照请求，并拒绝因可见性变更而变得过期的结果。
- 改进排行榜查询的错误上下文，同时保持现有的排名行为和响应限制。

测试：
- 增加对缓存命中、过期、可见性失效、并发过期结果、取消行为、事务性修订更新以及缺失修订状态等场景的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

缓存公开用户使用排名，并在多个 API 实例间协调快照的新鲜度。

New Features:
- 按周期缓存公开用户使用排名快照，并根据共享的数据库修订版本进行刷新。

Bug Fixes:
- 将已删除用户从公开排名中排除，并在可见性变更后防止返回陈旧结果。
- 在构建排名快照时正确响应请求取消。

Enhancements:
- 协调并发快照生成，在保留现有排名限制和行为的前提下添加带上下文的错误信息。

Build:
- 为共享的用户排名修订状态添加数据迁移和启动时验证。

Tests:
- 增加对缓存命中与过期、可见性失效、并发陈旧结果、请求取消、事务性修订更新以及缺失修订状态等场景的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cache public user usage rankings and coordinate snapshot freshness across API instances.

New Features:
- Cache public user usage ranking snapshots by period and refresh them according to a shared database revision.

Bug Fixes:
- Exclude deleted users from public rankings and prevent stale results after visibility changes.
- Honor request cancellation while building ranking snapshots.

Enhancements:
- Coordinate concurrent snapshot generation and add contextual errors while preserving existing ranking limits and behavior.

Build:
- Add migration and startup validation for the shared user-ranking revision state.

Tests:
- Add coverage for cache hits and expiry, visibility invalidation, stale concurrent results, cancellation, transactional revision updates, and missing revision state.

</details>

</details>

</details>

</details>