### PR TITLE
fix: redact sensitive channel fields in read endpoints

### DIFF
--- a/apps/api-go/controller/channel.go
+++ b/apps/api-go/controller/channel.go
@@ -64,19 +64,23 @@ func parseStatusFilter(statusParam string) int {
 	}
 }
 
-func clearChannelInfo(c *gin.Context, channel *model.Channel) {
+func canViewChannelSecrets(c *gin.Context) bool {
+	return authz.Can(c.GetInt("id"), c.GetInt("role"), authz.ChannelSecretView)
+}
+
+func clearChannelInfo(channel *model.Channel, canViewSecrets bool) {
 	if channel.ChannelInfo.IsMultiKey {
 		channel.ChannelInfo.MultiKeyDisabledReason = nil
 		channel.ChannelInfo.MultiKeyDisabledTime = nil
 	}
-	if !authz.Can(c.GetInt("id"), c.GetInt("role"), authz.ChannelSensitiveWrite) {
+	if !canViewSecrets {
 		clearChannelSensitiveInfo(channel)
 	}
 }
 
 // clearChannelSensitiveInfo removes provider configuration that may contain
 // credentials. ChannelRead is intentionally sufficient for channel inventory,
-// but these values are only visible to callers trusted to edit them.
+// but these values require the independent ChannelSecretView permission.
 func clearChannelSensitiveInfo(channel *model.Channel) {
 	channel.Key = ""
 	channel.BaseURL = nil
@@ -162,6 +166,7 @@ func GetChannelOps(c *gin.Context) {
 }
 
 func GetAllChannels(c *gin.Context) {
+	canViewSecrets := canViewChannelSecrets(c)
 	pageInfo := common.GetPageQuery(c)
 	channelData := make([]*model.Channel, 0)
 	idSort, _ := strconv.ParseBool(c.Query("id_sort"))
@@ -230,7 +235,7 @@ func GetAllChannels(c *gin.Context) {
 	}
 
 	for _, datum := range channelData {
-		clearChannelInfo(c, datum)
+		clearChannelInfo(datum, canViewSecrets)
 	}
 
 	countQuery := buildChannelListQuery(groupFilter, statusFilter, -1)
@@ -337,6 +342,7 @@ func FixChannelsAbilities(c *gin.Context) {
 }
 
 func SearchChannels(c *gin.Context) {
+	canViewSecrets := canViewChannelSecrets(c)
 	keyword := c.Query("keyword")
 	group := c.Query("group")
 	modelKeyword := c.Query("model")
@@ -362,6 +368,7 @@ func SearchChannels(c *gin.Context) {
 			typeFilter,
 			pageInfo.GetStartIdx(),
 			pageInfo.GetPageSize(),
+			canViewSecrets,
 			idSort,
 			sortOptions,
 		)
@@ -373,7 +380,7 @@ func SearchChannels(c *gin.Context) {
 			return
 		}
 		for _, datum := range result.Channels {
-			clearChannelInfo(c, datum)
+			clearChannelInfo(datum, canViewSecrets)
 		}
 		c.JSON(http.StatusOK, gin.H{
 			"success": true,
@@ -388,7 +395,7 @@ func SearchChannels(c *gin.Context) {
 	}
 
 	channelData := make([]*model.Channel, 0)
-	tags, err := model.SearchTags(keyword, group, modelKeyword, idSort)
+	tags, err := model.SearchTags(keyword, group, modelKeyword, canViewSecrets, idSort)
 	if err != nil {
 		c.JSON(http.StatusOK, gin.H{
 			"success": false,
@@ -465,7 +472,7 @@ func SearchChannels(c *gin.Context) {
 	pagedData := channelData[startIdx:endIdx]
 
 	for _, datum := range pagedData {
-		clearChannelInfo(c, datum)
+		clearChannelInfo(datum, canViewSecrets)
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -492,7 +499,7 @@ func GetChannel(c *gin.Context) {
 		return
 	}
 	if channel != nil {
-		clearChannelInfo(c, channel)
+		clearChannelInfo(channel, canViewChannelSecrets(c))
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
@@ -1223,7 +1230,7 @@ func UpdateChannel(c *gin.Context) {
 		"changed_fields": changedFields,
 	})
 	channel.Key = ""
-	clearChannelInfo(&channel.Channel)
+	clearChannelInfo(&channel.Channel, canViewChannelSecrets(c))
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,
 		"message": "",

--- a/apps/api-go/controller/channel.go
+++ b/apps/api-go/controller/channel.go
@@ -64,11 +64,28 @@ func parseStatusFilter(statusParam string) int {
 	}
 }
 
-func clearChannelInfo(channel *model.Channel) {
+func clearChannelInfo(c *gin.Context, channel *model.Channel) {
 	if channel.ChannelInfo.IsMultiKey {
 		channel.ChannelInfo.MultiKeyDisabledReason = nil
 		channel.ChannelInfo.MultiKeyDisabledTime = nil
 	}
+	if !authz.Can(c.GetInt("id"), c.GetInt("role"), authz.ChannelSensitiveWrite) {
+		clearChannelSensitiveInfo(channel)
+	}
+}
+
+// clearChannelSensitiveInfo removes provider configuration that may contain
+// credentials. ChannelRead is intentionally sufficient for channel inventory,
+// but these values are only visible to callers trusted to edit them.
+func clearChannelSensitiveInfo(channel *model.Channel) {
+	channel.Key = ""
+	channel.BaseURL = nil
+	channel.OpenAIOrganization = nil
+	channel.HeaderOverride = nil
+	channel.ParamOverride = nil
+	channel.Setting = nil
+	channel.Other = ""
+	channel.OtherSettings = ""
 }
 
 func channelIDsFromChannels(channels []*model.Channel) []int {
@@ -213,7 +230,7 @@ func GetAllChannels(c *gin.Context) {
 	}
 
 	for _, datum := range channelData {
-		clearChannelInfo(datum)
+		clearChannelInfo(c, datum)
 	}
 
 	countQuery := buildChannelListQuery(groupFilter, statusFilter, -1)
@@ -356,7 +373,7 @@ func SearchChannels(c *gin.Context) {
 			return
 		}
 		for _, datum := range result.Channels {
-			clearChannelInfo(datum)
+			clearChannelInfo(c, datum)
 		}
 		c.JSON(http.StatusOK, gin.H{
 			"success": true,
@@ -448,7 +465,7 @@ func SearchChannels(c *gin.Context) {
 	pagedData := channelData[startIdx:endIdx]
 
 	for _, datum := range pagedData {
-		clearChannelInfo(datum)
+		clearChannelInfo(c, datum)
 	}
 
 	c.JSON(http.StatusOK, gin.H{
@@ -475,7 +492,7 @@ func GetChannel(c *gin.Context) {
 		return
 	}
 	if channel != nil {
-		clearChannelInfo(channel)
+		clearChannelInfo(c, channel)
 	}
 	c.JSON(http.StatusOK, gin.H{
 		"success": true,

--- a/apps/api-go/controller/channel_authz_test.go
+++ b/apps/api-go/controller/channel_authz_test.go
@@ -129,6 +129,41 @@ func TestClearChannelReadOnlyFields(t *testing.T) {
 	assert.Equal(t, "default", channel.Group)
 }
 
+func TestClearChannelSensitiveInfo(t *testing.T) {
+	baseURL := "https://proxy-user:proxy-pass@example.com"
+	organization := "secret-organization"
+	headerOverride := `{"Authorization":"Bearer secret"}`
+	paramOverride := `{"api_key":"secret"}`
+	setting := `{"credential":"secret"}`
+	channel := &model.Channel{
+		Type:               1,
+		Key:                "secret-key",
+		BaseURL:            &baseURL,
+		OpenAIOrganization: &organization,
+		HeaderOverride:     &headerOverride,
+		ParamOverride:      &paramOverride,
+		Setting:            &setting,
+		Other:              "secret-other",
+		OtherSettings:      `{"proxy":"secret"}`,
+		Name:               "preserved channel name",
+		Models:             "gpt-4o",
+	}
+
+	clearChannelSensitiveInfo(channel)
+
+	assert.Empty(t, channel.Key)
+	assert.Nil(t, channel.BaseURL)
+	assert.Nil(t, channel.OpenAIOrganization)
+	assert.Nil(t, channel.HeaderOverride)
+	assert.Nil(t, channel.ParamOverride)
+	assert.Nil(t, channel.Setting)
+	assert.Empty(t, channel.Other)
+	assert.Empty(t, channel.OtherSettings)
+	assert.Equal(t, 1, channel.Type)
+	assert.Equal(t, "preserved channel name", channel.Name)
+	assert.Equal(t, "gpt-4o", channel.Models)
+}
+
 func TestUpdateChannelRejectsStatusField(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()

--- a/apps/api-go/controller/channel_authz_test.go
+++ b/apps/api-go/controller/channel_authz_test.go
@@ -5,14 +5,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
 	"github.com/LIghtJUNction/api.lmm.best/model"
 	"github.com/gin-gonic/gin"
+	"github.com/glebarez/sqlite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestChannelHasSensitiveChanges(t *testing.T) {
@@ -162,6 +165,106 @@ func TestClearChannelSensitiveInfo(t *testing.T) {
 	assert.Equal(t, 1, channel.Type)
 	assert.Equal(t, "preserved channel name", channel.Name)
 	assert.Equal(t, "gpt-4o", channel.Models)
+}
+
+func TestChannelReadEndpointsRequireSecretViewForSensitiveData(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	previousDB := model.DB
+	previousDatabaseType := common.MainDatabaseType()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&model.Channel{}))
+	model.DB = db
+	common.SetMainDatabaseType(common.DatabaseTypeSQLite)
+	t.Cleanup(func() {
+		model.DB = previousDB
+		common.SetMainDatabaseType(previousDatabaseType)
+	})
+
+	baseURL := "https://channel-read-secret.example.com/v1"
+	headerOverride := `{"X-Provider-Metadata":"header-redaction-sentinel"}`
+	paramOverride := `{"request_field":"param-redaction-sentinel"}`
+	setting := `{"proxy":"https://proxy-redaction.example.com"}`
+	keySearch := "provider-key-lookup-sentinel"
+	channel := model.Channel{
+		Name:           "ordinary channel inventory entry",
+		Key:            keySearch,
+		BaseURL:        &baseURL,
+		HeaderOverride: &headerOverride,
+		ParamOverride:  &paramOverride,
+		Setting:        &setting,
+		Other:          "other-redaction-sentinel",
+		OtherSettings:  `{"provider":"other-settings-redaction-sentinel"}`,
+		Models:         "gpt-5",
+		Group:          "default",
+		Status:         common.ChannelStatusEnabled,
+	}
+	require.NoError(t, model.DB.Create(&channel).Error)
+	t.Cleanup(func() { model.DB.Unscoped().Delete(&channel) })
+
+	readChannel := func(role int) model.Channel {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/api/channel/"+strconv.Itoa(channel.Id), nil)
+		ctx.Params = gin.Params{{Key: "id", Value: strconv.Itoa(channel.Id)}}
+		ctx.Set("id", 880001+role)
+		ctx.Set("role", role)
+		GetChannel(ctx)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var response struct {
+			Success bool          `json:"success"`
+			Data    model.Channel `json:"data"`
+		}
+		require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &response))
+		require.True(t, response.Success)
+		return response.Data
+	}
+
+	adminView := readChannel(common.RoleAdminUser)
+	assert.Empty(t, adminView.Key)
+	assert.Nil(t, adminView.BaseURL)
+	assert.Nil(t, adminView.HeaderOverride)
+	assert.Nil(t, adminView.ParamOverride)
+	assert.Nil(t, adminView.Setting)
+	assert.Empty(t, adminView.Other)
+	assert.Empty(t, adminView.OtherSettings)
+	assert.Equal(t, channel.Name, adminView.Name)
+
+	rootView := readChannel(common.RoleRootUser)
+	// The detail query has always omitted the key itself; secret-view controls
+	// the remaining provider configuration fields.
+	assert.Empty(t, rootView.Key)
+	require.NotNil(t, rootView.BaseURL)
+	assert.Equal(t, baseURL, *rootView.BaseURL)
+	assert.Equal(t, channel.OtherSettings, rootView.OtherSettings)
+
+	searchTotal := func(role int, keyword string) int64 {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(recorder)
+		ctx.Request = httptest.NewRequest(http.MethodGet, "/api/channel/search?keyword="+keyword, nil)
+		ctx.Set("id", 880101+role)
+		ctx.Set("role", role)
+		SearchChannels(ctx)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var response struct {
+			Success bool `json:"success"`
+			Data    struct {
+				Total int64 `json:"total"`
+			} `json:"data"`
+		}
+		require.NoError(t, common.Unmarshal(recorder.Body.Bytes(), &response))
+		require.True(t, response.Success)
+		return response.Data.Total
+	}
+
+	for _, keyword := range []string{keySearch, "channel-read-secret.example.com"} {
+		assert.Zero(t, searchTotal(common.RoleAdminUser, keyword))
+		assert.Equal(t, int64(1), searchTotal(common.RoleRootUser, keyword))
+	}
 }
 
 func TestUpdateChannelRejectsStatusField(t *testing.T) {

--- a/apps/api-go/model/channel.go
+++ b/apps/api-go/model/channel.go
@@ -446,7 +446,7 @@ type ChannelSearchPage struct {
 	TypeCounts map[int64]int64
 }
 
-func searchChannelsQuery(keyword string, group string, model string) *gorm.DB {
+func searchChannelsQuery(keyword string, group string, model string, searchSensitiveFields bool) *gorm.DB {
 	modelsCol := "`models`"
 
 	// 如果是 PostgreSQL，使用双引号
@@ -454,26 +454,32 @@ func searchChannelsQuery(keyword string, group string, model string) *gorm.DB {
 		modelsCol = `"models"`
 	}
 
-	baseURLCol := "`base_url`"
-	// 如果是 PostgreSQL，使用双引号
-	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
-		baseURLCol = `"base_url"`
+	conditions := []string{"id = ?", "name LIKE ?"}
+	args := []any{common.String2Int(keyword), "%" + keyword + "%"}
+	if searchSensitiveFields {
+		keyCol := "`key`"
+		baseURLCol := "`base_url`"
+		// 如果是 PostgreSQL，使用双引号
+		if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
+			keyCol = `"key"`
+			baseURLCol = `"base_url"`
+		}
+		conditions = append(conditions, keyCol+" = ?", baseURLCol+" LIKE ?")
+		args = append(args, keyword, "%"+keyword+"%")
 	}
+	args = append(args, "%"+model+"%")
 
-	// 构造基础查询
+	// Key and base URL may only influence matching for callers with explicit
+	// secret-view permission; otherwise result counts become a secret oracle.
+	whereClause := "(" + strings.Join(conditions, " OR ") + ") AND " + modelsCol + " LIKE ?"
 	baseQuery := DB.Model(&Channel{}).Omit("key")
-
-	// 构造WHERE子句
-	whereClause := "(id = ? OR name LIKE ? OR " + commonKeyCol + " = ? OR " + baseURLCol + " LIKE ?) AND " + modelsCol + " LIKE ?"
-	args := []any{common.String2Int(keyword), "%" + keyword + "%", keyword, "%" + keyword + "%", "%" + model + "%"}
-	baseQuery = ApplyChannelGroupFilter(baseQuery.Where(whereClause, args...), group)
-	return baseQuery
+	return ApplyChannelGroupFilter(baseQuery.Where(whereClause, args...), group)
 }
 
 // SearchChannelsPage searches channels with all filters applied by SQL before
 // pagination. TypeCounts intentionally reflects the status/group/model search
 // set before the optional type filter, matching the channel UI's filter counts.
-func SearchChannelsPage(keyword string, group string, model string, statusFilter int, typeFilter int, startIdx int, pageSize int, idSort bool, sortOptions ...ChannelSortOptions) (ChannelSearchPage, error) {
+func SearchChannelsPage(keyword string, group string, model string, statusFilter int, typeFilter int, startIdx int, pageSize int, searchSensitiveFields bool, idSort bool, sortOptions ...ChannelSortOptions) (ChannelSearchPage, error) {
 	if startIdx < 0 {
 		startIdx = 0
 	}
@@ -484,7 +490,7 @@ func SearchChannelsPage(keyword string, group string, model string, statusFilter
 		pageSize = channelSearchMaxPageSize
 	}
 
-	baseQuery := searchChannelsQuery(keyword, group, model)
+	baseQuery := searchChannelsQuery(keyword, group, model, searchSensitiveFields)
 	if statusFilter == common.ChannelStatusEnabled {
 		baseQuery = baseQuery.Where("status = ?", common.ChannelStatusEnabled)
 	} else if statusFilter == 0 {
@@ -526,8 +532,8 @@ func SearchChannelsPage(keyword string, group string, model string, statusFilter
 
 // SearchChannels is retained for internal callers that need a bounded search
 // result without pagination metadata.
-func SearchChannels(keyword string, group string, model string, idSort bool, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
-	result, err := SearchChannelsPage(keyword, group, model, -1, -1, 0, channelSearchMaxPageSize, idSort, sortOptions...)
+func SearchChannels(keyword string, group string, model string, searchSensitiveFields bool, idSort bool, sortOptions ...ChannelSortOptions) ([]*Channel, error) {
+	result, err := SearchChannelsPage(keyword, group, model, -1, -1, 0, channelSearchMaxPageSize, searchSensitiveFields, idSort, sortOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -1087,7 +1093,11 @@ func DeleteDisabledChannel() (int64, error) {
 }
 
 func GetPaginatedTags(offset int, limit int) ([]*string, error) {
-	return GetPaginatedChannelTags(DB.Model(&Channel{}), offset, limit)
+	tags, err := GetPaginatedChannelTags(DB.Model(&Channel{}), offset, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get paginated channel tags: %w", err)
+	}
+	return tags, nil
 }
 
 func GetPaginatedChannelTags(query *gorm.DB, offset int, limit int) ([]*string, error) {
@@ -1102,35 +1112,14 @@ func GetPaginatedChannelTags(query *gorm.DB, offset int, limit int) ([]*string, 
 	return tags, err
 }
 
-func SearchTags(keyword string, group string, model string, idSort bool) ([]*string, error) {
+func SearchTags(keyword string, group string, model string, searchSensitiveFields bool, idSort bool) ([]*string, error) {
 	var tags []*string
-	modelsCol := "`models`"
-
-	// 如果是 PostgreSQL，使用双引号
-	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
-		modelsCol = `"models"`
-	}
-
-	baseURLCol := "`base_url`"
-	// 如果是 PostgreSQL，使用双引号
-	if common.UsingMainDatabase(common.DatabaseTypePostgreSQL) {
-		baseURLCol = `"base_url"`
-	}
-
 	order := "priority desc"
 	if idSort {
 		order = "id desc"
 	}
 
-	// 构造基础查询
-	baseQuery := DB.Model(&Channel{}).Omit("key")
-
-	// 构造WHERE子句
-	whereClause := "(id = ? OR name LIKE ? OR " + commonKeyCol + " = ? OR " + baseURLCol + " LIKE ?) AND " + modelsCol + " LIKE ?"
-	args := []any{common.String2Int(keyword), "%" + keyword + "%", keyword, "%" + keyword + "%", "%" + model + "%"}
-	baseQuery = ApplyChannelGroupFilter(baseQuery.Where(whereClause, args...), group)
-
-	subQuery := baseQuery.
+	subQuery := searchChannelsQuery(keyword, group, model, searchSensitiveFields).
 		Select("tag").
 		Where("tag != ''").
 		Order(order)
@@ -1300,7 +1289,11 @@ func CountAllChannels() (int64, error) {
 
 // CountAllTags returns number of non-empty distinct tags
 func CountAllTags() (int64, error) {
-	return CountChannelTags(DB.Model(&Channel{}))
+	total, err := CountChannelTags(DB.Model(&Channel{}))
+	if err != nil {
+		return 0, fmt.Errorf("count channel tags: %w", err)
+	}
+	return total, nil
 }
 
 func CountChannelTags(query *gorm.DB) (int64, error) {

--- a/apps/api-go/model/channel_search_test.go
+++ b/apps/api-go/model/channel_search_test.go
@@ -46,6 +46,7 @@ func TestSearchChannelsPageFiltersBeforePagination(t *testing.T) {
 		0,
 		1,
 		false,
+		false,
 		NewChannelSortOptions("id", "asc", false),
 	)
 	require.NoError(t, err)
@@ -63,6 +64,7 @@ func TestSearchChannelsPageFiltersBeforePagination(t *testing.T) {
 		0,
 		10000,
 		false,
+		false,
 		NewChannelSortOptions("id", "asc", false),
 	)
 	require.NoError(t, err)
@@ -79,9 +81,68 @@ func TestSearchChannelsPageFiltersBeforePagination(t *testing.T) {
 		0,
 		10000,
 		false,
+		false,
 		NewChannelSortOptions("id", "asc", false),
 	)
 	require.NoError(t, err)
 	require.Equal(t, int64(101), page.Total)
 	require.Len(t, page.Channels, channelSearchMaxPageSize)
+}
+
+func TestChannelSearchSensitiveFieldsRequirePermission(t *testing.T) {
+	truncateTables(t)
+
+	privateBaseURL := "https://private-host.example.com/v1"
+	keyTag := "key-secret-tag"
+	baseURLTag := "base-url-secret-tag"
+	keySearch := "provider-key-search-sentinel"
+	channels := []Channel{
+		{
+			Name:   "ordinary key channel",
+			Key:    keySearch,
+			Status: common.ChannelStatusEnabled,
+			Models: "gpt-5",
+			Group:  "default",
+			Tag:    &keyTag,
+		},
+		{
+			Name:    "ordinary base url channel",
+			BaseURL: &privateBaseURL,
+			Status:  common.ChannelStatusEnabled,
+			Models:  "gpt-5",
+			Group:   "default",
+			Tag:     &baseURLTag,
+		},
+	}
+	require.NoError(t, DB.Create(&channels).Error)
+
+	for _, test := range []struct {
+		name    string
+		keyword string
+		tag     string
+	}{
+		{name: "key", keyword: keySearch, tag: keyTag},
+		{name: "base url", keyword: "private-host.example.com", tag: baseURLTag},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			withoutSecrets, err := SearchChannelsPage(test.keyword, "", "", -1, -1, 0, 20, false, false)
+			require.NoError(t, err)
+			require.Zero(t, withoutSecrets.Total)
+			require.Empty(t, withoutSecrets.Channels)
+
+			withoutSecretTags, err := SearchTags(test.keyword, "", "", false, false)
+			require.NoError(t, err)
+			require.Empty(t, withoutSecretTags)
+
+			withSecrets, err := SearchChannelsPage(test.keyword, "", "", -1, -1, 0, 20, true, false)
+			require.NoError(t, err)
+			require.Equal(t, int64(1), withSecrets.Total)
+			require.Len(t, withSecrets.Channels, 1)
+
+			withSecretTags, err := SearchTags(test.keyword, "", "", true, false)
+			require.NoError(t, err)
+			require.Len(t, withSecretTags, 1)
+			require.Equal(t, test.tag, *withSecretTags[0])
+		})
+	}
 }


### PR DESCRIPTION
### Motivation
- Channel read endpoints (`GET /api/channel/`, `GET /api/channel/:id`, search/list) returned JSON-exposed sensitive channel configuration even for callers granted only `ChannelRead`, which breaks the intended `ChannelSensitiveWrite` separation and can leak upstream credentials and overrides.
- The backend already classifies fields like `base_url`, `header_override`, `param_override`, `setting`, `other`, and `settings` as sensitive for writes, so read paths must avoid returning them to callers without the sensitive permission.

### Description
- Change `clearChannelInfo` to accept the request context (`*gin.Context`) and check `authz.ChannelSensitiveWrite` via `authz.Can` to decide whether to redact sensitive fields.  
- Add `clearChannelSensitiveInfo(channel *model.Channel)` which clears `Key`, `BaseURL`, `OpenAIOrganization`, `HeaderOverride`, `ParamOverride`, `Setting`, `Other`, and `OtherSettings` to prevent credential leakage.  
- Apply the permission-aware `clearChannelInfo(c, ...)` call consistently in channel list, tag-mode lists, search results, paginated results, and the single-channel detail handler.  
- Add unit test `TestClearChannelSensitiveInfo` to assert sensitive fields are removed while non-sensitive inventory fields (e.g., `Type`, `Name`, `Models`) are preserved.

### Testing
- Ran code formatting with `gofmt -w controller/channel.go controller/channel_authz_test.go` and the formatter completed successfully.  
- Ran targeted unit tests with `go test ./controller -run 'TestClearChannelSensitiveInfo|TestChannelHasSensitiveChanges|TestChannelFieldsAreClassified' -count=1`, and they passed.  
- Ran `go test ./controller -count=1` to exercise the controller package tests and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a873078430883209b7c8bbe543a4e3b)

## Summary by Sourcery

通过将库存可见性与敏感配置及基于密钥的搜索访问分离，保护渠道读取 API。

Bug Fixes:
- 对于没有独立 secret-view 权限的调用方，从读取端点中去除敏感的渠道配置。
- 防止未授权的渠道搜索和标签查询匹配到密钥（secret keys）和服务提供方 URL（provider URLs）。

Enhancements:
- 在列表（list）、搜索（search）、标签（tag）、分页（paginated）、详情（detail）和更新（update）响应中，一致地应用基于权限的渠道数据清理（sanitization），同时保留库存字段。
- 为敏感字段的脱敏处理和基于权限控制的搜索行为增加测试覆盖。

Tests:
- 新增控制器和模型测试，用于验证敏感渠道数据和搜索条件需要具备 secret-view 访问权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Protect channel read APIs by separating inventory visibility from sensitive configuration and secret-based search access.

Bug Fixes:
- Redact sensitive channel configuration from read endpoints for callers without the independent secret-view permission.
- Prevent unauthorized channel searches and tag lookups from matching against secret keys and provider URLs.

Enhancements:
- Apply permission-aware channel sanitization consistently across list, search, tag, paginated, detail, and update responses while preserving inventory fields.
- Add coverage for sensitive-field redaction and permission-controlled search behavior.

Tests:
- Add controller and model tests verifying sensitive channel data and search criteria require secret-view access.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过将库存可见性与敏感配置及基于密钥的搜索访问分离，保护渠道读取 API。

Bug Fixes:
- 对于没有独立 secret-view 权限的调用方，从读取端点中去除敏感的渠道配置。
- 防止未授权的渠道搜索和标签查询匹配到密钥（secret keys）和服务提供方 URL（provider URLs）。

Enhancements:
- 在列表（list）、搜索（search）、标签（tag）、分页（paginated）、详情（detail）和更新（update）响应中，一致地应用基于权限的渠道数据清理（sanitization），同时保留库存字段。
- 为敏感字段的脱敏处理和基于权限控制的搜索行为增加测试覆盖。

Tests:
- 新增控制器和模型测试，用于验证敏感渠道数据和搜索条件需要具备 secret-view 访问权限。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Protect channel read APIs by separating inventory visibility from sensitive configuration and secret-based search access.

Bug Fixes:
- Redact sensitive channel configuration from read endpoints for callers without the independent secret-view permission.
- Prevent unauthorized channel searches and tag lookups from matching against secret keys and provider URLs.

Enhancements:
- Apply permission-aware channel sanitization consistently across list, search, tag, paginated, detail, and update responses while preserving inventory fields.
- Add coverage for sensitive-field redaction and permission-controlled search behavior.

Tests:
- Add controller and model tests verifying sensitive channel data and search criteria require secret-view access.

</details>

</details>