### PR TITLE
fix: 修复模型倍率被算成 0 以及被丢弃的错误

### DIFF
--- a/apps/api-go/common/rate_limit_test.go
+++ b/apps/api-go/common/rate_limit_test.go
@@ -27,7 +27,9 @@ func TestInMemoryRateLimiterUsesConstantSpacePerKey(t *testing.T) {
 
 func TestInMemoryRateLimiterRejectsAtLimit(t *testing.T) {
 	limiter := &InMemoryRateLimiter{}
-	if !limiter.Request("user", 2, 60) || !limiter.Request("user", 2, 60) {
+	firstOK := limiter.Request("user", 2, 60)
+	secondOK := limiter.Request("user", 2, 60)
+	if !firstOK || !secondOK {
 		t.Fatal("requests within the limit were rejected")
 	}
 	if limiter.Request("user", 2, 60) {

--- a/apps/api-go/controller/assistant.go
+++ b/apps/api-go/controller/assistant.go
@@ -874,8 +874,9 @@ func assistantMessageIsSinglePunctuation(message string) bool {
 
 func AssistantChat(c *gin.Context) {
 	settings := setting.GetAssistantSettings()
-	group, groupOK := c.Get(assistantRouteGroupContextKey)
-	modelID, modelOK := c.Get(assistantRouteModelContextKey)
+	group, _ := c.Get(assistantRouteGroupContextKey)
+	modelID, _ := c.Get(assistantRouteModelContextKey)
+	var groupOK, modelOK bool
 	settings.Group, groupOK = group.(string)
 	settings.Model, modelOK = modelID.(string)
 	if !groupOK || !modelOK || strings.TrimSpace(settings.Group) == "" || strings.TrimSpace(settings.Model) == "" {

--- a/apps/api-go/controller/billing.go
+++ b/apps/api-go/controller/billing.go
@@ -17,26 +17,28 @@ func GetSubscription(c *gin.Context) {
 	if common.DisplayTokenStatEnabled {
 		tokenId := c.GetInt("token_id")
 		token, err = model.GetTokenById(tokenId)
+		if err != nil {
+			writeBillingOpenAIError(c, err, "upstream_error")
+			return
+		}
 		expiredTime = token.ExpiredTime
 		remainQuota = token.RemainQuota
 		usedQuota = token.UsedQuota
 	} else {
 		userId := c.GetInt("id")
 		remainQuota, err = model.GetUserQuota(userId, false)
+		if err != nil {
+			writeBillingOpenAIError(c, err, "upstream_error")
+			return
+		}
 		usedQuota, err = model.GetUserUsedQuota(userId)
+		if err != nil {
+			writeBillingOpenAIError(c, err, "upstream_error")
+			return
+		}
 	}
 	if expiredTime <= 0 {
 		expiredTime = 0
-	}
-	if err != nil {
-		openAIError := types.OpenAIError{
-			Message: err.Error(),
-			Type:    "upstream_error",
-		}
-		c.JSON(200, gin.H{
-			"error": openAIError,
-		})
-		return
 	}
 	quota := remainQuota + usedQuota
 	amount := float64(quota)
@@ -75,20 +77,18 @@ func GetUsage(c *gin.Context) {
 	if common.DisplayTokenStatEnabled {
 		tokenId := c.GetInt("token_id")
 		token, err = model.GetTokenById(tokenId)
+		if err != nil {
+			writeBillingOpenAIError(c, err, "new_api_error")
+			return
+		}
 		quota = token.UsedQuota
 	} else {
 		userId := c.GetInt("id")
 		quota, err = model.GetUserUsedQuota(userId)
-	}
-	if err != nil {
-		openAIError := types.OpenAIError{
-			Message: err.Error(),
-			Type:    "new_api_error",
+		if err != nil {
+			writeBillingOpenAIError(c, err, "new_api_error")
+			return
 		}
-		c.JSON(200, gin.H{
-			"error": openAIError,
-		})
-		return
 	}
 	amount := float64(quota)
 	switch operation_setting.GetQuotaDisplayType() {
@@ -105,4 +105,13 @@ func GetUsage(c *gin.Context) {
 	}
 	c.JSON(200, usage)
 	return
+}
+
+func writeBillingOpenAIError(c *gin.Context, err error, errorType string) {
+	c.JSON(200, gin.H{
+		"error": types.OpenAIError{
+			Message: err.Error(),
+			Type:    errorType,
+		},
+	})
 }

--- a/apps/api-go/controller/topup.go
+++ b/apps/api-go/controller/topup.go
@@ -967,10 +967,14 @@ func RequestAmount(c *gin.Context) {
 		payMoney, _, err = quoteLegacyTopUpWithDiscount(req.Amount, group, req.DiscountCode, id)
 	} else {
 		payMoney, _, err = quoteTopUpWithDiscount(req.Amount, group, req.PaymentMethod, req.DiscountCode, id)
-		if err != nil {
-			c.JSON(http.StatusOK, gin.H{"message": "error", "data": "支付方式配置无效"})
-			return
+	}
+	if err != nil {
+		message := "优惠码无效"
+		if req.PaymentMethod != "" {
+			message = "支付方式配置无效"
 		}
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": message})
+		return
 	}
 	if payMoney.LessThanOrEqual(decimal.NewFromFloat(0.01)) {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "充值金额过低"})

--- a/apps/api-go/controller/topup_stripe.go
+++ b/apps/api-go/controller/topup_stripe.go
@@ -65,6 +65,10 @@ func (*StripeAdaptor) RequestAmount(c *gin.Context, req *StripePayRequest) {
 		return
 	}
 	payMoney, _, err := applyDiscountCodeQuote(decimal.NewFromFloat(getStripePayMoney(float64(req.Amount), group)), req.Amount, req.DiscountCode, id)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "优惠码无效"})
+		return
+	}
 	expectedAmountMicros, err := monetaryStringToMicros(payMoney.StringFixed(2))
 	if err != nil || expectedAmountMicros <= 10_000 {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "充值金额过低"})
@@ -115,6 +119,10 @@ func (*StripeAdaptor) RequestPay(c *gin.Context, req *StripePayRequest) {
 		return
 	}
 	payMoney, discountCode, err := applyDiscountCodeQuote(decimal.NewFromFloat(getStripePayMoney(float64(req.Amount), group)), req.Amount, req.DiscountCode, id)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "优惠码无效"})
+		return
+	}
 	expectedAmountMicros, err := monetaryStringToMicros(payMoney.StringFixed(2))
 	if err != nil || expectedAmountMicros <= 10_000 {
 		c.JSON(http.StatusOK, gin.H{"message": "error", "data": "充值金额过低"})

--- a/apps/api-go/internal/appcli/cookie_store.go
+++ b/apps/api-go/internal/appcli/cookie_store.go
@@ -153,11 +153,7 @@ func (jar *persistentJar) save() error {
 }
 
 func cookieRecord(target *url.URL, cookie *http.Cookie, now time.Time) storedCookie {
-	domain := strings.TrimPrefix(strings.ToLower(cookie.Domain), ".")
-	hostOnly := domain == ""
-	if hostOnly {
-		domain = strings.ToLower(target.Hostname())
-	}
+	hostOnly := strings.TrimPrefix(strings.ToLower(cookie.Domain), ".") == ""
 	path := cookie.Path
 	if path == "" {
 		path = defaultCookiePath(target.EscapedPath())

--- a/apps/api-go/main.go
+++ b/apps/api-go/main.go
@@ -81,7 +81,7 @@ func runMigrationCommand(mode model.DBMigrationMode) {
 func runServer() {
 	startTime := time.Now()
 	kitutil.SetLogging(common.SysLog, func(message string) {
-		logger.LogError(nil, message)
+		logger.LogError(context.TODO(), message)
 	})
 	kitutil.SetSystemErrorLogging(common.SysError)
 

--- a/apps/api-go/middleware/secure_verification.go
+++ b/apps/api-go/middleware/secure_verification.go
@@ -38,13 +38,13 @@ func RequireSecurityProof(c *gin.Context, requiredScope string, allowedMethods [
 	// The configured list remains part of the call contract, but the account
 	// policy is authoritative: a bound email must use email verification; an
 	// account without one may use only its existing Passkey.
-	allowedMethods = preferredMethods
+	_ = allowedMethods
 	raw := strings.TrimSpace(c.GetHeader("X-Security-Proof"))
 	if raw == "" {
 		securityProofError(c, "SECURITY_PROOF_REQUIRED", "需要安全验证")
 		return false
 	}
-	if _, err := service.VerifySecurityProof(raw, identity, requiredScope, allowedMethods); err != nil {
+	if _, err := service.VerifySecurityProof(raw, identity, requiredScope, preferredMethods); err != nil {
 		switch {
 		case errors.Is(err, service.ErrAuthTokenExpired):
 			securityProofError(c, "SECURITY_PROOF_EXPIRED", "安全验证已过期")

--- a/apps/api-go/relay/channel/ali/image.go
+++ b/apps/api-go/relay/channel/ali/image.go
@@ -210,6 +210,10 @@ func updateTask(info *relaycommon.RelayInfo, taskID string) (*AliResponse, error
 	defer resp.Body.Close()
 
 	responseBody, err := common.ReadResponseBody(resp)
+	if err != nil {
+		common.SysLog("updateTask ReadResponseBody err: " + err.Error())
+		return &aliResponse, err, nil
+	}
 
 	var response AliResponse
 	err = common.Unmarshal(responseBody, &response)

--- a/apps/api-go/relay/channel/baidu/relay-baidu.go
+++ b/apps/api-go/relay/channel/baidu/relay-baidu.go
@@ -169,7 +169,7 @@ func baiduHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respon
 	}
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, err = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(jsonResponse)
 	return nil, &fullTextResponse.Usage
 }
 
@@ -194,7 +194,7 @@ func baiduEmbeddingHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *ht
 	}
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, err = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(jsonResponse)
 	return nil, &fullTextResponse.Usage
 }
 

--- a/apps/api-go/relay/channel/cohere/relay-cohere.go
+++ b/apps/api-go/relay/channel/cohere/relay-cohere.go
@@ -252,6 +252,6 @@ func cohereRerankHandler(c *gin.Context, resp *http.Response, info *relaycommon.
 	}
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, err = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(jsonResponse)
 	return &usage, nil
 }

--- a/apps/api-go/relay/channel/coze/adaptor.go
+++ b/apps/api-go/relay/channel/coze/adaptor.go
@@ -96,6 +96,9 @@ func (a *Adaptor) DoRequest(c *gin.Context, info *common.RelayInfo, requestBody 
 		return nil, err
 	}
 	err = json.Unmarshal(respBody, &cozeResponse)
+	if err != nil {
+		return nil, err
+	}
 	if cozeResponse.Code != 0 {
 		return nil, errors.New(cozeResponse.Msg)
 	}

--- a/apps/api-go/relay/channel/ollama/stream.go
+++ b/apps/api-go/relay/channel/ollama/stream.go
@@ -288,8 +288,7 @@ func ollamaChatHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.R
 			}
 			aggContent.WriteString(single.Message.Content)
 			if len(single.Message.ToolCalls) > 0 {
-				var converted []dto.ToolCallResponse
-				converted, toolCallIndex = ollamaToolCallsToOpenAI(single.Message.ToolCalls, toolCallIndex, false)
+				converted, _ := ollamaToolCallsToOpenAI(single.Message.ToolCalls, toolCallIndex, false)
 				toolCalls = append(toolCalls, converted...)
 			}
 		} else {

--- a/apps/api-go/relay/channel/zhipu/relay-zhipu.go
+++ b/apps/api-go/relay/channel/zhipu/relay-zhipu.go
@@ -258,6 +258,6 @@ func zhipuHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Respon
 	}
 	c.Writer.Header().Set("Content-Type", "application/json")
 	c.Writer.WriteHeader(resp.StatusCode)
-	_, err = c.Writer.Write(jsonResponse)
+	_, _ = c.Writer.Write(jsonResponse)
 	return &fullTextResponse.Usage, nil
 }

--- a/apps/api-go/setting/ratio_setting/model_ratio.go
+++ b/apps/api-go/setting/ratio_setting/model_ratio.go
@@ -245,8 +245,8 @@ var defaultModelRatio = map[string]float64{
 	// Perplexity online 模型对搜索额外收费，有需要应自行调整，此处不计入搜索费用
 	"llama-3-sonar-small-32k-chat":   0.2 / 1000 * USD,
 	"llama-3-sonar-small-32k-online": 0.2 / 1000 * USD,
-	"llama-3-sonar-large-32k-chat":   1 / 1000 * USD,
-	"llama-3-sonar-large-32k-online": 1 / 1000 * USD,
+	"llama-3-sonar-large-32k-chat":   1.0 / 1000 * USD,
+	"llama-3-sonar-large-32k-online": 1.0 / 1000 * USD,
 	// grok
 	"grok-3-beta":           1.5,
 	"grok-3-mini-beta":      0.15,

--- a/apps/api-go/setting/ratio_setting/model_ratio_test.go
+++ b/apps/api-go/setting/ratio_setting/model_ratio_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+package ratio_setting
+
+import "testing"
+
+func TestDefaultSonarLargeRatiosUseFloatingDivision(t *testing.T) {
+	defaults := GetDefaultModelRatioMap()
+	want := 1.0 / 1000 * USD
+	for _, name := range []string{
+		"llama-3-sonar-large-32k-chat",
+		"llama-3-sonar-large-32k-online",
+	} {
+		ratio, ok := defaults[name]
+		if !ok {
+			t.Fatalf("missing default ratio for %s", name)
+		}
+		if ratio == 0 {
+			t.Fatalf("default ratio for %s is 0 because of integer division", name)
+		}
+		if ratio != want {
+			t.Fatalf("default ratio for %s = %v, want %v", name, ratio, want)
+		}
+	}
+}

--- a/apps/web/src/components/layout/components/authenticated-layout.tsx
+++ b/apps/web/src/components/layout/components/authenticated-layout.tsx
@@ -19,6 +19,7 @@ For commercial licensing, please contact support@quantumnous.com
 import { useRouterState } from '@tanstack/react-router'
 
 import { AccessRestrictionNotice } from '@/components/access-restriction-notice'
+import { CommandMenu } from '@/components/command-menu'
 import { AnimatedOutlet } from '@/components/page-transition'
 import { SkipToMain } from '@/components/skip-to-main'
 import { SidebarInset, SidebarProvider } from '@/components/ui/sidebar'
@@ -80,6 +81,7 @@ export function AuthenticatedLayout(props: AuthenticatedLayoutProps) {
           </div>
           <AccessRestrictionNotice className='shrink-0' />
           <ReleaseNoteDialog />
+          <CommandMenu />
         </SidebarProvider>
       </SearchProvider>
     </LayoutProvider>

--- a/apps/web/src/components/turnstile.tsx
+++ b/apps/web/src/components/turnstile.tsx
@@ -102,7 +102,7 @@ export function Turnstile({
     }
 
     const scriptId = 'cf-turnstile'
-    const existingScript = document.getElementById(scriptId)
+    const existingScript = document.querySelector(`#${scriptId}`)
 
     // A different login form may have inserted the shared script already.
     // Wait for its runtime instead of returning before this widget is rendered.

--- a/apps/web/src/context/search-provider.tsx
+++ b/apps/web/src/context/search-provider.tsx
@@ -18,8 +18,6 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import { createContext, useContext, useEffect, useState } from 'react'
 
-import { CommandMenu } from '@/components/command-menu'
-
 type SearchContextType = {
   open: boolean
   setOpen: React.Dispatch<React.SetStateAction<boolean>>
@@ -48,7 +46,6 @@ export function SearchProvider({ children }: SearchProviderProps) {
   return (
     <SearchContext.Provider value={{ open, setOpen }}>
       {children}
-      <CommandMenu />
     </SearchContext.Provider>
   )
 }

--- a/apps/web/src/features/assistant/assistant-clipboard.test.ts
+++ b/apps/web/src/features/assistant/assistant-clipboard.test.ts
@@ -51,7 +51,9 @@ describe('assistant clipboard', () => {
     assert.equal(await copyAssistantText('WEEKLY-20', undefined), false)
     assert.equal(
       await copyAssistantText('WEEKLY-20', {
-        writeText: async () => Promise.reject(new Error('denied')),
+        writeText: async () => {
+          throw new Error('denied')
+        },
       }),
       false
     )

--- a/apps/web/src/features/assistant/assistant-handoff-tool.tsx
+++ b/apps/web/src/features/assistant/assistant-handoff-tool.tsx
@@ -92,7 +92,7 @@ export function AssistantHandoffTool(props: {
     }
   }, [props.confirmationAction])
   const trimmedMessage = message.trim()
-  const messageLength = Array.from(trimmedMessage).length
+  const messageLength = [...trimmedMessage].length
   const messageTooShort =
     trimmedMessage.length > 0 && messageLength < minAssistantHandoffCharacters
 

--- a/apps/web/src/features/auth/lib/validation.ts
+++ b/apps/web/src/features/auth/lib/validation.ts
@@ -64,7 +64,7 @@ export function formatBackupCode(value: string): string {
  * Remove hyphens from backup code before sending to server
  */
 export function cleanBackupCode(code: string): string {
-  return code.replaceAll(/-/g, '')
+  return code.replaceAll('-', '')
 }
 
 // ============================================================================

--- a/apps/web/src/features/drawing/index.tsx
+++ b/apps/web/src/features/drawing/index.tsx
@@ -293,7 +293,7 @@ export function Drawing() {
   }
 
   const addReferenceImages = (files: FileList | null) => {
-    const selected = Array.from(files ?? [])
+    const selected = [...(files ?? [])]
     if (selected.length === 0) return
     if (referenceImages.length + selected.length > maxReferenceImages) {
       setError(

--- a/apps/web/src/features/pricing/components/model-details-api.tsx
+++ b/apps/web/src/features/pricing/components/model-details-api.tsx
@@ -109,7 +109,7 @@ function buildChatSample(lang: Lang, ctx: SampleContext): string {
       `curl ${url} \\`,
       `  -H "Authorization: Bearer $${ctx.apiKeyEnv}" \\`,
       `  -H "Content-Type: application/json" \\`,
-      `  -d '${bodyJson.replaceAll(/\n/g, '\n     ')}'`,
+      `  -d '${bodyJson.replaceAll('\n', '\n     ')}'`,
     ].join('\n')
   }
 
@@ -177,7 +177,7 @@ function buildAnthropicSample(lang: Lang, ctx: SampleContext): string {
       `  -H "x-api-key: $${ctx.apiKeyEnv}" \\`,
       `  -H "anthropic-version: 2023-06-01" \\`,
       `  -H "Content-Type: application/json" \\`,
-      `  -d '${body.replaceAll(/\n/g, '\n     ')}'`,
+      `  -d '${body.replaceAll('\n', '\n     ')}'`,
     ].join('\n')
   }
   if (lang === 'python') {
@@ -249,7 +249,7 @@ function buildGeminiSample(lang: Lang, ctx: SampleContext): string {
     return [
       `curl '${url}' \\`,
       `  -H 'Content-Type: application/json' \\`,
-      `  -d '${body.replaceAll(/\n/g, '\n     ')}'`,
+      `  -d '${body.replaceAll('\n', '\n     ')}'`,
     ].join('\n')
   }
   if (lang === 'python') {
@@ -299,7 +299,7 @@ function buildEmbeddingSample(lang: Lang, ctx: SampleContext): string {
       `curl ${url} \\`,
       `  -H "Authorization: Bearer $${ctx.apiKeyEnv}" \\`,
       `  -H "Content-Type: application/json" \\`,
-      `  -d '${body.replaceAll(/\n/g, '\n     ')}'`,
+      `  -d '${body.replaceAll('\n', '\n     ')}'`,
     ].join('\n')
   }
   if (lang === 'python') {
@@ -365,7 +365,7 @@ function buildImageSample(lang: Lang, ctx: SampleContext): string {
       `curl ${url} \\`,
       `  -H "Authorization: Bearer $${ctx.apiKeyEnv}" \\`,
       `  -H "Content-Type: application/json" \\`,
-      `  -d '${body.replaceAll(/\n/g, '\n     ')}'`,
+      `  -d '${body.replaceAll('\n', '\n     ')}'`,
     ].join('\n')
   }
   if (lang === 'python') {

--- a/apps/web/src/features/pricing/components/vendor-model-sections.tsx
+++ b/apps/web/src/features/pricing/components/vendor-model-sections.tsx
@@ -47,8 +47,8 @@ function getVendorSectionId(name: string, index: number) {
     name
       .trim()
       .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '') || 'vendor'
+      .replaceAll(/[^a-z0-9]+/g, '-')
+      .replaceAll(/^-+|-+$/g, '') || 'vendor'
   return `vendor-section-${index}-${slug}`
 }
 

--- a/apps/web/src/features/security/index.tsx
+++ b/apps/web/src/features/security/index.tsx
@@ -326,13 +326,13 @@ function PolicyMetadata({ policy }: { policy: SecurityPolicy }) {
 
 function ProtectedGroupsSummary({ policy }: { policy: SecurityPolicy }) {
   const { t } = useTranslation()
-  const groups = Array.from(
-    new Set(
+  const groups = [
+    ...new Set(
       (policy.protected_groups ?? [])
         .map((group) => group.trim())
         .filter(Boolean)
-    )
-  ).sort()
+    ),
+  ].sort()
 
   return (
     <div className='border-border/70 space-y-3 rounded-xl border p-5'>

--- a/apps/web/src/features/system-settings/auth/basic-auth-section.tsx
+++ b/apps/web/src/features/system-settings/auth/basic-auth-section.tsx
@@ -273,7 +273,7 @@ export function BasicAuthSection({ defaultValues }: BasicAuthSectionProps) {
                               const next = new Set(disabledMethods)
                               if (allowed) next.delete(method.id)
                               else next.add(method.id)
-                              field.onChange(Array.from(next).sort().join(','))
+                              field.onChange([...next].sort().join(','))
                             }}
                           />
                         </FormControl>

--- a/apps/web/src/features/system-settings/content/chat-settings-section.tsx
+++ b/apps/web/src/features/system-settings/content/chat-settings-section.tsx
@@ -38,6 +38,8 @@ import { SettingsForm } from '../components/settings-form-layout'
 import { SettingsPageFormActions } from '../components/settings-page-context'
 import { SettingsSection } from '../components/settings-section'
 import { useUpdateOption } from '../hooks/use-update-option'
+import { ChatSettingsVisualEditor } from './chat-settings-visual-editor'
+import { formatJsonForEditor, normalizeJsonString } from './utils'
 
 const CHAT_SETTINGS_EXAMPLE = JSON.stringify(
   [
@@ -47,8 +49,6 @@ const CHAT_SETTINGS_EXAMPLE = JSON.stringify(
   null,
   2
 )
-import { ChatSettingsVisualEditor } from './chat-settings-visual-editor'
-import { formatJsonForEditor, normalizeJsonString } from './utils'
 
 const createChatSchema = (t: (key: string) => string) =>
   z.object({

--- a/apps/web/src/features/system-settings/models/group-warning-validation.ts
+++ b/apps/web/src/features/system-settings/models/group-warning-validation.ts
@@ -17,7 +17,7 @@ export function isValidGroupWarnings(value: unknown): boolean {
 
   return Object.entries(value).every(([group, warning]) => {
     const groupName = group.trim()
-    if (!groupName || Array.from(groupName).length > 64) return false
+    if (!groupName || [...groupName].length > 64) return false
     if (!isPlainObject(warning)) return false
 
     const enabled = warning.enabled
@@ -25,7 +25,7 @@ export function isValidGroupWarnings(value: unknown): boolean {
 
     const message = warning.message
     if (message !== undefined && typeof message !== 'string') return false
-    if (typeof message === 'string' && Array.from(message).length > 2000) {
+    if (typeof message === 'string' && [...message].length > 2000) {
       return false
     }
     if (enabled === true && (typeof message !== 'string' || !message.trim())) {

--- a/apps/web/src/features/system-settings/security/security-audit.tsx
+++ b/apps/web/src/features/system-settings/security/security-audit.tsx
@@ -62,15 +62,15 @@ function shortIdentifier(value: string | undefined): string {
 
 function getProtectedGroups(policy: AdminSecurityPolicy | undefined): string[] {
   if (!policy || !policy.settings.enabled) return []
-  return Array.from(
-    new Set(
+  return [
+    ...new Set(
       policy.rules
         .filter((rule) => rule.enabled)
         .flatMap((rule) => rule.groups)
         .map((group) => group.trim())
         .filter(Boolean)
-    )
-  ).sort((left, right) => left.localeCompare(right))
+    ),
+  ].sort((left, right) => left.localeCompare(right))
 }
 
 function sourceLabel(
@@ -182,7 +182,7 @@ function reviewCount(rows: Array<{ count: number }> | undefined): number {
 function reviewLabel(value: string): string {
   return value
     .replaceAll('_', ' ')
-    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+    .replaceAll(/\b\w/g, (letter) => letter.toUpperCase())
 }
 
 function ReviewBreakdown({
@@ -743,13 +743,13 @@ export function SecurityAuditPanel() {
   const protectedGroups = useMemo(() => getProtectedGroups(policy), [policy])
   const categories = useMemo(
     () =>
-      Array.from(
-        new Set(
+      [
+        ...new Set(
           (policy?.rules ?? [])
             .map((rule) => rule.category.trim())
             .filter(Boolean)
-        )
-      )
+        ),
+      ]
         .concat('assistant_review')
         .filter((value, index, values) => values.indexOf(value) === index)
         .sort(),
@@ -757,14 +757,14 @@ export function SecurityAuditPanel() {
   )
   const sources = useMemo(
     () =>
-      Array.from(
-        new Set([
+      [
+        ...new Set([
           ...(policy?.rules ?? [])
             .map((rule) => rule.source.trim())
             .filter(Boolean),
           'ai_review',
-        ])
-      ).sort(),
+        ]),
+      ].sort(),
     [policy]
   )
 

--- a/apps/web/src/features/usage-logs/api.ts
+++ b/apps/web/src/features/usage-logs/api.ts
@@ -18,7 +18,7 @@ For commercial licensing, please contact support@quantumnous.com
 */
 import { api } from '@/lib/api'
 
-import { buildQueryParams } from './lib/utils'
+import { buildQueryParams } from './lib/query-params'
 import type {
   GetLogsParams,
   GetLogsResponse,

--- a/apps/web/src/features/usage-logs/lib/query-params.ts
+++ b/apps/web/src/features/usage-logs/lib/query-params.ts
@@ -1,0 +1,35 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+/**
+ * Build query parameters from filters
+ */
+export function buildQueryParams(
+  params: Record<string, unknown>
+): URLSearchParams {
+  const queryParams = new URLSearchParams()
+
+  Object.entries(params).forEach(([key, value]) => {
+    // Keep 0 as a valid value, only filter out undefined, null, and empty string
+    if (value !== undefined && value !== null && value !== '') {
+      queryParams.append(key, String(value))
+    }
+  })
+
+  return queryParams
+}

--- a/apps/web/src/features/usage-logs/lib/utils.ts
+++ b/apps/web/src/features/usage-logs/lib/utils.ts
@@ -92,24 +92,6 @@ function timestampToSeconds(ms: number): number {
 }
 
 /**
- * Build query parameters from filters
- */
-export function buildQueryParams(
-  params: Record<string, unknown>
-): URLSearchParams {
-  const queryParams = new URLSearchParams()
-
-  Object.entries(params).forEach(([key, value]) => {
-    // Keep 0 as a valid value, only filter out undefined, null, and empty string
-    if (value !== undefined && value !== null && value !== '') {
-      queryParams.append(key, String(value))
-    }
-  })
-
-  return queryParams
-}
-
-/**
  * Build time range parameters with default values
  * Shared logic for all log types
  */

--- a/apps/web/src/lib/passkey.ts
+++ b/apps/web/src/lib/passkey.ts
@@ -36,7 +36,7 @@ export function base64UrlToArrayBuffer(value?: string | null): ArrayBuffer {
   if (!value) return new ArrayBuffer(0)
 
   const padding = '='.repeat((4 - (value.length % 4)) % 4)
-  const base64 = (value + padding).replaceAll(/-/g, '+').replaceAll(/_/g, '/')
+  const base64 = (value + padding).replaceAll('-', '+').replaceAll('_', '/')
 
   const globalRef = globalThis as typeof globalThis & {
     Buffer?: NodeBufferCtor
@@ -96,8 +96,8 @@ export function arrayBufferToBase64Url(
         }
 
   return encode(binary)
-    .replaceAll(/\+/g, '-')
-    .replaceAll(/\//g, '_')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
     .replaceAll(/=+$/g, '')
 }
 

--- a/justfile
+++ b/justfile
@@ -46,7 +46,7 @@ dev-web:
 dev-rust:
     #!/usr/bin/env bash
     set -euo pipefail
-    @if [[ ! -f docker-compose.dev.yml ]]; then \
+    if [[ ! -f docker-compose.dev.yml ]]; then \
       echo "error: docker-compose.dev.yml is not present in this branch; dev-rust requires the preview compose stack." >&2; \
       exit 1; \
     fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明 / Summary

修复仓库里已确认的代码错误和静态检查警告，优先处理会影响计费、错误传播和构建的问题。

- 默认模型倍率里 `llama-3-sonar-large-32k-*` 使用了整数除法 `1 / 1000`，结果恒为 `0`，现改为 `1.0 / 1000 * USD`。
- 额度查询、充值报价、阿里云任务轮询和 Coze 响应解析中，错误值被后续赋值覆盖，现改为分别检查。
- 前端拆开 `usage-logs` 与 `SearchProvider`/`CommandMenu` 的循环依赖，并修正 `justfile` 中 `dev-rust` 的 bash 语法。
- 顺带处理 oxlint 可自动修复的警告，以及若干被 staticcheck 标出的无用赋值。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference:

N/A

## 关联 Issue / Related issue

无对应公开 Issue。由“修复代码错误和警告”任务发起。

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [x] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
command: cd apps/api-go && go test -p 2 ./controller ./setting/ratio_setting ./common ./middleware ./internal/appcli ./relay/channel/ali ./relay/channel/coze ./relay/channel/ollama && go vet ./controller ./setting/ratio_setting ./common ./middleware ./internal/appcli ./relay/channel/...
result: all packages ok; go vet clean

command: bun run --filter @lmm/web format:check && bun run --filter @lmm/web copyright:check && bun run --filter @lmm/web typecheck
result: passed

command: cd apps/web && bun test src/features/assistant/assistant-clipboard.test.ts src/features/system-settings/models/group-warning-validation.test.ts src/features/security/index.test.tsx src/features/drawing/index.test.tsx
result: 9 pass, 0 fail
```

## 截图或日志 / Screenshots or logs

N/A

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5d28710-e1f9-4553-b3db-cb5aa992000f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5d28710-e1f9-4553-b3db-cb5aa992000f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 摘要

修复模型定价为零的问题，并防止错误在计费、支付、服务商集成及相关前端代码中被覆盖或忽略。

错误修复：
- 修正计算结果为零的模型定价比例，并在计费、充值、支付及服务商响应流程中保留错误信息。
- 传递 Aliyun 响应正文错误和 Coze JSON 解析失败，而不是继续使用无效数据。

增强功能：
- 解耦 Web 使用日志工具和搜索命令菜单，以减少循环依赖。
- 清理后端和前端代码中的静态分析及 lint 警告。

构建：
- 修复 dev-rust justfile 配方，使其 Bash 条件语句能够正确执行。

测试：
- 为修正后的 Sonar Large 默认模型比例添加回归测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

防止计费、支付、提供商集成及相关前端代码中出现模型定价为零和错误被丢弃的问题。

错误修复：
- 修正 Llama 3 Sonar Large 模型的默认定价比率，使其不再计算为零。
- 保留并返回来自计费、充值、Stripe 折扣、阿里云任务轮询和 Coze 响应处理的错误，而不是继续使用无效数据。

改进：
- 将使用日志查询工具与网页搜索和命令菜单组件解耦。
- 清理后端和前端的静态分析及 lint 警告。

构建：
- 修复 dev-rust Just 配方，使其 Bash 条件语句能够正确执行。

测试：
- 为修正后的 Sonar Large 模型定价比率添加回归测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent zero-valued model pricing and dropped errors across billing, payment, provider integrations, and related frontend code.

Bug Fixes:
- Correct the default pricing ratios for Llama 3 Sonar Large models so they no longer evaluate to zero.
- Preserve and return errors from billing, top-up, Stripe discount, Aliyun task polling, and Coze response processing instead of continuing with invalid data.

Enhancements:
- Decouple usage-log query utilities from the web search and command-menu components.
- Clean up backend and frontend static-analysis and lint warnings.

Build:
- Fix the dev-rust Just recipe so its Bash conditional executes correctly.

Tests:
- Add regression coverage for the corrected Sonar Large model pricing ratios.

</details>

</details>