### PR TITLE
test(api-rust): 补齐拆分后的支付与媒体 router 测试

### DIFF
--- a/apps/api-rust/src/migration_routes/billing_payments.rs
+++ b/apps/api-rust/src/migration_routes/billing_payments.rs
@@ -335,6 +335,10 @@ pub fn billing_provider_payments_router(state: BillingHttpState) -> Router {
 pub fn billing_payments_router(state: BillingHttpState) -> Router {
     Router::new()
         .route(BALANCE_PAY_PATH, post(balance_pay))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            billing_payment_auth_boundary,
+        ))
         .with_state(state.clone())
         .merge(billing_provider_payments_router(state))
 }

--- a/apps/api-rust/tests/migration_billing_payments.rs
+++ b/apps/api-rust/tests/migration_billing_payments.rs
@@ -196,7 +196,15 @@ fn router_with_authorizer(
     compliance: Arc<dyn PaymentCompliance>,
     authorizer: Arc<dyn BillingAuthorizer>,
 ) -> axum::Router {
-    billing_payments_router(BillingHttpState::new(
+    billing_payments_router(billing_state(repo, compliance, authorizer))
+}
+
+fn billing_state(
+    repo: Arc<MemoryRepo>,
+    compliance: Arc<dyn PaymentCompliance>,
+    authorizer: Arc<dyn BillingAuthorizer>,
+) -> BillingHttpState {
+    BillingHttpState::new(
         BillingDependencies {
             repository: repo,
             authorizer,
@@ -211,7 +219,7 @@ fn router_with_authorizer(
             wallet_url: Arc::from("https://console.example.test/wallet"),
             quota_per_unit: 1,
         },
-    ))
+    )
 }
 
 #[tokio::test]
@@ -709,6 +717,42 @@ async fn http_checkout_adapter_uses_a_loopback_provider_and_fails_closed() {
             .await,
         Err(BillingError::Provider)
     ));
+}
+
+#[tokio::test]
+async fn billing_provider_payments_router_mounts_provider_checkout_without_balance_pay() {
+    let repo = Arc::new(MemoryRepo {
+        completions: Mutex::new(Vec::new()),
+        failures: Mutex::new(Vec::new()),
+    });
+    let app = billing_provider_payments_router(billing_state(
+        repo,
+        Arc::new(MutableCompliance(AtomicBool::new(true))),
+        Arc::new(AllowUser),
+    ));
+
+    let stripe = app
+        .clone()
+        .oneshot(
+            Request::post("/api/subscription/stripe/pay")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"plan_id":1}"#))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(stripe.status(), StatusCode::OK);
+
+    let balance = app
+        .oneshot(
+            Request::post("/api/subscription/balance/pay")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"plan_id":1}"#))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(balance.status(), StatusCode::NOT_FOUND);
 }
 
 async fn mock_checkout(Json(payload): Json<serde_json::Value>) -> Json<serde_json::Value> {

--- a/apps/api-rust/tests/migration_identity_federation.rs
+++ b/apps/api-rust/tests/migration_identity_federation.rs
@@ -11,7 +11,8 @@ use lmm_api_rs::migration_routes::identity_federation::{
     FederatedLogin, FederatedUser, FederationError, FederationIdentity,
     FederationMutationPublisher, FederationPrincipal, FederationProviderError, FederationProviders,
     FederationState, OAuthFlowContext, bindings_router, oauth_email_bind_router,
-    oauth_state_router, provider_router, router, verify_telegram_authorization,
+    oauth_external_provider_router, oauth_state_router, provider_router, router,
+    verify_telegram_authorization,
 };
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -36,6 +37,11 @@ fn oauth_state_router_constructor_is_exposed_for_listener_composition() {
 fn oauth_email_bind_router_constructor_is_exposed_for_listener_composition() {
     let _constructor: fn(FederationState, Arc<dyn DashboardAuth>) -> Router =
         oauth_email_bind_router;
+}
+
+#[test]
+fn oauth_external_provider_router_constructor_is_exposed_for_listener_composition() {
+    let _constructor: fn(FederationState) -> Router = oauth_external_provider_router;
 }
 
 #[async_trait]

--- a/apps/api-rust/tests/migration_media_tasks.rs
+++ b/apps/api-rust/tests/migration_media_tasks.rs
@@ -7,7 +7,8 @@ use axum::{
     response::Response,
 };
 use lmm_api_rs::migration_routes::media_tasks::{
-    MediaTaskHttpState, MediaTaskOperation, MediaTaskService, media_task_router,
+    MediaTaskHttpState, MediaTaskOperation, MediaTaskService, media_provider_task_router,
+    media_task_router,
 };
 use serde_json::{Value, json};
 use tower::ServiceExt;
@@ -346,4 +347,41 @@ async fn every_selected_submit_and_task_route_reaches_its_exact_operation() {
     assert_eq!(calls[18].operation, MediaTaskOperation::KlingImageToVideo);
     assert_eq!(calls[19].operation, MediaTaskOperation::KlingTextToVideo);
     assert_eq!(calls[20].operation, MediaTaskOperation::JimengSubmit);
+}
+
+#[tokio::test]
+async fn media_provider_task_router_mounts_suno_kling_and_jimeng_without_midjourney() {
+    let service = Arc::new(StubTaskService::default());
+    let router = media_provider_task_router(MediaTaskHttpState::new(
+        Arc::clone(&service) as Arc<dyn MediaTaskService>
+    ));
+    for path in [
+        "/suno/fetch",
+        "/suno/fetch/suno-job",
+        "/suno/submit/extend",
+        "/kling/v1/videos/image2video",
+        "/kling/v1/videos/text2video",
+        "/jimeng/",
+    ] {
+        let method = if path.ends_with("suno-job") {
+            "GET"
+        } else {
+            "POST"
+        };
+        assert_eq!(
+            call(&router, method, path, Body::from("{}")).await.status(),
+            StatusCode::OK,
+            "{path}"
+        );
+    }
+    let midjourney = call(
+        &router,
+        "POST",
+        "/mj/submit/imagine",
+        Body::from(r#"{"prompt":"ok"}"#),
+    )
+    .await
+    .status();
+    assert_eq!(midjourney, StatusCode::NOT_FOUND);
+    assert_eq!(service.calls.lock().expect("calls lock").len(), 6);
 }

--- a/apps/api-rust/tests/migration_observability.rs
+++ b/apps/api-rust/tests/migration_observability.rs
@@ -9,8 +9,8 @@ use lmm_api_rs::migration_routes::observability::{
     InMemoryObservabilityStore, ObservabilityAccess, ObservabilityAuthError,
     ObservabilityAuthorizer, ObservabilityCall, ObservabilityPrincipal, ObservabilityState,
     ObservabilityStore, ObservabilityStoreError, observability_disk_cache_router,
-    observability_metrics_router, observability_performance_router, observability_read_router,
-    observability_router,
+    observability_force_gc_router, observability_metrics_router, observability_performance_router,
+    observability_read_router, observability_router,
 };
 use serde_json::{Value, json};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -108,6 +108,13 @@ fn disk_cache_router() -> axum::Router {
     ))
 }
 
+fn force_gc_router() -> axum::Router {
+    observability_force_gc_router(ObservabilityState::new(
+        Arc::new(SuccessStore),
+        Arc::new(Allow { role: 100 }),
+    ))
+}
+
 #[tokio::test]
 async fn observability_read_router_mounts_the_storage_only_surface() {
     let response = read_router()
@@ -164,6 +171,33 @@ async fn observability_performance_router_mounts_only_the_root_operations() {
             .expect("router response");
         assert_eq!(response.status(), StatusCode::OK, "{method} {uri}");
     }
+}
+
+#[tokio::test]
+async fn observability_force_gc_router_mounts_only_the_gc_operation() {
+    let response = force_gc_router()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/performance/gc")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let stats = force_gc_router()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/performance/stats")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    assert_eq!(stats.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# LMM API Pull Request

> LMM Forge 的 Go 服务保留上游兼容层。请说明本次变更对悬赏协作、交付跟踪或兼容行为的影响，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

#133 已把冻结 Go 清单里剩余 43 条路由挂到 Rust `extra_surface`，但拆 router 后漏了构造器测试，导致 `CI / Rust backend formatting, lint, and tests` 失败。本 PR 在最新 `main`（含 #133 与 Go 同步 #134）上补齐这些测试，并恢复 `billing_payments_router` 上的鉴权层，避免畸形 JSON 在鉴权前被 400 拒绝。

具体改动：

- `billing_provider_payments_router`、`oauth_external_provider_router`、`media_provider_task_router`、`observability_force_gc_router` 补上 integration 测试，满足 `every_migration_route_module_should_have_a_router_integration_test`
- `billing_payments_router` 在 balance-pay 字面量上重新挂上 `billing_payment_auth_boundary`，使 `payment_auth_precedes_malformed_json_rejection` 继续返回 401

生产所有权仍是 Go；冻结清单 `legacy-go-routes.tsv` 未改。

对照最新 Go 清单后：冻结 352 条已全部实现；当前 Go 528 条里还有 102 条冻结之后的新功能未实现。这些路由在 Go 侧已可用，本轮不在 Rust 上挂 fail-closed 适配器，避免抢走生产流量。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: 无

## 关联 Issue / Related issue

接续已合并的 #133。

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

已变基到 `origin/main` 并 force-push。本地按 CI Rust job 与路由对齐门闩跑通：

```text
command:
rustup run 1.88.0 cargo fmt --all --check
result: passed

command:
rustup run 1.88.0 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
result: passed

command:
rustup run 1.88.0 cargo test --workspace --all-targets --all-features --locked
result: passed (EXIT:0)

command:
check-complete-route-coverage / check-go-route-manifest / check-migration-plan /
check-draft-route-coverage / check-behavior-deviations / check-fixtures /
对应 self-test / check-test-instance-runtime-blockers
result: all passed

go-route-manifest:
active production ownership: 0 Rust / 352 Go
frozen baseline: 352/352 implemented
current Go inventory: 528 identities
Rust implementation: 427 routes (352 frozen + 75 current-only)
```

## 截图或日志 / Screenshots or logs

N/A

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-007a3c61-0711-449d-a51a-ce75cc36908f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-007a3c61-0711-449d-a51a-ce75cc36908f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 总结

在保留余额支付身份验证优先级的同时，完成 Rust migration-router 的覆盖。

错误修复：
- 恢复账单支付身份验证边界，确保格式错误的支付请求会被拒绝，并返回预期的未授权响应。
- 为拆分账单、OAuth 提供商、媒体提供商和可观测性 force-GC 路由器添加集成覆盖。

测试：
- 验证拆分路由器构造函数仅公开其预期路由，并拒绝无关端点。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Complete Rust migration-router coverage while preserving authentication precedence for balance payments.

Bug Fixes:
- Restore the billing payment authentication boundary so malformed payment requests are rejected with the intended unauthorized response.
- Add integration coverage for the split billing, OAuth provider, media provider, and observability force-GC routers.

Tests:
- Verify that split router constructors expose only their intended routes and reject unrelated endpoints.

</details>