### PR TITLE
fix(go): 消除额度缓存异步更新与 RedisEnabled 的竞态

### DIFF
--- a/apps/api-go/model/checkin.go
+++ b/apps/api-go/model/checkin.go
@@ -149,10 +149,12 @@ func userCheckinWithTransaction(checkin *Checkin, userId int, quotaAwarded int) 
 		return nil, err
 	}
 
-	// 事务成功后，异步更新缓存
-	go func() {
-		_ = cacheIncrUserQuota(userId, int64(quotaAwarded))
-	}()
+	// 事务成功后，异步更新缓存（无 Redis 时跳过，避免空跑并与测试 cleanup 竞态）
+	if common.RedisEnabled {
+		go func() {
+			_ = cacheIncrUserQuota(userId, int64(quotaAwarded))
+		}()
+	}
 
 	return checkin, nil
 }

--- a/apps/api-go/model/gift.go
+++ b/apps/api-go/model/gift.go
@@ -241,9 +241,11 @@ func claimGiftWithTransaction(claim *GiftClaim, userId int, quota int) error {
 	if err != nil {
 		return err
 	}
-	go func() {
-		_ = cacheIncrUserQuota(userId, int64(quota))
-	}()
+	if common.RedisEnabled {
+		go func() {
+			_ = cacheIncrUserQuota(userId, int64(quota))
+		}()
+	}
 	return nil
 }
 

--- a/apps/api-go/model/user.go
+++ b/apps/api-go/model/user.go
@@ -1520,12 +1520,17 @@ func IncreaseUserQuota(id int, quota int, db bool) (err error) {
 	if quota < 0 {
 		return errors.New("quota 不能为负数！")
 	}
-	gopool.Go(func() {
-		err := cacheIncrUserQuota(id, int64(quota))
-		if err != nil {
-			common.SysLog("failed to increase user quota: " + err.Error())
-		}
-	})
+	// Skip the cache worker when Redis is off; the goroutine would only read
+	// RedisEnabled and return. Spawning it races test cleanups that restore
+	// that flag and wastes a pool slot in production without Redis.
+	if common.RedisEnabled {
+		gopool.Go(func() {
+			err := cacheIncrUserQuota(id, int64(quota))
+			if err != nil {
+				common.SysLog("failed to increase user quota: " + err.Error())
+			}
+		})
+	}
 	if !db && common.BatchUpdateEnabled {
 		addNewRecord(BatchUpdateTypeUserQuota, id, quota)
 		return nil
@@ -1545,12 +1550,14 @@ func DecreaseUserQuota(id int, quota int, db bool) (err error) {
 	if quota < 0 {
 		return errors.New("quota 不能为负数！")
 	}
-	gopool.Go(func() {
-		err := cacheDecrUserQuota(id, int64(quota))
-		if err != nil {
-			common.SysLog("failed to decrease user quota: " + err.Error())
-		}
-	})
+	if common.RedisEnabled {
+		gopool.Go(func() {
+			err := cacheDecrUserQuota(id, int64(quota))
+			if err != nil {
+				common.SysLog("failed to decrease user quota: " + err.Error())
+			}
+		})
+	}
 	if !db && common.BatchUpdateEnabled {
 		addNewRecord(BatchUpdateTypeUserQuota, id, -quota)
 		return nil

--- a/apps/api-go/model/violation_fee.go
+++ b/apps/api-go/model/violation_fee.go
@@ -187,7 +187,7 @@ func ApplyViolationFee(input ViolationFeeChargeInput) (*ViolationFeeChargeResult
 			return err
 		}
 		result.Record = record
-		if chargedQuota > 0 {
+		if chargedQuota > 0 && common.RedisEnabled {
 			// Keep the Redis wallet counter aligned with the actual deduction only.
 			go func(userID, quota int) {
 				if err := cacheDecrUserQuota(userID, int64(quota)); err != nil {
@@ -315,7 +315,7 @@ func ReviewViolationFeeAppeal(adminUserID int, appealID uint, approve bool, note
 	if err != nil {
 		return nil, err
 	}
-	if reversedQuota > 0 {
+	if reversedQuota > 0 && common.RedisEnabled {
 		go func(userID, quota int) {
 			if err := cacheIncrUserQuota(userID, int64(quota)); err != nil {
 				common.SysLog("failed to restore violation fee quota cache: " + err.Error())

--- a/apps/api-go/service/task_polling_test.go
+++ b/apps/api-go/service/task_polling_test.go
@@ -275,10 +275,15 @@ func TestUpdateVideoTasksSlowChannelDoesNotBlockOtherChannels(t *testing.T) {
 	slowTask := seedPollingTask(t, slowChannelID, "task_public_slow", "upstream_slow_1")
 	fastFirst := seedPollingTask(t, fastChannelID, "task_public_fast_1", "upstream_fast_parallel_1")
 	fastSecond := seedPollingTask(t, fastChannelID, "task_public_fast_2", "upstream_fast_parallel_2")
+	// Snapshot upstream IDs before UpdateVideoTasks mutates the shared Task
+	// structs via GORM Updates; reading them from Another goroutine races.
+	slowUpstreamID := slowTask.GetUpstreamTaskID()
+	fastFirstUpstreamID := fastFirst.GetUpstreamTaskID()
+	fastSecondUpstreamID := fastSecond.GetUpstreamTaskID()
 
 	adaptor := &taskPollingFetchAdaptor{
 		fetched:      make(chan string, 4),
-		blockTaskID:  slowTask.GetUpstreamTaskID(),
+		blockTaskID:  slowUpstreamID,
 		blockStarted: make(chan struct{}),
 		releaseBlock: make(chan struct{}),
 	}
@@ -297,16 +302,16 @@ func TestUpdateVideoTasksSlowChannelDoesNotBlockOtherChannels(t *testing.T) {
 	gopool.Go(func() {
 		errCh <- UpdateVideoTasks(context.Background(), constant.TaskPlatform("kling"), map[int][]string{
 			slowChannelID: {
-				slowTask.GetUpstreamTaskID(),
+				slowUpstreamID,
 			},
 			fastChannelID: {
-				fastFirst.GetUpstreamTaskID(),
-				fastSecond.GetUpstreamTaskID(),
+				fastFirstUpstreamID,
+				fastSecondUpstreamID,
 			},
 		}, map[string]*model.Task{
-			slowTask.GetUpstreamTaskID():   slowTask,
-			fastFirst.GetUpstreamTaskID():  fastFirst,
-			fastSecond.GetUpstreamTaskID(): fastSecond,
+			slowUpstreamID:       slowTask,
+			fastFirstUpstreamID:  fastFirst,
+			fastSecondUpstreamID: fastSecond,
 		})
 	})
 
@@ -319,16 +324,16 @@ func TestUpdateVideoTasksSlowChannelDoesNotBlockOtherChannels(t *testing.T) {
 	require.Eventually(t, func() bool {
 		fetchedTaskIDs := adaptor.fetchedTaskIDs()
 		return len(fetchedTaskIDs) == 2 &&
-			fetchedTaskIDs[0] == fastFirst.GetUpstreamTaskID() &&
-			fetchedTaskIDs[1] == fastSecond.GetUpstreamTaskID()
+			fetchedTaskIDs[0] == fastFirstUpstreamID &&
+			fetchedTaskIDs[1] == fastSecondUpstreamID
 	}, 500*time.Millisecond, 10*time.Millisecond)
 
 	releaseBlockedTask()
 	require.NoError(t, <-errCh)
 	assert.ElementsMatch(t, []string{
-		slowTask.GetUpstreamTaskID(),
-		fastFirst.GetUpstreamTaskID(),
-		fastSecond.GetUpstreamTaskID(),
+		slowUpstreamID,
+		fastFirstUpstreamID,
+		fastSecondUpstreamID,
 	}, adaptor.fetchedTaskIDs())
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明 / Summary

在上游 Go 同步合入后做 `-race` 验证时，发现额度缓存异步更新与测试 cleanup 恢复 `RedisEnabled` 存在数据竞争。本 PR 仅修复 Go 侧竞态。

> **说明**：main 已通过 #135 修复 Rust 路由合约门禁；本 PR 不再包含重复的 Rust 测试改动，避免 CI merge preview 出现重复定义。

### Go 修复

- `IncreaseUserQuota` / `DecreaseUserQuota`：Redis 关闭时不再启动空跑的 cache worker
- `gift` / `checkin` / `violation_fee`：同样仅在 `RedisEnabled` 时异步刷缓存
- `TestUpdateVideoTasksSlowChannelDoesNotBlockOtherChannels`：在并发轮询前快照 upstream task ID，避免与 GORM Updates 并发读共享 `Task`

### 验证

- `go test -race ./model/ -run 'TestClaimGift|TestApplyViolationFee|TestCheckin'` 通过
- `go test -race ./service/ -run 'TestUpdateVideoTasksSlow'` 通过

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change

## 关联 Issue / Related issue

Follow-up to #134

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix

## 验证 / Verification

```text
command: go test -race ./model/ -count=2 -run 'TestClaimGift|TestApplyViolationFee|TestCheckin'
result: ok

command: go test -race ./service/ -count=2 -run 'TestUpdateVideoTasksSlow'
result: ok
```

## 提交检查 / Checklist

- [x] 我已搜索本仓库 Issues/PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动。
- [x] 已说明对兼容行为的影响（无行为变化：仅跳过无 Redis 时的空异步任务）。
- [x] 已补充/更新相关测试并记录验证结果。
- [x] 无敏感信息。

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74aa890a-8f39-4fe3-9182-38e4cab7799b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74aa890a-8f39-4fe3-9182-38e4cab7799b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 摘要

消除 Redis 禁用时的配额缓存竞争问题，并提高并发任务轮询测试的稳定性。

错误修复：
- 防止 Redis 被禁用时，配额缓存更新工作线程与 Redis 配置清理操作发生竞争。
- 避免在慢速通道轮询测试中并发访问可变任务数据。

改进：
- Redis 被禁用时，在配额、签到、礼物和违规费用流程中跳过不必要的异步缓存更新。

测试：
- 在并发更新之前对上游任务 ID 进行快照，从而增强任务轮询并发测试的稳定性。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

消除 Redis 禁用时的缓存竞态问题，并增强隔离的 Rust 路由行为和并发测试。

错误修复：
- Redis 禁用时，阻止异步配额缓存更新运行，消除其与 Redis 配置清理之间的竞态，并避免不必要的后台工作。
- 修正 Rust 计费路由中间件和路由隔离，确保身份验证先于 JSON 解析执行，并使提供商挂载排除本地账本端点。

增强功能：
- 在更新修改共享任务数据之前，对上游任务标识符进行快照，从而稳定并发任务轮询测试。

测试：
- 增加对计费路由隔离和身份验证顺序、外部 OAuth 状态处理、媒体提供商路由范围以及可观测性强制 GC 路由隔离的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

消除 Redis 禁用时异步缓存更新以及并发任务轮询测试访问所导致的 Go 端竞态问题。

错误修复：
- Redis 禁用时阻止启动异步配额缓存更新，消除其在签到、赠礼、配额和违规费用流程中与 Redis 配置清理之间的竞态。
- 通过避免并发读取可变任务数据，稳定并发任务轮询测试。

测试：
- 更新慢频道任务轮询测试，在并发执行期间使用上游任务标识符的稳定快照。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Eliminate Go-side races caused by asynchronous cache updates when Redis is disabled and concurrent task polling test access.

Bug Fixes:
- Prevent asynchronous quota-cache updates from starting when Redis is disabled, eliminating races with Redis configuration cleanup across check-in, gift, quota, and violation-fee flows.
- Stabilize the concurrent task-polling test by avoiding concurrent reads of mutable task data.

Tests:
- Update the slow-channel task-polling test to use stable snapshots of upstream task identifiers during concurrent execution.

</details>

</details>

</details>