### PR TITLE
feat(api-rust): 通过 cortexfs-protocol 对齐 Go 后端 API 与协议转换

### DIFF
--- a/apps/api-rust/Cargo.lock
+++ b/apps/api-rust/Cargo.lock
@@ -533,6 +533,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cortexfs-protocol"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7f7b11039e5fc3b17c0d769c933ad59f4b3d3ba29b10c43437df1cf2c3dca3"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1568,6 +1578,7 @@ dependencies = [
  "bcrypt",
  "brotli",
  "chrono",
+ "cortexfs-protocol",
  "flate2",
  "form_urlencoded",
  "futures-util",

--- a/apps/api-rust/Cargo.toml
+++ b/apps/api-rust/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [workspace.package]
 edition = "2024"
 license = "AGPL-3.0-or-later"
-rust-version = "1.85"
+rust-version = "1.91"
 version = "0.1.6"
 
 [workspace.dependencies]
@@ -67,6 +67,7 @@ bcrypt.workspace = true
 base64.workspace = true
 brotli.workspace = true
 chrono.workspace = true
+cortexfs-protocol = "0.1.7"
 hmac.workspace = true
 hex.workspace = true
 form_urlencoded.workspace = true

--- a/apps/api-rust/crates/contracts/src/relay/registry.rs
+++ b/apps/api-rust/crates/contracts/src/relay/registry.rs
@@ -13,7 +13,10 @@ use serde::{Deserialize, Serialize};
 
 use super::{Feature, Fidelity, Protocol};
 
-const REGISTRY_VERSION: &str = "relay-capabilities-v1";
+const REGISTRY_VERSION: &str = "relay-capabilities-v2-cortexfs";
+
+const CORTEXFS_CONVERTER_PREFIX: &str = "cortexfs";
+const CORTEXFS_RUNTIME_PREFIX: &str = "cortexfs-runtime";
 
 const RAW_OPENAI_CHAT: &str = "raw-openai-chat-v1";
 const RAW_OPENAI_RESPONSES: &str = "raw-openai-responses-v1";
@@ -149,6 +152,33 @@ impl RouteRegistration {
             quality: Fidelity::Exact,
             version: REGISTRY_VERSION.to_owned(),
             raw_passthrough: true,
+        }
+    }
+
+    /// Creates a cortexfs-backed cross-protocol route aligned with the Go relay matrix.
+    pub fn cortexfs_cross(source: Protocol, target: Protocol) -> Self {
+        let request_converter = cortexfs_converter_id(source, target, Direction::Request);
+        let response_converter = cortexfs_converter_id(source, target, Direction::Response);
+        let stream_converter = cortexfs_converter_id(source, target, Direction::Stream);
+        let stream_finalizer = cortexfs_stream_finalizer_id(source, target);
+        let runtime = cortexfs_runtime_adaptor_id(source, target);
+        Self {
+            source,
+            target,
+            request_supported: true,
+            response_supported: true,
+            stream_supported: true,
+            request_converter_id: Some(request_converter),
+            response_converter_id: Some(response_converter),
+            stream_converter_id: Some(stream_converter),
+            stream_finalizer_id: Some(stream_finalizer),
+            runtime_adaptors: vec![runtime],
+            feature_requirements: all_features(),
+            unsupported_features: BTreeSet::new(),
+            model_constraints: BtreeSetExt::one(ModelConstraint::any()),
+            quality: cross_protocol_fidelity(source, target),
+            version: REGISTRY_VERSION.to_owned(),
+            raw_passthrough: false,
         }
     }
 
@@ -460,7 +490,7 @@ impl Registry {
                 let route = if source == target {
                     RouteRegistration::raw(source)
                 } else {
-                    RouteRegistration::unsupported(source, target)
+                    RouteRegistration::cortexfs_cross(source, target)
                 };
                 routes.push(route);
             }
@@ -978,6 +1008,60 @@ fn raw_converter_id(protocol: Protocol) -> &'static str {
     }
 }
 
+/// Returns the Go-aligned fidelity claim for one cross-protocol pair.
+const fn cross_protocol_fidelity(source: Protocol, target: Protocol) -> Fidelity {
+    match (source, target) {
+        (Protocol::OpenAi, Protocol::OpenAiResponses)
+        | (Protocol::OpenAiResponses, Protocol::OpenAi) => Fidelity::Normalized,
+        (Protocol::Claude, Protocol::Gemini) | (Protocol::Gemini, Protocol::Claude) => {
+            Fidelity::Lossy
+        }
+        _ => Fidelity::Normalized,
+    }
+}
+
+fn cortexfs_converter_id(source: Protocol, target: Protocol, direction: Direction) -> String {
+    format!(
+        "{CORTEXFS_CONVERTER_PREFIX}-{}-to-{}-{}-v1",
+        cortexfs_protocol_slug(source),
+        cortexfs_protocol_slug(target),
+        cortexfs_direction_slug(direction)
+    )
+}
+
+fn cortexfs_stream_finalizer_id(source: Protocol, target: Protocol) -> String {
+    format!(
+        "{CORTEXFS_CONVERTER_PREFIX}-{}-to-{}-stream-finalizer-v1",
+        cortexfs_protocol_slug(source),
+        cortexfs_protocol_slug(target)
+    )
+}
+
+fn cortexfs_runtime_adaptor_id(source: Protocol, target: Protocol) -> String {
+    format!(
+        "{CORTEXFS_RUNTIME_PREFIX}-{}-to-{}-v1",
+        cortexfs_protocol_slug(source),
+        cortexfs_protocol_slug(target)
+    )
+}
+
+const fn cortexfs_protocol_slug(protocol: Protocol) -> &'static str {
+    match protocol {
+        Protocol::OpenAi => "openai-chat",
+        Protocol::OpenAiResponses => "openai-responses",
+        Protocol::Claude => "claude-messages",
+        Protocol::Gemini => "gemini-generate-content",
+    }
+}
+
+const fn cortexfs_direction_slug(direction: Direction) -> &'static str {
+    match direction {
+        Direction::Request => "request",
+        Direction::Response => "response",
+        Direction::Stream => "stream",
+    }
+}
+
 fn protocol_rank(protocol: Protocol) -> u8 {
     match protocol {
         Protocol::OpenAi => 0,
@@ -1023,19 +1107,23 @@ mod tests {
     }
 
     #[test]
-    fn cross_protocol_routes_remain_unsupported_without_a_runtime_adaptor() {
+    fn cross_protocol_routes_are_wired_through_cortexfs() {
         let registry = Registry::default();
         let bridge = registry
             .route(Protocol::OpenAi, Protocol::OpenAiResponses)
             .expect("bridge");
-        assert_eq!(bridge.quality, Fidelity::Unsupported);
-        assert!(!bridge.supports_any_direction());
+        assert_eq!(bridge.quality, Fidelity::Normalized);
+        assert!(bridge.supports_any_direction());
+        assert!(bridge
+            .request_converter_id
+            .as_deref()
+            .is_some_and(|id| id.starts_with("cortexfs-")));
 
-        let unsupported = registry
+        let discouraged = registry
             .route(Protocol::Claude, Protocol::Gemini)
-            .expect("explicit unsupported route");
-        assert_eq!(unsupported.quality, Fidelity::Unsupported);
-        assert!(!unsupported.supports_any_direction());
+            .expect("discouraged bridge");
+        assert_eq!(discouraged.quality, Fidelity::Lossy);
+        assert!(discouraged.supports_any_direction());
     }
 
     #[test]
@@ -1057,7 +1145,7 @@ mod tests {
         registry
             .route_mut(Protocol::Claude, Protocol::Gemini)
             .expect("route")
-            .quality = Fidelity::Normalized;
+            .quality = Fidelity::Exact;
         assert!(matches!(
             registry.validate(),
             Err(RegistryValidationError::QualityCapabilityConflict { .. })
@@ -1110,24 +1198,18 @@ mod tests {
     }
 
     #[test]
-    fn catalog_cannot_invent_an_openai_bridge() {
+    fn catalog_cannot_claim_exact_quality_on_cross_protocol_routes() {
         let mut catalog = runtime_catalog();
-        let raw = RouteRegistration::raw(Protocol::OpenAi);
-        let mut bridge = RuntimeRoute::new(Protocol::OpenAi, Protocol::OpenAiResponses);
-        bridge.request_converter_id = raw.request_converter_id.clone();
-        bridge.response_converter_id = raw.response_converter_id.clone();
-        bridge.stream_converter_id = raw.stream_converter_id.clone();
-        bridge.stream_finalizer_id = raw.stream_finalizer_id.clone();
-        if let Some(adaptor) = raw.runtime_adaptors.first() {
-            bridge.runtime_adaptors.insert(adaptor.clone());
-        }
-        catalog.routes.push(bridge);
+        let bridge = catalog
+            .routes
+            .iter_mut()
+            .find(|route| route.source == Protocol::OpenAi && route.target == Protocol::OpenAiResponses)
+            .expect("cross route runtime metadata");
+        bridge.request_converter_id = Some("raw-openai-chat-v1".to_owned());
         assert!(matches!(
             Registry::default().validate_against_catalog(&catalog),
-            Err(RegistryValidationError::CatalogClaimsUnsupportedRoute {
-                source: Protocol::OpenAi,
-                target: Protocol::OpenAiResponses,
-            })
+            Err(RegistryValidationError::RuntimeDirectionMismatch { .. })
+                | Err(RegistryValidationError::UnknownConverter { .. })
         ));
     }
 
@@ -1174,7 +1256,7 @@ mod tests {
         );
         let json = matrix.to_json().expect("matrix json");
         assert!(json.contains("open_ai_responses"));
-        assert!(json.contains("unsupported"));
+        assert!(json.contains("normalized"));
     }
 
     fn runtime_catalog() -> RuntimeCatalog {
@@ -1182,32 +1264,33 @@ mod tests {
         let mut finalizers = BTreeSet::new();
         let mut adaptors = BTreeSet::new();
         let mut routes = Vec::new();
-        for protocol in protocols() {
-            let route = RouteRegistration::raw(protocol);
-            let converter = route
-                .request_converter_id
-                .clone()
-                .expect("raw request converter");
-            let finalizer = route
-                .stream_finalizer_id
-                .clone()
-                .expect("raw stream finalizer");
-            let adaptor = route
-                .runtime_adaptors
-                .first()
-                .cloned()
-                .expect("raw runtime adaptor");
-            converters.insert(converter.clone());
-            finalizers.insert(finalizer.clone());
-            adaptors.insert(adaptor.clone());
-            let mut runtime = RuntimeRoute::new(protocol, protocol);
-            runtime.request_converter_id = Some(converter.clone());
-            runtime.response_converter_id = Some(converter.clone());
-            runtime.stream_converter_id = Some(converter);
-            runtime.stream_finalizer_id = Some(finalizer);
-            runtime.runtime_adaptors.insert(adaptor);
-            routes.push(runtime);
+        for source in protocols() {
+            for target in protocols() {
+                let registration = if source == target {
+                    RouteRegistration::raw(source)
+                } else {
+                    RouteRegistration::cortexfs_cross(source, target)
+                };
+                for converter in registration.converter_ids() {
+                    converters.insert(converter.to_owned());
+                }
+                if let Some(finalizer) = registration.stream_finalizer_id.clone() {
+                    finalizers.insert(finalizer);
+                }
+                for adaptor in &registration.runtime_adaptors {
+                    adaptors.insert(adaptor.clone());
+                }
+                let mut runtime = RuntimeRoute::new(source, target);
+                runtime.request_converter_id = registration.request_converter_id.clone();
+                runtime.response_converter_id = registration.response_converter_id.clone();
+                runtime.stream_converter_id = registration.stream_converter_id.clone();
+                runtime.stream_finalizer_id = registration.stream_finalizer_id.clone();
+                runtime
+                    .runtime_adaptors
+                    .extend(registration.runtime_adaptors.iter().cloned());
+                routes.push(runtime);
+            }
         }
-        RuntimeCatalog::new("test-runtime-v1", converters, finalizers, adaptors, routes)
+        RuntimeCatalog::new("test-runtime-v2-cortexfs", converters, finalizers, adaptors, routes)
     }
 }

--- a/apps/api-rust/rust-toolchain.toml
+++ b/apps/api-rust/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.91.0"

--- a/apps/api-rust/src/cortexfs_protocol_bridge.rs
+++ b/apps/api-rust/src/cortexfs_protocol_bridge.rs
@@ -1,0 +1,611 @@
+//! Production protocol conversion through the [`cortexfs-protocol`] crate.
+//!
+//! This module is the only runtime conversion boundary for cross-provider
+//! relay traffic.  Same-protocol routes continue to use opaque byte
+//! passthrough; every other source/target pair is transcoded through
+//! `transcode_request` / `transcode_response` and, for streaming SSE, through
+//! normalized [`ModelEvent`] values mapped into the contracts
+//! [`CanonicalStreamEvent`] state machine.
+
+use std::fmt;
+
+use cortexfs_protocol::{
+    BridgePath, ConversionError, EventStatus, ModelEvent, WireProtocol, decode_response_events,
+    transcode_request, transcode_response,
+};
+use lmm_contracts::relay::{
+    CanonicalStreamEvent, Direction, FinishReason, Fidelity, Protocol, TokenUsage, protocols,
+};
+
+use crate::{
+    migration_routes::sse::SseFrame,
+    protocol_stream_pipeline::{
+        StreamAdaptor, StreamAdaptorItem, StreamAdaptorOutput, StreamAdaptorRegistry,
+        StreamAdaptorSession, StreamCloseReason, StreamSetupFailure, TypedStreamFailure,
+    },
+};
+
+/// Converter ID prefix shared by every cortexfs-backed route.
+pub const CORTEXFS_CONVERTER_PREFIX: &str = "cortexfs";
+
+/// Runtime adaptor prefix for cortexfs-backed routes.
+pub const CORTEXFS_RUNTIME_PREFIX: &str = "cortexfs-runtime";
+
+/// Failures surfaced by the bridge before an upstream call is attempted.
+#[derive(Debug)]
+pub enum CortexFsBridgeError {
+    /// The contracts protocol has no cortexfs wire dialect.
+    UnsupportedProtocol(Protocol),
+    /// The underlying cortexfs conversion failed.
+    Conversion(ConversionError),
+}
+
+impl fmt::Display for CortexFsBridgeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedProtocol(protocol) => {
+                write!(formatter, "unsupported protocol for cortexfs bridge: {protocol:?}")
+            }
+            Self::Conversion(error) => write!(formatter, "cortexfs conversion failed: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for CortexFsBridgeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::UnsupportedProtocol(_) => None,
+            Self::Conversion(error) => Some(error),
+        }
+    }
+}
+
+impl From<ConversionError> for CortexFsBridgeError {
+    fn from(error: ConversionError) -> Self {
+        Self::Conversion(error)
+    }
+}
+
+/// Result of a successful request transcoding, including the route taken.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CortexFsTranscodedRequest {
+    /// Target-protocol request bytes.
+    pub bytes: Vec<u8>,
+    /// Conversion route selected by cortexfs.
+    pub path: BridgePath,
+}
+
+/// Result of a successful response transcoding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CortexFsTranscodedResponse {
+    /// Target-protocol response bytes.
+    pub bytes: Vec<u8>,
+    /// Conversion route selected by cortexfs.
+    pub path: BridgePath,
+}
+
+/// Maps a contracts protocol to the cortexfs wire dialect.
+#[must_use]
+pub const fn protocol_to_wire(protocol: Protocol) -> Option<WireProtocol> {
+    match protocol {
+        Protocol::OpenAi => Some(WireProtocol::OpenAiChat),
+        Protocol::OpenAiResponses => Some(WireProtocol::OpenAiResponses),
+        Protocol::Claude => Some(WireProtocol::Anthropic),
+        Protocol::Gemini => Some(WireProtocol::Gemini),
+    }
+}
+
+/// Maps a cortexfs wire dialect back to the contracts protocol.
+#[must_use]
+pub const fn wire_to_protocol(wire: WireProtocol) -> Protocol {
+    match wire {
+        WireProtocol::OpenAiChat => Protocol::OpenAi,
+        WireProtocol::OpenAiResponses => Protocol::OpenAiResponses,
+        WireProtocol::Anthropic => Protocol::Claude,
+        WireProtocol::Gemini => Protocol::Gemini,
+    }
+}
+
+/// Returns the Go-aligned fidelity claim for one source/target pair.
+#[must_use]
+pub fn cross_protocol_fidelity(source: Protocol, target: Protocol) -> Fidelity {
+    if source == target {
+        return Fidelity::Exact;
+    }
+    match (source, target) {
+        (Protocol::OpenAi, Protocol::OpenAiResponses)
+        | (Protocol::OpenAiResponses, Protocol::OpenAi) => Fidelity::Normalized,
+        (Protocol::Claude, Protocol::Gemini) | (Protocol::Gemini, Protocol::Claude) => {
+            Fidelity::Lossy
+        }
+        _ => Fidelity::Normalized,
+    }
+}
+
+/// Stable converter identifier for one direction and conversion phase.
+#[must_use]
+pub fn converter_id(source: Protocol, target: Protocol, direction: Direction) -> String {
+    format!(
+        "{CORTEXFS_CONVERTER_PREFIX}-{}-to-{}-{}-v1",
+        protocol_slug(source),
+        protocol_slug(target),
+        direction_slug(direction)
+    )
+}
+
+/// Stable stream-finalizer identifier for one source/target pair.
+#[must_use]
+pub fn stream_finalizer_id(source: Protocol, target: Protocol) -> String {
+    format!(
+        "{CORTEXFS_CONVERTER_PREFIX}-{}-to-{}-stream-finalizer-v1",
+        protocol_slug(source),
+        protocol_slug(target)
+    )
+}
+
+/// Stable runtime adaptor identifier for one source/target pair.
+#[must_use]
+pub fn runtime_adaptor_id(source: Protocol, target: Protocol) -> String {
+    format!(
+        "{CORTEXFS_RUNTIME_PREFIX}-{}-to-{}-v1",
+        protocol_slug(source),
+        protocol_slug(target)
+    )
+}
+
+const fn protocol_slug(protocol: Protocol) -> &'static str {
+    match protocol {
+        Protocol::OpenAi => "openai-chat",
+        Protocol::OpenAiResponses => "openai-responses",
+        Protocol::Claude => "claude-messages",
+        Protocol::Gemini => "gemini-generate-content",
+    }
+}
+
+const fn direction_slug(direction: Direction) -> &'static str {
+    match direction {
+        Direction::Request => "request",
+        Direction::Response => "response",
+        Direction::Stream => "stream",
+    }
+}
+
+/// Transcodes a request body from `source` to `target`.
+pub fn transcode_request_protocol(
+    source: Protocol,
+    target: Protocol,
+    input: &[u8],
+) -> Result<CortexFsTranscodedRequest, CortexFsBridgeError> {
+    let source_wire =
+        protocol_to_wire(source).ok_or(CortexFsBridgeError::UnsupportedProtocol(source))?;
+    let target_wire =
+        protocol_to_wire(target).ok_or(CortexFsBridgeError::UnsupportedProtocol(target))?;
+    let converted = transcode_request(source_wire, target_wire, input)?;
+    Ok(CortexFsTranscodedRequest {
+        bytes: converted.bytes,
+        path: converted.path,
+    })
+}
+
+/// Transcodes a complete non-streaming response body from `source` to `target`.
+pub fn transcode_response_protocol(
+    source: Protocol,
+    target: Protocol,
+    input: &[u8],
+) -> Result<CortexFsTranscodedResponse, CortexFsBridgeError> {
+    let source_wire =
+        protocol_to_wire(source).ok_or(CortexFsBridgeError::UnsupportedProtocol(source))?;
+    let target_wire =
+        protocol_to_wire(target).ok_or(CortexFsBridgeError::UnsupportedProtocol(target))?;
+    let converted = transcode_response(source_wire, target_wire, input)?;
+    Ok(CortexFsTranscodedResponse {
+        bytes: converted.bytes,
+        path: converted.path,
+    })
+}
+
+/// Decodes one complete provider response body into normalized events.
+pub fn decode_provider_events(
+    source: Protocol,
+    input: &[u8],
+) -> Result<Vec<ModelEvent>, CortexFsBridgeError> {
+    let source_wire =
+        protocol_to_wire(source).ok_or(CortexFsBridgeError::UnsupportedProtocol(source))?;
+    Ok(decode_response_events(source_wire, input)?)
+}
+
+/// Maps one normalized [`ModelEvent`] into zero or more canonical stream events.
+pub fn model_event_to_canonical(
+    event: &ModelEvent,
+    state: &mut StreamMapState,
+) -> Vec<CanonicalStreamEvent> {
+    match event {
+        ModelEvent::Start { run, model } => {
+            state.run_id = Some(run.clone());
+            state.started = true;
+            vec![CanonicalStreamEvent::ResponseStart {
+                id: run.clone(),
+                model: model.clone(),
+            }]
+        }
+        ModelEvent::TextDelta { text, .. } => {
+            let index = state.ensure_text_block();
+            vec![CanonicalStreamEvent::TextDelta {
+                index,
+                delta: text.clone(),
+            }]
+        }
+        ModelEvent::ReasoningDelta { text, .. } => {
+            let index = state.ensure_reasoning_block();
+            vec![CanonicalStreamEvent::ReasoningDelta {
+                index,
+                delta: text.clone(),
+            }]
+        }
+        ModelEvent::ToolCall { call, .. } => {
+            let index = state.next_block_index();
+            let arguments = serde_json::to_string(&call.arguments).unwrap_or_else(|_| "{}".to_owned());
+            vec![
+                CanonicalStreamEvent::ToolCallStart {
+                    index,
+                    id: call.id.clone(),
+                    name: call.name.clone(),
+                },
+                CanonicalStreamEvent::ToolArgumentsDelta {
+                    index,
+                    delta: arguments,
+                },
+                CanonicalStreamEvent::ContentEnd { index },
+            ]
+        }
+        ModelEvent::Message { message, .. } => {
+            let text = message.content.text_value();
+            if text.is_empty() {
+                return Vec::new();
+            }
+            let index = state.ensure_text_block();
+            vec![CanonicalStreamEvent::TextDelta {
+                index,
+                delta: text,
+            }]
+        }
+        ModelEvent::Usage { usage, .. } => {
+            state.pending_usage = Some(TokenUsage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                total_tokens: usage.input_tokens.saturating_add(usage.output_tokens),
+                cached_input_tokens: usage.cached_tokens.unwrap_or(0),
+                reasoning_tokens: usage.reasoning_tokens.unwrap_or(0),
+            });
+            Vec::new()
+        }
+        ModelEvent::Error { error, .. } => vec![CanonicalStreamEvent::Error {
+            code: Some(error.code.clone()),
+            message: error.message.clone(),
+        }],
+        ModelEvent::Done { status, .. } => {
+            let finish_reason = match status {
+                EventStatus::Ok => FinishReason::Stop,
+                EventStatus::Error => FinishReason::Error,
+                EventStatus::Cancelled => FinishReason::Cancelled,
+            };
+            vec![CanonicalStreamEvent::ResponseEnd {
+                finish_reason,
+                usage: state.pending_usage.take(),
+                model: None,
+            }]
+        }
+    }
+}
+
+/// Mutable mapping state for one streaming conversion session.
+#[derive(Clone, Debug, Default)]
+pub struct StreamMapState {
+    run_id: Option<String>,
+    started: bool,
+    next_index: usize,
+    text_block: Option<usize>,
+    reasoning_block: Option<usize>,
+    pending_usage: Option<TokenUsage>,
+}
+
+impl StreamMapState {
+    fn ensure_text_block(&mut self) -> usize {
+        if let Some(index) = self.text_block {
+            return index;
+        }
+        let index = self.next_block_index();
+        self.text_block = Some(index);
+        index
+    }
+
+    fn ensure_reasoning_block(&mut self) -> usize {
+        if let Some(index) = self.reasoning_block {
+            return index;
+        }
+        let index = self.next_block_index();
+        self.reasoning_block = Some(index);
+        index
+    }
+
+    fn next_block_index(&mut self) -> usize {
+        let index = self.next_index;
+        self.next_index += 1;
+        index
+    }
+}
+
+/// Registry exposing cortexfs-backed stream adaptors for every cross-protocol pair.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CortexFsStreamAdaptorRegistry;
+
+fn adaptor_table() -> &'static [CortexFsStreamAdaptor] {
+    static TABLE: std::sync::OnceLock<Vec<CortexFsStreamAdaptor>> = std::sync::OnceLock::new();
+    TABLE.get_or_init(|| {
+        let mut adaptors = Vec::new();
+        for source in protocols() {
+            for target in protocols() {
+                if source != target {
+                    adaptors.push(CortexFsStreamAdaptor { source, target });
+                }
+            }
+        }
+        adaptors
+    })
+}
+
+impl StreamAdaptorRegistry for CortexFsStreamAdaptorRegistry {
+    fn for_route(&self, source: Protocol, target: Protocol) -> Option<&dyn StreamAdaptor> {
+        adaptor_table()
+            .iter()
+            .find(|adaptor| adaptor.source == source && adaptor.target == target)
+            .map(|adaptor| adaptor as &dyn StreamAdaptor)
+    }
+}
+
+/// One cortexfs-backed typed stream adaptor.
+#[derive(Clone, Copy, Debug)]
+struct CortexFsStreamAdaptor {
+    source: Protocol,
+    target: Protocol,
+}
+
+impl StreamAdaptor for CortexFsStreamAdaptor {
+    fn source(&self) -> Protocol {
+        self.source
+    }
+
+    fn target(&self) -> Protocol {
+        self.target
+    }
+
+    fn compile(
+        &self,
+        _plan: &lmm_contracts::relay::ConversionPlan,
+    ) -> Result<Box<dyn StreamAdaptorSession>, StreamSetupFailure> {
+        Ok(Box::new(CortexFsStreamSession {
+            source: self.source,
+            target: self.target,
+            map_state: StreamMapState::default(),
+        }))
+    }
+}
+
+struct CortexFsStreamSession {
+    source: Protocol,
+    target: Protocol,
+    map_state: StreamMapState,
+}
+
+impl StreamAdaptorSession for CortexFsStreamSession {
+    fn process_frame(
+        &mut self,
+        frame: &SseFrame,
+    ) -> Result<StreamAdaptorOutput, TypedStreamFailure> {
+        let _ = self.target;
+        if frame.data.trim() == "[DONE]" {
+            return Ok(StreamAdaptorOutput::empty());
+        }
+        let payload = frame.data.as_bytes();
+        if payload.is_empty() {
+            return Ok(StreamAdaptorOutput::empty());
+        }
+        let events =
+            decode_provider_events(self.source, payload).map_err(|_| TypedStreamFailure::UnknownEvent)?;
+        let mut items = Vec::new();
+        for event in events {
+            for canonical in model_event_to_canonical(&event, &mut self.map_state) {
+                items.push(StreamAdaptorItem::Canonical { event: canonical });
+            }
+        }
+        Ok(StreamAdaptorOutput::new(items))
+    }
+
+    fn cancel(&mut self) -> Result<(), TypedStreamFailure> {
+        Ok(())
+    }
+}
+
+/// Returns whether the bridge can transcode between two protocols.
+#[must_use]
+pub fn supports_transcode(source: Protocol, target: Protocol) -> bool {
+    protocol_to_wire(source).is_some() && protocol_to_wire(target).is_some()
+}
+
+/// Returns the local close reason when no typed adaptor is available.
+#[must_use]
+pub const fn typed_adaptor_close_reason() -> StreamCloseReason {
+    StreamCloseReason::TypedAdaptorUnavailable
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cortexfs_protocol::BridgePath;
+
+    const CHAT: &[u8] = br#"{"model":"chat-model","messages":[{"role":"user","content":"hi"}]}"#;
+    const RESPONSES: &[u8] = br#"{"model":"responses-model","input":"hi"}"#;
+    const GEMINI: &[u8] =
+        br#"{"model":"gemini-model","contents":[{"role":"user","parts":[{"text":"hi"}]}]}"#;
+    const ANTHROPIC: &[u8] =
+        br#"{"model":"claude-model","max_tokens":32,"messages":[{"role":"user","content":"hi"}]}"#;
+
+    fn fixture(protocol: Protocol) -> &'static [u8] {
+        match protocol {
+            Protocol::OpenAi => CHAT,
+            Protocol::OpenAiResponses => RESPONSES,
+            Protocol::Claude => ANTHROPIC,
+            Protocol::Gemini => GEMINI,
+        }
+    }
+
+    #[test]
+    fn protocol_mapping_is_bijective_for_supported_dialects() {
+        for protocol in [
+            Protocol::OpenAi,
+            Protocol::OpenAiResponses,
+            Protocol::Claude,
+            Protocol::Gemini,
+        ] {
+            let wire = protocol_to_wire(protocol).expect("wire dialect");
+            assert_eq!(wire_to_protocol(wire), protocol);
+        }
+    }
+
+    #[test]
+    fn request_matrix_matches_cortexfs_capabilities() {
+        for source in [
+            Protocol::OpenAi,
+            Protocol::OpenAiResponses,
+            Protocol::Claude,
+            Protocol::Gemini,
+        ] {
+            for target in [
+                Protocol::OpenAi,
+                Protocol::OpenAiResponses,
+                Protocol::Claude,
+                Protocol::Gemini,
+            ] {
+                let converted =
+                    transcode_request_protocol(source, target, fixture(source)).expect("transcode");
+                assert!(serde_json::from_slice::<serde_json::Value>(&converted.bytes).is_ok());
+                if source == target {
+                    assert_eq!(converted.path, BridgePath::Identity);
+                    assert_eq!(converted.bytes, fixture(source));
+                } else if matches!(
+                    (source, target),
+                    (Protocol::OpenAi, Protocol::Gemini) | (Protocol::Gemini, Protocol::OpenAi)
+                ) {
+                    assert_eq!(converted.path, BridgePath::Direct);
+                } else {
+                    assert_eq!(converted.path, BridgePath::ViaIr);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn response_matrix_matches_cortexfs_capabilities() {
+        const CHAT_RESPONSE: &[u8] = br#"{"id":"chat-run","model":"chat-model","choices":[{"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#;
+        const RESPONSES_RESPONSE: &[u8] = br#"{"id":"responses-run","model":"responses-model","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hello"}]}],"usage":{"input_tokens":3,"output_tokens":2}}"#;
+        const GEMINI_RESPONSE: &[u8] = br#"{"responseId":"gemini-run","modelVersion":"gemini-model","candidates":[{"content":{"role":"model","parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":2}}"#;
+        const ANTHROPIC_RESPONSE: &[u8] = br#"{"id":"anthropic-run","model":"claude-model","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}"#;
+
+        let response_fixture = |protocol: Protocol| match protocol {
+            Protocol::OpenAi => CHAT_RESPONSE,
+            Protocol::OpenAiResponses => RESPONSES_RESPONSE,
+            Protocol::Claude => ANTHROPIC_RESPONSE,
+            Protocol::Gemini => GEMINI_RESPONSE,
+        };
+
+        for source in [
+            Protocol::OpenAi,
+            Protocol::OpenAiResponses,
+            Protocol::Claude,
+            Protocol::Gemini,
+        ] {
+            for target in [
+                Protocol::OpenAi,
+                Protocol::OpenAiResponses,
+                Protocol::Claude,
+                Protocol::Gemini,
+            ] {
+                let converted =
+                    transcode_response_protocol(source, target, response_fixture(source))
+                        .expect("response transcode");
+                assert!(serde_json::from_slice::<serde_json::Value>(&converted.bytes).is_ok());
+                if source == target {
+                    assert_eq!(converted.path, BridgePath::Identity);
+                } else {
+                    assert_eq!(converted.path, BridgePath::ViaIr);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn converter_ids_are_stable_and_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        for source in [
+            Protocol::OpenAi,
+            Protocol::OpenAiResponses,
+            Protocol::Claude,
+            Protocol::Gemini,
+        ] {
+            for target in [
+                Protocol::OpenAi,
+                Protocol::OpenAiResponses,
+                Protocol::Claude,
+                Protocol::Gemini,
+            ] {
+                for direction in [
+                    Direction::Request,
+                    Direction::Response,
+                    Direction::Stream,
+                ] {
+                    assert!(seen.insert(converter_id(source, target, direction)));
+                }
+                assert!(seen.insert(stream_finalizer_id(source, target)));
+                assert!(seen.insert(runtime_adaptor_id(source, target)));
+            }
+        }
+    }
+
+    #[test]
+    fn model_event_start_and_done_map_to_canonical_terminal_sequence() {
+        let mut state = StreamMapState::default();
+        let start = model_event_to_canonical(
+            &ModelEvent::Start {
+                run: "run-1".to_owned(),
+                model: "model".to_owned(),
+            },
+            &mut state,
+        );
+        assert!(matches!(
+            start.as_slice(),
+            [CanonicalStreamEvent::ResponseStart { .. }]
+        ));
+        let done = model_event_to_canonical(
+            &ModelEvent::Done {
+                run: "run-1".to_owned(),
+                status: EventStatus::Ok,
+            },
+            &mut state,
+        );
+        assert!(matches!(
+            done.as_slice(),
+            [CanonicalStreamEvent::ResponseEnd { .. }]
+        ));
+    }
+
+    #[test]
+    fn stream_registry_exposes_only_cross_protocol_pairs() {
+        let registry = CortexFsStreamAdaptorRegistry;
+        assert!(registry
+            .for_route(Protocol::OpenAi, Protocol::OpenAi)
+            .is_none());
+        assert!(registry
+            .for_route(Protocol::OpenAi, Protocol::Claude)
+            .is_some());
+    }
+}

--- a/apps/api-rust/src/lib.rs
+++ b/apps/api-rust/src/lib.rs
@@ -77,6 +77,9 @@ pub mod route_ownership;
 /// Runtime-owned protocol capability catalog and startup drift validation.
 pub mod protocol_runtime_registry;
 
+/// Production protocol conversion backed by the cortexfs-protocol crate.
+pub mod cortexfs_protocol_bridge;
+
 /// Candidate route slices compiled for migration testing but not mounted.
 pub mod migration_routes;
 

--- a/apps/api-rust/src/migration_routes/assistant.rs
+++ b/apps/api-rust/src/migration_routes/assistant.rs
@@ -1653,7 +1653,7 @@ pub fn assistant_read_router(state: AssistantReadState) -> Router {
             post(admin_resolve_handoff),
         )
         .route("/api/assistant/admin/intents", get(admin_intents))
-        .merge(assistant_extended::extended_routes())
+        .merge(assistant_extended::extended_router())
         .with_state(state)
 }
 

--- a/apps/api-rust/src/migration_routes/assistant_extended.rs
+++ b/apps/api-rust/src/migration_routes/assistant_extended.rs
@@ -32,7 +32,7 @@ const ROOT_ROLE: i64 = 100;
 const ASSISTANT_HISTORY_PAGE_MAX: i64 = 100;
 const ASSISTANT_REQUEST_REVIEW_PAGE_MAX: i64 = 100;
 
-pub fn extended_routes() -> Router<AssistantReadState> {
+pub fn extended_router() -> Router<AssistantReadState> {
     Router::new()
         .route("/api/assistant/journey", get(get_journey))
         .route("/api/assistant/new-user-gift", get(get_new_user_gift))

--- a/apps/api-rust/src/migration_routes/discount_code.rs
+++ b/apps/api-rust/src/migration_routes/discount_code.rs
@@ -733,8 +733,9 @@ fn discount_code_pattern_matches(code: &str) -> bool {
     if chars.len() < 3 || chars.len() > 64 {
         return false;
     }
-    let valid = |ch: char| ch.is_ascii_uppercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-');
-    valid(chars[0]) && chars[1..].iter().copied().all(valid)
+    let first_valid = |ch: char| ch.is_ascii_uppercase() || ch.is_ascii_digit();
+    let rest_valid = |ch: char| ch.is_ascii_uppercase() || ch.is_ascii_digit() || matches!(ch, '_' | '-');
+    first_valid(chars[0]) && chars[1..].iter().copied().all(rest_valid)
 }
 
 fn normalize_discount_code(value: &str) -> String {

--- a/apps/api-rust/src/migration_routes/mcp.rs
+++ b/apps/api-rust/src/migration_routes/mcp.rs
@@ -6,9 +6,9 @@ use axum::{
     Router,
     body::Bytes,
     extract::{Request, State},
-    http::{HeaderMap, StatusCode, header},
+    http::{HeaderMap, Method, StatusCode, header},
     response::{IntoResponse, Response},
-    routing::any,
+    routing::{connect, delete, get, head, options, patch, post, put, trace},
     Json,
 };
 use serde_json::json;
@@ -39,10 +39,54 @@ impl McpHttpState {
 /// Mounts `/mcp` and `/mcp/drawing` with Go-compatible Any-method handlers.
 pub fn mcp_router(state: McpHttpState) -> Router {
     Router::new()
-        .route("/mcp", any(open_source_bounty_mcp))
-        .route("/mcp/", any(open_source_bounty_mcp))
-        .route("/mcp/drawing", any(drawing_mcp))
-        .route("/mcp/drawing/", any(drawing_mcp))
+        .route(
+            "/mcp",
+            connect(open_source_bounty_mcp)
+                .trace(open_source_bounty_mcp)
+                .get(open_source_bounty_mcp)
+                .post(open_source_bounty_mcp)
+                .put(open_source_bounty_mcp)
+                .delete(open_source_bounty_mcp)
+                .patch(open_source_bounty_mcp)
+                .head(open_source_bounty_mcp)
+                .options(open_source_bounty_mcp),
+        )
+        .route(
+            "/mcp/",
+            connect(open_source_bounty_mcp)
+                .trace(open_source_bounty_mcp)
+                .get(open_source_bounty_mcp)
+                .post(open_source_bounty_mcp)
+                .put(open_source_bounty_mcp)
+                .delete(open_source_bounty_mcp)
+                .patch(open_source_bounty_mcp)
+                .head(open_source_bounty_mcp)
+                .options(open_source_bounty_mcp),
+        )
+        .route(
+            "/mcp/drawing",
+            connect(drawing_mcp)
+                .trace(drawing_mcp)
+                .get(drawing_mcp)
+                .post(drawing_mcp)
+                .put(drawing_mcp)
+                .delete(drawing_mcp)
+                .patch(drawing_mcp)
+                .head(drawing_mcp)
+                .options(drawing_mcp),
+        )
+        .route(
+            "/mcp/drawing/",
+            connect(drawing_mcp)
+                .trace(drawing_mcp)
+                .get(drawing_mcp)
+                .post(drawing_mcp)
+                .put(drawing_mcp)
+                .delete(drawing_mcp)
+                .patch(drawing_mcp)
+                .head(drawing_mcp)
+                .options(drawing_mcp),
+        )
         .with_state(state)
 }
 

--- a/apps/api-rust/src/protocol_differential_gate.rs
+++ b/apps/api-rust/src/protocol_differential_gate.rs
@@ -1719,19 +1719,21 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_registry_route_stays_closed() {
+    fn supported_cross_protocol_registry_route_validates_with_signed_document() {
         let registry = validated_current_registry().expect("built-in registry validates");
-        let mut document = valid_document();
-        document.scope = RouteOwnershipScope {
+        let scope = RouteOwnershipScope {
             source: Protocol::OpenAi,
             target: Protocol::Claude,
             stream: true,
         };
-        document.shadow.scope = document.scope;
-        assert_eq!(
-            document.verify(&registry, &trusted_policy()),
-            Err(DifferentialEvidenceError::RouteQualityUnsupported)
-        );
+        let mut document = valid_document();
+        document.scope = scope;
+        document.shadow.scope = scope;
+        document.model_family = "claude".to_owned();
+        sign_document(&mut document);
+        document
+            .verify(&registry, &trusted_policy())
+            .expect("supported cross route validates");
     }
 
     #[test]

--- a/apps/api-rust/src/protocol_route_gate.rs
+++ b/apps/api-rust/src/protocol_route_gate.rs
@@ -262,7 +262,7 @@ mod tests {
     use crate::{
         protocol_rollout::{FlagConfig, MAX_BASIS_POINTS, ShadowDifference, ShadowRecord},
         protocol_runtime_registry::validated_current_registry,
-        route_ownership::{DifferentialClass, MIN_REVIEW_CANARY_BASIS_POINTS},
+        route_ownership::{DifferentialClass, MIN_REVIEW_CANARY_BASIS_POINTS, OwnershipBlocker},
     };
     use lmm_contracts::relay::protocols;
 
@@ -299,7 +299,8 @@ mod tests {
     }
 
     #[test]
-    fn current_sixteen_route_registry_closes_every_cross_protocol_pair() {
+    fn current_sixteen_route_registry_keeps_cross_protocol_closed_without_trusted_evidence(
+    ) {
         let registry = validated_current_registry().expect("current registry validates");
         let config = enabled_config();
         for source in protocols() {
@@ -322,14 +323,10 @@ mod tests {
                 );
                 assert!(decision.is_closed(), "{source:?} -> {target:?}");
                 assert!(
-                    decision
-                        .blockers()
-                        .contains(&RouteGateBlocker::DirectionUnsupported)
-                );
-                assert!(
-                    decision
-                        .blockers()
-                        .contains(&RouteGateBlocker::RouteQualityUnsupported)
+                    decision.blockers().iter().any(|blocker| matches!(
+                        blocker,
+                        RouteGateBlocker::Ownership(OwnershipBlocker::UntrustedEvidence)
+                    ))
                 );
             }
         }

--- a/apps/api-rust/src/protocol_runtime_registry.rs
+++ b/apps/api-rust/src/protocol_runtime_registry.rs
@@ -2,17 +2,20 @@
 //!
 //! The contracts crate describes route claims, but it cannot know which HTTP
 //! handlers are actually mounted. This module is the application-owned
-//! inventory for the four native same-protocol passthrough paths and is
-//! checked against the contracts registry before the listener starts.
+//! inventory for native passthrough routes and cortexfs-backed cross-protocol
+//! conversions, and is checked against the contracts registry before the
+//! listener starts.
 
 use std::collections::BTreeSet;
 
 use lmm_contracts::relay::{
     Direction, Fidelity, ModelConstraint, Protocol, Registry, RegistryValidationError,
-    RouteRegistration, RuntimeCatalog, RuntimeRoute, SupportMatrix, ValidatedRegistry,
+    RouteRegistration, RuntimeCatalog, RuntimeRoute, SupportMatrix, ValidatedRegistry, protocols,
 };
 
-const RUNTIME_CATALOG_VERSION: &str = "api-rust-native-relay-v1";
+use crate::cortexfs_protocol_bridge::{converter_id, runtime_adaptor_id, stream_finalizer_id};
+
+const RUNTIME_CATALOG_VERSION: &str = "api-rust-cortexfs-relay-v2";
 
 /// Converter ID registered by the OpenAI Chat native passthrough handler.
 pub const OPENAI_CHAT_RAW_CONVERTER: &str = "raw-openai-chat-v1";
@@ -46,34 +49,67 @@ const RAW_RUNTIME_ROWS: [(Protocol, &str, &str); 4] = [
     ),
 ];
 
-/// Builds the catalog from the native passthrough handlers actually mounted
-/// by the current Rust listener.
+fn native_runtime_route(source: Protocol, converter: &str, adaptor: &str) -> RuntimeRoute {
+    let mut route = RuntimeRoute::new(source, source);
+    route.request_converter_id = Some(converter.to_owned());
+    route.response_converter_id = Some(converter.to_owned());
+    route.stream_converter_id = Some(converter.to_owned());
+    route.stream_finalizer_id = Some(format!("{converter}-finalizer"));
+    route.runtime_adaptors.insert(adaptor.to_owned());
+    route
+}
+
+fn cortexfs_runtime_route(source: Protocol, target: Protocol) -> RuntimeRoute {
+    let mut route = RuntimeRoute::new(source, target);
+    route.request_converter_id = Some(converter_id(source, target, Direction::Request));
+    route.response_converter_id = Some(converter_id(source, target, Direction::Response));
+    route.stream_converter_id = Some(converter_id(source, target, Direction::Stream));
+    route.stream_finalizer_id = Some(stream_finalizer_id(source, target));
+    route
+        .runtime_adaptors
+        .insert(runtime_adaptor_id(source, target));
+    route
+}
+
+/// Builds the catalog from the native passthrough handlers and cortexfs bridge.
 #[must_use]
 pub fn current_runtime_catalog() -> RuntimeCatalog {
-    let converters = RAW_RUNTIME_ROWS
-        .iter()
-        .map(|(_, converter, _)| (*converter).to_owned())
-        .collect::<BTreeSet<_>>();
-    let finalizers = RAW_RUNTIME_ROWS
-        .iter()
-        .map(|(_, converter, _)| format!("{converter}-finalizer"))
-        .collect::<BTreeSet<_>>();
-    let adaptors = RAW_RUNTIME_ROWS
-        .iter()
-        .map(|(_, _, adaptor)| (*adaptor).to_owned())
-        .collect::<BTreeSet<_>>();
-    let routes = RAW_RUNTIME_ROWS
-        .iter()
-        .map(|(protocol, converter, adaptor)| {
-            let mut route = RuntimeRoute::new(*protocol, *protocol);
-            route.request_converter_id = Some((*converter).to_owned());
-            route.response_converter_id = Some((*converter).to_owned());
-            route.stream_converter_id = Some((*converter).to_owned());
-            route.stream_finalizer_id = Some(format!("{converter}-finalizer"));
-            route.runtime_adaptors.insert((*adaptor).to_owned());
-            route
-        })
-        .collect::<Vec<_>>();
+    let mut converters = BTreeSet::new();
+    let mut finalizers = BTreeSet::new();
+    let mut adaptors = BTreeSet::new();
+    let mut routes = Vec::new();
+
+    for (protocol, converter, adaptor) in RAW_RUNTIME_ROWS {
+        converters.insert((*converter).to_owned());
+        finalizers.insert(format!("{converter}-finalizer"));
+        adaptors.insert((*adaptor).to_owned());
+        routes.push(native_runtime_route(protocol, converter, adaptor));
+    }
+
+    for source in protocols() {
+        for target in protocols() {
+            if source == target {
+                continue;
+            }
+            let route = cortexfs_runtime_route(source, target);
+            for converter in [
+                route.request_converter_id.as_deref(),
+                route.response_converter_id.as_deref(),
+                route.stream_converter_id.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                converters.insert(converter.to_owned());
+            }
+            if let Some(finalizer) = route.stream_finalizer_id.as_ref() {
+                finalizers.insert(finalizer.clone());
+            }
+            adaptors.extend(route.runtime_adaptors.iter().cloned());
+            routes.push(route);
+        }
+    }
+
     RuntimeCatalog::new(
         RUNTIME_CATALOG_VERSION,
         converters,
@@ -362,41 +398,37 @@ mod tests {
     }
 
     #[test]
-    fn current_catalog_has_only_four_native_raw_runtime_routes() {
+    fn current_catalog_has_four_native_and_twelve_cortexfs_routes() {
         let catalog = current_runtime_catalog();
-        assert_eq!(catalog.routes.len(), 4);
-        assert!(catalog.routes.iter().all(|route| {
-            route.source == route.target
-                && route.request_converter_id.is_some()
-                && route.response_converter_id.is_some()
-                && route.stream_converter_id.is_some()
-                && route.stream_finalizer_id.is_some()
-        }));
+        assert_eq!(catalog.routes.len(), 16);
+        assert_eq!(
+            catalog
+                .routes
+                .iter()
+                .filter(|route| route.source == route.target)
+                .count(),
+            4
+        );
+        assert_eq!(
+            catalog
+                .routes
+                .iter()
+                .filter(|route| route.source != route.target)
+                .count(),
+            12
+        );
     }
 
     #[test]
-    fn openai_chat_to_responses_is_unsupported_without_a_runtime_adaptor() {
+    fn openai_chat_to_responses_is_supported_with_cortexfs_converters() {
         let registry = validated_current_registry().expect("runtime catalog validates");
         let route = registry
             .route(Protocol::OpenAi, Protocol::OpenAiResponses)
             .expect("complete matrix route");
-        assert!(!route.request_supported);
-        assert!(!route.response_supported);
-        assert!(!route.stream_supported);
-    }
-
-    #[test]
-    fn responses_to_claude_and_gemini_to_claude_are_unsupported() {
-        let registry = validated_current_registry().expect("runtime catalog validates");
-        for (source, target) in [
-            (Protocol::OpenAiResponses, Protocol::Claude),
-            (Protocol::Gemini, Protocol::Claude),
-        ] {
-            let route = registry
-                .route(source, target)
-                .expect("complete matrix route");
-            assert!(!route.supports_any_direction());
-        }
+        assert!(route.request_supported);
+        assert!(route.response_supported);
+        assert!(route.stream_supported);
+        assert_eq!(route.quality, Fidelity::Normalized);
     }
 
     #[test]
@@ -416,44 +448,33 @@ mod tests {
     }
 
     #[test]
-    fn unsupported_cross_protocol_capability_fails_before_converter_selection() {
-        let result = current_route_capability(
+    fn cross_protocol_capability_is_executable_when_registry_and_runtime_agree() {
+        let capability = current_route_capability(
             Protocol::OpenAi,
             Protocol::Claude,
             "claude",
             Direction::Request,
-        );
-        assert!(matches!(
-            result,
-            Err(RuntimeCapabilityError::UnsupportedDirection {
-                source: Protocol::OpenAi,
-                target: Protocol::Claude,
-                direction: Direction::Request,
-            })
-        ));
-        let projection = current_route_projection(Protocol::OpenAi, Protocol::Claude, "claude")
-            .expect("unsupported route remains visible in matrix");
-        assert_eq!(projection.quality, Fidelity::Unsupported);
-        assert!(!projection.is_executable(Direction::Request));
+        )
+        .expect("cross route is executable");
+        assert_eq!(capability.quality, Fidelity::Normalized);
+        assert!(!capability.raw_passthrough);
+        assert!(capability.is_executable(Direction::Request));
     }
 
     #[test]
-    fn explicit_registry_validation_uses_the_same_runtime_direction_gate() {
+    fn explicit_registry_validation_rejects_raw_converter_on_cross_route() {
         let registry = Registry::current();
         let mut catalog = current_runtime_catalog();
         let route = catalog
             .routes
             .iter_mut()
-            .find(|route| route.source == Protocol::OpenAi && route.target == Protocol::OpenAi)
-            .expect("native runtime route");
-        route.stream_converter_id = Some(OPENAI_RESPONSES_RAW_CONVERTER.to_owned());
+            .find(|route| route.source == Protocol::OpenAi && route.target == Protocol::Claude)
+            .expect("cross runtime route");
+        route.request_converter_id = Some(OPENAI_RESPONSES_RAW_CONVERTER.to_owned());
         let result = validate_explicit_registry_against_catalog(&registry, &catalog);
         assert!(matches!(
             result,
-            Err(RegistryValidationError::RuntimeDirectionMismatch {
-                direction: Direction::Stream,
-                ..
-            })
+            Err(RegistryValidationError::RuntimeDirectionMismatch { .. })
         ));
     }
 }

--- a/apps/api-rust/src/protocol_stream_pipeline.rs
+++ b/apps/api-rust/src/protocol_stream_pipeline.rs
@@ -5,9 +5,9 @@
 //! or a provider decoder.  Same-protocol traffic is an opaque raw passthrough
 //! and borrows the parser's bytes.  Cross-protocol traffic is admitted only
 //! after the route gate and an explicitly supplied source-to-canonical-
-//! to-target adaptor are both present.  The default adaptor registry is empty,
-//! so the current validated registry remains closed for every cross-protocol
-//! stream.
+//! to-target adaptor are both present.  The default adaptor registry is backed
+//! by [`CortexFsStreamAdaptorRegistry`], so cross-protocol streams can compile
+//! once rollout and ownership evidence admit the route.
 
 use std::{collections::BTreeSet, time::Instant};
 
@@ -21,6 +21,7 @@ use crate::{
         ClientAbortGuard, ConversionObserver, ConversionResult, ConverterVersion, FailureReason,
         FeatureClass, MetricLabels, QueueDepthGuard, StreamTiming,
     },
+    cortexfs_protocol_bridge::CortexFsStreamAdaptorRegistry,
     migration_routes::sse::{
         DEFAULT_MAX_FRAME_BYTES, LOSS_UNKNOWN_EVENT, SseFrame, UnknownEventClass,
         UnknownEventDecision, unknown_event_decision,
@@ -1260,12 +1261,12 @@ fn closed_session(
     }
 }
 
-/// Compiles a session with the default closed adaptor registry and route gate.
+/// Compiles a session with the cortexfs-backed adaptor registry and route gate.
 pub fn compile_stream_session(
     spec: StreamSessionSpec<'_>,
 ) -> Result<StreamSession, StreamSetupFailure> {
     let compiler = ValidatedRegistryPlanCompiler;
-    let adaptors = EmptyStreamAdaptorRegistry;
+    let adaptors = CortexFsStreamAdaptorRegistry;
     let admission = ValidatedStreamRouteAdmission;
     compile_stream_session_with_runtime(spec, &compiler, &adaptors, &admission)
 }

--- a/apps/api-rust/src/route_ownership.rs
+++ b/apps/api-rust/src/route_ownership.rs
@@ -497,24 +497,23 @@ mod tests {
     }
 
     #[test]
-    fn registry_gate_keeps_unsupported_route_closed_after_complete_differential_proof() {
+    fn registry_gate_keeps_cross_protocol_closed_without_trusted_evidence() {
         let mut evidence = complete();
         evidence.set_shadow_identical(true);
         let registry = crate::protocol_runtime_registry::validated_current_registry()
             .expect("native registry validates");
-        let unsupported_scope = RouteOwnershipScope {
+        let cross_scope = RouteOwnershipScope {
             source: Protocol::OpenAi,
             target: Protocol::Claude,
             stream: true,
         };
-        evidence.scope = unsupported_scope;
+        evidence.scope = cross_scope;
         let decision =
             OwnershipGate::default().evaluate_with_registry(&evidence, &registry, "claude");
         assert!(matches!(
             decision,
             OwnershipDecision::ClosedByDefault { blockers, .. }
-                if blockers.contains(&OwnershipBlocker::RouteQualityUnsupported)
-                    && blockers.contains(&OwnershipBlocker::RouteDirectionUnsupported)
+                if blockers.contains(&OwnershipBlocker::UntrustedEvidence)
         ));
     }
 

--- a/apps/api-rust/tests/cortexfs_protocol_bridge.rs
+++ b/apps/api-rust/tests/cortexfs_protocol_bridge.rs
@@ -1,0 +1,62 @@
+use lmm_api_rs::{
+    cortexfs_protocol_bridge::{
+        CortexFsStreamAdaptorRegistry, transcode_request_protocol, transcode_response_protocol,
+    },
+    protocol_stream_pipeline::StreamAdaptorRegistry,
+};
+use lmm_contracts::relay::Protocol;
+
+const CHAT: &[u8] = br#"{"model":"chat-model","messages":[{"role":"user","content":"hi"}]}"#;
+const CHAT_RESPONSE: &[u8] = br#"{"id":"chat-run","model":"chat-model","choices":[{"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2}}"#;
+
+#[test]
+fn cortexfs_bridge_transcodes_openai_to_claude_request_and_response() {
+    let request =
+        transcode_request_protocol(Protocol::OpenAi, Protocol::Claude, CHAT).expect("request");
+    assert!(serde_json::from_slice::<serde_json::Value>(&request.bytes).is_ok());
+
+    let response = transcode_response_protocol(
+        Protocol::Claude,
+        Protocol::OpenAi,
+        br#"{"id":"anthropic-run","model":"claude-model","role":"assistant","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":2}}"#,
+    )
+    .expect("response");
+    assert!(serde_json::from_slice::<serde_json::Value>(&response.bytes).is_ok());
+}
+
+#[test]
+fn cortexfs_stream_registry_exposes_all_twelve_cross_protocol_pairs() {
+    let registry = CortexFsStreamAdaptorRegistry;
+    let mut count = 0;
+    for source in [
+        Protocol::OpenAi,
+        Protocol::OpenAiResponses,
+        Protocol::Claude,
+        Protocol::Gemini,
+    ] {
+        for target in [
+            Protocol::OpenAi,
+            Protocol::OpenAiResponses,
+            Protocol::Claude,
+            Protocol::Gemini,
+        ] {
+            if source == target {
+                continue;
+            }
+            assert!(registry.for_route(source, target).is_some());
+            count += 1;
+        }
+    }
+    assert_eq!(count, 12);
+}
+
+#[test]
+fn cortexfs_bridge_roundtrips_openai_chat_identity() {
+    let converted =
+        transcode_request_protocol(Protocol::OpenAi, Protocol::OpenAi, CHAT).expect("identity");
+    assert_eq!(converted.bytes, CHAT);
+
+    let response = transcode_response_protocol(Protocol::OpenAi, Protocol::OpenAi, CHAT_RESPONSE)
+        .expect("identity response");
+    assert_eq!(response.bytes, CHAT_RESPONSE);
+}

--- a/apps/api-rust/tests/migration_account_action.rs
+++ b/apps/api-rust/tests/migration_account_action.rs
@@ -1,0 +1,51 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::account_action::{AccountActionState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn account_action_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey.clone(),
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "account-action-route-test-secret-012345678901234567890123456789",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(AccountActionState::new(
+        pg,
+        valkey,
+        auth,
+        SecretString::from("account-action-route-test-secret-012345678901234567890123456789"),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/account-action-requests")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert!(matches!(
+        response.status(),
+        axum::http::StatusCode::UNAUTHORIZED | axum::http::StatusCode::FORBIDDEN | axum::http::StatusCode::NOT_FOUND
+    ));
+}

--- a/apps/api-rust/tests/migration_assistant_extended.rs
+++ b/apps/api-rust/tests/migration_assistant_extended.rs
@@ -1,0 +1,61 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::assistant::{AssistantRateLimitConfig, AssistantReadState},
+    migration_routes::assistant_extended::extended_router,
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn assistant_extended_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey.clone(),
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "assistant-extended-route-test-secret-012345678901234567890123456789",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let state = AssistantReadState::new(
+        pg,
+        valkey,
+        auth,
+        SecretString::from(
+            "assistant-extended-route-test-secret-012345678901234567890123456789",
+        ),
+        AssistantRateLimitConfig {
+            enabled: false,
+            max_requests: 1,
+            window: std::time::Duration::from_secs(1),
+            dependency_timeout: std::time::Duration::from_secs(1),
+        },
+    );
+    let app = extended_router().with_state(state);
+
+    // `extended_router` is the production constructor under test.
+    let _ = extended_router;
+
+    let response = app
+        .oneshot(
+            Request::get("/api/assistant/conversations")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+}

--- a/apps/api-rust/tests/migration_discount_code.rs
+++ b/apps/api-rust/tests/migration_discount_code.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::discount_code::{DiscountCodeState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn discount_code_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey,
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "discount-code-route-test-secret-012345678901234567890123456789",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(DiscountCodeState::new(pg, auth));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/discount-code/search")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+}

--- a/apps/api-rust/tests/migration_dynamic_pricing.rs
+++ b/apps/api-rust/tests/migration_dynamic_pricing.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::dynamic_pricing::{DynamicPricingState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn dynamic_pricing_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey.clone(),
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "dynamic-pricing-route-test-secret-012345678901234567890123456789",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(DynamicPricingState::new(pg, valkey, auth));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/dynamic_pricing/status")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+}

--- a/apps/api-rust/tests/migration_finance.rs
+++ b/apps/api-rust/tests/migration_finance.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::finance::{FinanceState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn finance_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey,
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "finance-route-test-secret-012345678901234567890123456789012345678901234",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(FinanceState::new(pg, auth));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/finance/overview")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+}

--- a/apps/api-rust/tests/migration_hero_sms.rs
+++ b/apps/api-rust/tests/migration_hero_sms.rs
@@ -1,0 +1,47 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::hero_sms::{DisabledHeroSmsGateway, HeroSmsState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn hero_sms_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey,
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "hero-sms-route-test-secret-012345678901234567890123456789012345678901234",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(HeroSmsState::new(
+        pg,
+        auth,
+        Arc::new(DisabledHeroSmsGateway),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/hero-sms/email/products")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+}

--- a/apps/api-rust/tests/migration_identity_federation.rs
+++ b/apps/api-rust/tests/migration_identity_federation.rs
@@ -11,8 +11,8 @@ use lmm_api_rs::migration_routes::identity_federation::{
     FederatedLogin, FederatedUser, FederationError, FederationIdentity,
     FederationMutationPublisher, FederationPrincipal, FederationProviderError, FederationProviders,
     FederationState, OAuthFlowContext, bindings_router, oauth_email_bind_router,
-    oauth_external_provider_router, oauth_state_router, provider_router, router,
-    verify_telegram_authorization,
+    oauth_external_provider_router, oauth_login_start_router, oauth_state_router, provider_router,
+    router, verify_telegram_authorization,
 };
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
@@ -26,6 +26,11 @@ use std::{
 use tower::ServiceExt;
 
 struct NoIdentity;
+
+#[test]
+fn oauth_login_start_router_constructor_is_exposed_for_listener_composition() {
+    let _constructor: fn(FederationState) -> Router = oauth_login_start_router;
+}
 
 #[test]
 fn oauth_state_router_constructor_is_exposed_for_listener_composition() {

--- a/apps/api-rust/tests/migration_mcp.rs
+++ b/apps/api-rust/tests/migration_mcp.rs
@@ -1,0 +1,28 @@
+use axum::{body::Body, http::Request};
+use lmm_api_rs::migration_routes::mcp::{McpHttpState, mcp_router};
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn mcp_router_requires_bearer_token() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let app = mcp_router(McpHttpState::new(
+        pg,
+        valkey,
+        std::time::Duration::from_secs(1),
+    ));
+
+    let response = app
+        .oneshot(
+            Request::post("/mcp")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+}

--- a/apps/api-rust/tests/migration_public_relay.rs
+++ b/apps/api-rust/tests/migration_public_relay.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::public_relay::{PublicRelayState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn public_relay_write_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey,
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "public-relay-route-test-secret-012345678901234567890123456789",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(PublicRelayState::new(pg, auth));
+
+    let response = app
+        .oneshot(
+            Request::post("/api/public-relays")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+}

--- a/apps/api-rust/tests/migration_security_admin.rs
+++ b/apps/api-rust/tests/migration_security_admin.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::security_admin::{SecurityAdminState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn security_admin_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey,
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "security-admin-route-test-secret-012345678901234567890123456789012345678",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(SecurityAdminState::new(pg, auth));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/security/admin/events")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+}

--- a/apps/api-rust/tests/migration_unified_todo.rs
+++ b/apps/api-rust/tests/migration_unified_todo.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::unified_todo::{UnifiedTodoState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn unified_todo_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey,
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "unified-todo-route-test-secret-012345678901234567890123456789012345678901",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(UnifiedTodoState::new(pg, auth));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/todos")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::UNAUTHORIZED);
+}

--- a/apps/api-rust/tests/migration_user_assistant_admin.rs
+++ b/apps/api-rust/tests/migration_user_assistant_admin.rs
@@ -1,0 +1,43 @@
+use std::sync::Arc;
+
+use axum::{body::Body, http::Request};
+use lmm_api_rs::{
+    auth::{AuthConfig, PgValkeyDashboardAuth},
+    migration_routes::user_assistant_admin::{UserAssistantAdminState, router},
+};
+use secrecy::SecretString;
+use sqlx::postgres::PgPoolOptions;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn user_assistant_admin_routes_require_dashboard_auth() {
+    let pg = PgPoolOptions::new()
+        .connect_lazy("postgres://route-test:route-test@127.0.0.1:1/route_test")
+        .expect("lazy PostgreSQL pool");
+    let valkey = redis::Client::open("redis://127.0.0.1:1").expect("lazy Valkey client");
+    let auth = Arc::new(
+        PgValkeyDashboardAuth::new(
+            pg.clone(),
+            valkey,
+            AuthConfig {
+                session_secret: SecretString::from(
+                    "user-assistant-admin-route-test-secret-012345678901234567890123456789012",
+                ),
+                ..AuthConfig::default()
+            },
+        )
+        .expect("route-test auth adapter"),
+    );
+    let app = router(UserAssistantAdminState::new(pg, auth));
+
+    let response = app
+        .oneshot(
+            Request::get("/api/assistant/admin/profiles")
+                .body(Body::empty())
+                .expect("route request"),
+        )
+        .await
+        .expect("route response");
+
+    assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 变更说明 / Summary

本 PR 将 Rust 后端（`apps/api-rust`）的协议转换层升级为生产级 `cortexfs-protocol` 实现，并与 Go 后端保持 API 与路由覆盖一致。

主要改动：

- **cortexfs-protocol 集成**：新增 `cortexfs_protocol_bridge` 模块，作为唯一的跨协议转换边界，覆盖 16×16 请求/响应矩阵及 12 条跨协议流式路由
- **Registry 升级**：`relay-capabilities-v2-cortexfs` 声明 4 条同协议原生 passthrough + 12 条 cortexfs 跨协议路由，运行时目录版本 `api-rust-cortexfs-relay-v2`
- **流式管道**：默认 adaptor registry 切换为 `CortexFsStreamAdaptorRegistry`（替代空的 `EmptyStreamAdaptorRegistry`）
- **API 对齐修复**：`discount_code` 正则与 Go 对齐；MCP 路由支持全 HTTP 方法；`assistant_extended` 构造函数重命名为 `extended_router`
- **集成测试**：新增 11 个 migration 模块测试及 `cortexfs_protocol_bridge` 集成测试
- **工具链**：固定 Rust 1.91.0（`cortexfs-protocol` 要求）

生产门控策略保持不变：跨协议流量需 `ConversionEngineV2` rollout 启用 + trusted ownership evidence 方可实际开放。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change

## 变更类型 / Type of change

- [x] 新功能 / Feature
- [x] Bug 修复 / Bug fix

## 验证 / Verification

```text
command: cd apps/api-rust && cargo test
result: 全部通过（642 lib tests + 全部 integration tests）

command: cd apps/api-rust && bash tests/scripts/check-draft-route-coverage.sh
result: candidate-method-paths=583 frozen-matches=352 missing=0 placeholders=1

command: cd apps/api-rust && cargo test --test cortexfs_protocol_bridge
result: 3 passed（OpenAI→Claude 请求/响应转码、12 对跨协议流 registry、同协议 identity roundtrip）
```

## 提交检查 / Checklist

- [x] 此 PR 只包含与当前目标相关的改动
- [x] 已补充相关测试并记录验证结果
- [x] 跨协议流量仍受 rollout + ownership 门控保护（fail-closed 默认）
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8db98158-ab6e-4592-a6e3-ed14d20da41a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8db98158-ab6e-4592-a6e3-ed14d20da41a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

## Sourcery 摘要

通过在现有生产安全门控机制下添加基于 cortexfs 的跨协议转换和流式传输支持，使 Rust 后端的协议中继能力与 Go 后端保持一致。

新功能：
- 集成 cortexfs-protocol，作为 Rust 后端跨提供商请求、响应和流式传输转换层，覆盖所有协议对。
- 在四条原生直通路由之外，提供十二条基于 cortexfs 的跨协议路由，并使运行时元数据和保真度声明与 Go 后端保持一致。
- 为跨协议中继流量启用类型化 cortexfs 流适配器，同时保留发布和可信所有权门控机制。

错误修复：
- 使折扣码验证和 MCP 方法覆盖范围与 Go 后端保持一致。
- 更新协议门控行为：仅当缺少可信所有权证据时，才继续关闭受支持的跨协议路由。

增强功能：
- 在专用桥接模块中集中管理协议映射、转换器标识符、流事件规范化和运行时适配器注册。

构建：
- 要求使用 Rust 1.91.0，并添加 cortexfs-protocol 依赖项。

测试：
- 添加协议转换矩阵、流适配器、身份往返以及迁移路由授权覆盖测试。

杂项：
- 重命名 assistant 扩展路由器构造函数，并更新支持 cortexfs 的运行时目录版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the Rust backend’s protocol relay capabilities with the Go backend by adding cortexfs-backed cross-protocol conversion and streaming support under the existing production safety gates.

New Features:
- Integrate cortexfs-protocol as the Rust backend’s cross-provider request, response, and streaming conversion layer across all protocol pairs.
- Expose twelve cortexfs-backed cross-protocol routes alongside the four native passthrough routes, with runtime metadata and fidelity claims aligned to the Go backend.
- Enable typed cortexfs stream adaptors for cross-protocol relay traffic while retaining rollout and trusted ownership gating.

Bug Fixes:
- Align discount-code validation and MCP method coverage with the Go backend.
- Update protocol gate behavior so supported cross-protocol routes remain closed only when trusted ownership evidence is absent.

Enhancements:
- Centralize protocol mappings, converter identifiers, stream event normalization, and runtime adaptor registration in a dedicated bridge module.

Build:
- Require Rust 1.91.0 and add the cortexfs-protocol dependency.

Tests:
- Add protocol conversion matrix, stream adaptor, identity round-trip, and migration route authorization coverage.

Chores:
- Rename the assistant extended router constructor and update the runtime catalog version for cortexfs support.

</details>