### PR TITLE
fix: bound HEIF metadata parser depth

### DIFF
--- a/apps/api-go/service/file_service.go
+++ b/apps/api-go/service/file_service.go
@@ -556,9 +556,20 @@ func parseHEIFDimensions(data []byte) (int, int, bool) {
 	return 0, 0, false
 }
 
+// Keep metadata parsing bounded; valid HEIF metadata has a shallow container path.
+const maxHEIFBoxDepth = 64
+
 // findISPE recursively searches for the ispe box within container boxes.
 // Path: meta -> iprp -> ipco -> ispe
 func findISPE(data []byte) (int, int, bool) {
+	return findISPEAtDepth(data, 0)
+}
+
+func findISPEAtDepth(data []byte, depth int) (int, int, bool) {
+	if depth > maxHEIFBoxDepth {
+		return 0, 0, false
+	}
+
 	offset := 0
 	size := len(data)
 	for offset+8 <= size {
@@ -570,7 +581,7 @@ func findISPE(data []byte) (int, int, bool) {
 		content := data[offset+8 : offset+boxSize]
 		switch boxType {
 		case "iprp", "ipco":
-			if w, h, ok := findISPE(content); ok {
+			if w, h, ok := findISPEAtDepth(content, depth+1); ok {
 				return w, h, true
 			}
 		case "ispe":

--- a/apps/api-go/service/file_service_test.go
+++ b/apps/api-go/service/file_service_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestParseHEIFDimensionsRejectsExcessiveNesting(t *testing.T) {
+	shallow := nestedHEIF(2)
+	width, height, ok := parseHEIFDimensions(shallow)
+	if !ok || width != 1 || height != 1 {
+		t.Fatalf("expected shallow HEIF to parse as 1x1, got %dx%d, ok=%v", width, height, ok)
+	}
+
+	width, height, ok = parseHEIFDimensions(nestedHEIF(maxHEIFBoxDepth))
+	if !ok || width != 1 || height != 1 {
+		t.Fatalf("expected maximum-depth HEIF to parse as 1x1, got %dx%d, ok=%v", width, height, ok)
+	}
+
+	if _, _, ok := parseHEIFDimensions(nestedHEIF(maxHEIFBoxDepth + 1)); ok {
+		t.Fatal("expected excessively nested HEIF metadata to be rejected")
+	}
+}
+
+func nestedHEIF(depth int) []byte {
+	box := make([]byte, 20)
+	binary.BigEndian.PutUint32(box[0:4], 20)
+	copy(box[4:8], "ispe")
+	binary.BigEndian.PutUint32(box[12:16], 1)
+	binary.BigEndian.PutUint32(box[16:20], 1)
+
+	for i := 0; i < depth; i++ {
+		container := make([]byte, 8+len(box))
+		binary.BigEndian.PutUint32(container[0:4], uint32(len(container)))
+		copy(container[4:8], "ipco")
+		copy(container[8:], box)
+		box = container
+	}
+
+	meta := make([]byte, 12+len(box))
+	binary.BigEndian.PutUint32(meta[0:4], uint32(len(meta)))
+	copy(meta[4:8], "meta")
+	copy(meta[12:], box)
+
+	ftyp := make([]byte, 16)
+	binary.BigEndian.PutUint32(ftyp[0:4], uint32(len(ftyp)))
+	copy(ftyp[4:8], "ftyp")
+	copy(ftyp[8:12], "heic")
+
+	return append(ftyp, meta...)
+}


### PR DESCRIPTION
## Summary

`findISPE` recursively walked nested `iprp`/`ipco` boxes without a depth limit. A user-controlled HEIF/HEIC image supplied through the image URL/base64 paths could exhaust the Go goroutine stack and terminate the API process.

## Reproduction

Using a synthetic HEIF-like payload containing 5,000,000 nested `ipco` boxes (about 40 MB):

- Before this change: Go 1.25.1 on arm64 terminated with `fatal error: stack overflow` and `runtime: goroutine stack exceeds 1000000000-byte limit`.
- After this change: the same shape is rejected as an invalid/unsupported image configuration without process termination.

## Fix

Add a bounded HEIF metadata container depth (`maxHEIFBoxDepth = 64`) and reject deeper trees. Existing shallow metadata paths continue to parse, and the regression test covers shallow, maximum-depth, and excessive-depth inputs.

## Verification

```text
GOTOOLCHAIN=local /tmp/go125/bin/go test ./service -count=1
ok   github.com/LIghtJUNction/api.lmm.best/service
```

The patch is limited to the HEIF parser and its regression test.

## Sourcery 摘要

限制 HEIF 元数据解析深度，以安全地拒绝嵌套层级过深的图像元数据。

错误修复：
- 防止嵌套过深的 HEIF/HEIC 元数据耗尽 Go 堆栈并终止 API 进程。

测试：
- 添加针对浅层、最大深度和嵌套过深的 HEIF 元数据的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bound HEIF metadata parsing depth to safely reject excessively nested image metadata.

Bug Fixes:
- Prevent deeply nested HEIF/HEIC metadata from exhausting the Go stack and terminating the API process.

Tests:
- Add regression coverage for shallow, maximum-depth, and excessively nested HEIF metadata.

</details>