### PR TITLE
Guard assistant conversation cursor SQL bindings (add testable helper and tests)

### DIFF
--- a/apps/api-rust/src/migration_routes/assistant_extended.rs
+++ b/apps/api-rust/src/migration_routes/assistant_extended.rs
@@ -1223,21 +1223,7 @@ async fn list_conversations_page(
     } else {
         None
     };
-    let archive_filter = if archived {
-        "archived_at <> 0"
-    } else {
-        "archived_at = 0"
-    };
-    let mut sql = format!(
-        "SELECT id, title, last_message_preview, created_at, updated_at, archived_at, restricted_at \
-         FROM assistant_conversations WHERE user_id = $1 AND {archive_filter} \
-         AND EXISTS (SELECT 1 FROM assistant_history_messages m WHERE m.conversation_id = assistant_conversations.id)"
-    );
-    if cursor.is_some() {
-        sql.push_str(" AND ((updated_at < $2) OR (updated_at = $2 AND id < $3))");
-    }
-    sql.push_str(" ORDER BY updated_at DESC, id DESC LIMIT ");
-    sql.push_str(&(limit + 1).to_string());
+    let sql = conversation_list_sql(limit, archived, cursor.is_some());
     let mut query = sqlx::query(&sql).bind(owner_user_id);
     if let Some(cursor) = cursor.as_ref() {
         query = query.bind(cursor.updated_at).bind(cursor.id);
@@ -1291,6 +1277,25 @@ async fn list_conversations_page(
         conversations,
         next_cursor,
     })
+}
+
+fn conversation_list_sql(limit: i64, archived: bool, has_cursor: bool) -> String {
+    let archive_filter = if archived {
+        "archived_at <> 0"
+    } else {
+        "archived_at = 0"
+    };
+    let mut sql = format!(
+        "SELECT id, title, last_message_preview, created_at, updated_at, archived_at, restricted_at \
+         FROM assistant_conversations WHERE user_id = $1 AND {archive_filter} \
+         AND EXISTS (SELECT 1 FROM assistant_history_messages m WHERE m.conversation_id = assistant_conversations.id)"
+    );
+    if has_cursor {
+        sql.push_str(" AND ((updated_at < $2) OR (updated_at = $2 AND id < $3))");
+    }
+    sql.push_str(" ORDER BY updated_at DESC, id DESC LIMIT ");
+    sql.push_str(&(limit + 1).to_string());
+    sql
 }
 
 async fn load_conversation_history(
@@ -1913,4 +1918,30 @@ fn unix_seconds() -> i64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or(Duration::ZERO)
         .as_secs() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::conversation_list_sql;
+
+    #[test]
+    fn conversation_list_sql_uses_contiguous_cursor_bindings() {
+        let sql = conversation_list_sql(25, false, true);
+
+        assert!(sql.contains("user_id = $1"));
+        assert!(sql.contains("updated_at < $2"));
+        assert!(sql.contains("updated_at = $2 AND id < $3"));
+        assert!(!sql.contains("$4"));
+        assert_eq!(sql.matches("$2").count(), 2);
+        assert!(sql.ends_with("LIMIT 26"));
+    }
+
+    #[test]
+    fn conversation_list_sql_omits_cursor_bindings_without_cursor() {
+        let sql = conversation_list_sql(10, true, false);
+
+        assert!(sql.contains("archived_at <> 0"));
+        assert!(!sql.contains("$2"));
+        assert!(sql.ends_with("LIMIT 11"));
+    }
 }


### PR DESCRIPTION
### Motivation

- Ensure PostgreSQL placeholder bindings for assistant conversation list pagination are contiguous and cannot regress into non-sequential placeholders that break `sqlx` binding order. 
- Make the SQL construction testable so cursor vs no-cursor and archived vs non-archived code paths are covered by unit tests.

### Description

- Extracted inline SQL construction from `list_conversations_page` into a helper `conversation_list_sql(limit, archived, has_cursor)` that conditionally appends the cursor clause with contiguous placeholders. 
- Replaced the previous inline `sql` build with a call to `conversation_list_sql` and kept runtime binding logic to `bind(owner_user_id)` and, when present, `bind(cursor.updated_at).bind(cursor.id)`. 
- Added unit tests under `#[cfg(test)]` that assert contiguous placeholder usage, that no extra `$4` appears, correct `LIMIT` arithmetic, and that cursor-less archived queries omit `$2`.

### Testing

- Ran `cargo test --manifest-path apps/api-rust/Cargo.toml conversation_list_sql --lib` and all added tests passed (`2 passed`).
- Ran `git diff --check` and confirmed no whitespace or diff-check errors introduced by this change. 
- Ran `cargo fmt --manifest-path apps/api-rust/Cargo.toml -- --check` which reported pre-existing formatting drift in the workspace unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8bb95a31dc8320bd102fa92ea47655)

## Sourcery 总结

确保助手对话分页在游标和归档查询路径中生成有效的 SQL 绑定。

错误修复：
- 防止列出助手对话时出现无效的 PostgreSQL 游标占位符绑定。

增强功能：
- 将对话列表 SQL 生成提取为可复用的辅助函数，并通过单元测试覆盖游标、归档、占位符和限制行为。

测试：
- 添加连续游标绑定和无游标归档查询的单元测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure assistant conversation pagination generates valid SQL bindings across cursor and archive query paths.

Bug Fixes:
- Prevent invalid PostgreSQL cursor placeholder bindings when listing assistant conversations.

Enhancements:
- Extract conversation list SQL generation into a reusable helper and cover cursor, archive, placeholder, and limit behavior with unit tests.

Tests:
- Add unit tests for contiguous cursor bindings and cursor-free archived queries.

</details>