### PR TITLE
fix(release): recover unified CLI T0 publication

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -87,6 +87,13 @@ jobs:
           go-version-file: apps/api-go/go.mod
           cache: false
 
+      - name: Install production contract tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes libarchive-tools
+          test "$(command -v bsdtar)" = /usr/bin/bsdtar
+          bsdtar --version | head -1
+
       - name: Check and test default Go module
         working-directory: apps/api-go
         run: |

--- a/apps/api-go/internal/appcli/deploy_production_cli_transition_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_cli_transition_test.go
@@ -63,12 +63,12 @@ func TestRemoveLegacyDeployPackageRequiresIntegratedT0(t *testing.T) {
 	if err := os.WriteFile(legacy, []byte("legacy"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	runner := &productionCLIRemovalRunner{legacyPath: legacy, goVersion: "0.1.58-1", legacy: true}
+	runner := &productionCLIRemovalRunner{legacyPath: legacy, goVersion: "0.1.59-1", legacy: true}
 	runtime := &productionRuntime{
 		paths:  productionPaths{LegacyDeployBinary: legacy},
 		runner: runner,
 	}
-	candidate := productionPackageMetadata{Name: productionAURPackageName, Version: "0.1.59-1"}
+	candidate := productionPackageMetadata{Name: productionAURPackageName, Version: "0.1.60-1"}
 	if err := runtime.removeLegacyDeployPackageForT1(context.Background(), candidate); err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +79,7 @@ func TestRemoveLegacyDeployPackageRequiresIntegratedT0(t *testing.T) {
 	if err := os.WriteFile(legacy, []byte("legacy"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	runner = &productionCLIRemovalRunner{legacyPath: legacy, goVersion: "0.1.57-1", legacy: true}
+	runner = &productionCLIRemovalRunner{legacyPath: legacy, goVersion: "0.1.58-1", legacy: true}
 	runtime.runner = runner
 	if err := runtime.removeLegacyDeployPackageForT1(context.Background(), candidate); err == nil || !strings.Contains(err.Error(), "requires a confirmed") {
 		t.Fatalf("pre-T0 removal error=%v", err)
@@ -101,7 +101,7 @@ func TestVerifyTransitionCLIEnforcesT0AndT1CommandSets(t *testing.T) {
 	runtime := &productionRuntime{paths: paths}
 	t1 := productionPackageTransition{
 		CandidatePackageName: productionAURPackageName,
-		CandidateIdentity:    productionAURPackageName + " 0.1.59-1",
+		CandidateIdentity:    productionAURPackageName + " 0.1.60-1",
 	}
 	if err := runtime.verifyTransitionCLI(t1, false); err != nil {
 		t.Fatal(err)
@@ -117,7 +117,7 @@ func TestVerifyTransitionCLIEnforcesT0AndT1CommandSets(t *testing.T) {
 	}
 	t0 := productionPackageTransition{
 		CandidatePackageName: productionAURPackageName,
-		CandidateIdentity:    productionAURPackageName + " 0.1.58-1",
+		CandidateIdentity:    productionAURPackageName + " 0.1.59-1",
 	}
 	if err := runtime.verifyTransitionCLI(t0, false); err == nil || !strings.Contains(err.Error(), "lacks its compatibility") {
 		t.Fatalf("T0 missing-link error=%v", err)

--- a/apps/api-go/internal/appcli/deploy_production_release.go
+++ b/apps/api-go/internal/appcli/deploy_production_release.go
@@ -712,6 +712,8 @@ func signedPackageMember(packageName, relative string) (packageRelative string, 
 	}
 }
 
+// The 0.1.58 tag produced no release artifacts. Version 0.1.59 is the
+// compatibility T0 release; the single-CLI T1 contract starts at 0.1.60.
 func isT1SingleCLIPackage(packageName, packageVersion string) (bool, error) {
 	if packageName == productionSourcePackageName {
 		return true, nil
@@ -719,7 +721,7 @@ func isT1SingleCLIPackage(packageName, packageVersion string) (bool, error) {
 	if packageName != productionAURPackageName {
 		return false, errors.New("single-CLI transition check received an unsupported package")
 	}
-	return numericPackageReleaseAtLeast(packageVersion, [3]int{0, 1, 59})
+	return numericPackageReleaseAtLeast(packageVersion, [3]int{0, 1, 60})
 }
 
 func isIntegratedOperatorPackage(packageName, packageVersion string) (bool, error) {
@@ -729,7 +731,7 @@ func isIntegratedOperatorPackage(packageName, packageVersion string) (bool, erro
 	if packageName != productionAURPackageName {
 		return false, nil
 	}
-	return numericPackageReleaseAtLeast(packageVersion, [3]int{0, 1, 58})
+	return numericPackageReleaseAtLeast(packageVersion, [3]int{0, 1, 59})
 }
 
 func numericPackageReleaseAtLeast(packageVersion string, minimum [3]int) (bool, error) {

--- a/apps/api-go/internal/appcli/deploy_production_release_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_release_test.go
@@ -204,19 +204,19 @@ func testProductionReleasePackage(root, name, version, digest, payload string) p
 }
 
 func testProductionReleasePlan(root string) productionReleasePlan {
-	goCandidate := testProductionReleasePackage(root, productionAURPackageName, "0.1.58-1", strings.Repeat("1", 64), strings.Repeat("2", 64))
+	goCandidate := testProductionReleasePackage(root, productionAURPackageName, "0.1.59-1", strings.Repeat("1", 64), strings.Repeat("2", 64))
 	goRollback := testProductionReleasePackage(root, productionAURPackageName, "0.1.57-1", strings.Repeat("3", 64), strings.Repeat("4", 64))
 	web := testProductionReleasePackage(root, productionWebPackageName, "0.1.41-1", strings.Repeat("5", 64), strings.Repeat("6", 64))
 	return productionReleasePlan{
 		Format:              productionReleasePlanFormat,
-		DeploymentID:        "release-0.1.58-test",
+		DeploymentID:        "release-0.1.59-test",
 		CreatedUTC:          time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC),
 		ControllerWorkspace: root,
 		Repository:          filepath.Join(root, "repo"),
 		TargetAlias:         productionTargetAlias,
 		ExpectedHost:        productionExpectedHost,
 		OperatorUser:        productionOperatorUser,
-		ExpectedVersion:     "0.1.58",
+		ExpectedVersion:     "0.1.59",
 		GoCandidate:         goCandidate,
 		GoRollback:          goRollback,
 		WebCandidate:        web,
@@ -313,9 +313,9 @@ func TestVerifySignedPackageLayoutRejectsUnsignedOperatorMutation(t *testing.T) 
 	workspace := t.TempDir()
 	asset := filepath.Join(workspace, "release.tar.gz")
 	writeTestTarGzip(t, asset, []testTarEntry{
-		{name: "lmm-api-go-0.1.58-linux-amd64/lmm-api", body: "binary", mode: 0o755},
-		{name: "lmm-api-go-0.1.58-linux-amd64/lmm-api-operator.sudoers", body: "safe-sudoers\n", mode: 0o644},
-		{name: "lmm-api-go-0.1.58-linux-amd64/LICENSE", body: "license\n", mode: 0o644},
+		{name: "lmm-api-go-0.1.59-linux-amd64/lmm-api", body: "binary", mode: 0o755},
+		{name: "lmm-api-go-0.1.59-linux-amd64/lmm-api-operator.sudoers", body: "safe-sudoers\n", mode: 0o644},
+		{name: "lmm-api-go-0.1.59-linux-amd64/LICENSE", body: "license\n", mode: 0o644},
 	})
 	assetSHA256, err := sha256File(asset)
 	if err != nil {
@@ -336,20 +336,20 @@ func TestVerifySignedPackageLayoutRejectsUnsignedOperatorMutation(t *testing.T) 
 	packagePath := filepath.Join(workspace, "package.tar.gz")
 	writeTestTarGzip(t, packagePath, packageEntries("safe-sudoers\n", true))
 	runtime := &productionReleaseRuntime{runner: osProductionCommandRunner{}}
-	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.58-1", packagePath, asset, assetSHA256); err != nil {
+	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.59-1", packagePath, asset, assetSHA256); err != nil {
 		t.Fatal(err)
 	}
 	tamperedPackage := filepath.Join(workspace, "tampered.tar.gz")
 	writeTestTarGzip(t, tamperedPackage, packageEntries("unsafe-sudoers\n", true))
-	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.58-1", tamperedPackage, asset, assetSHA256); err == nil || !strings.Contains(err.Error(), "differs from signed release") {
+	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.59-1", tamperedPackage, asset, assetSHA256); err == nil || !strings.Contains(err.Error(), "differs from signed release") {
 		t.Fatalf("tampered package error=%v", err)
 	}
 	t1Package := filepath.Join(workspace, "t1.tar.gz")
 	writeTestTarGzip(t, t1Package, packageEntries("safe-sudoers\n", false))
-	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.59-1", t1Package, asset, assetSHA256); err != nil {
+	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.60-1", t1Package, asset, assetSHA256); err != nil {
 		t.Fatal(err)
 	}
-	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.59-1", packagePath, asset, assetSHA256); err == nil || !strings.Contains(err.Error(), "T1 package still exposes") {
+	if err := runtime.verifySignedPackageLayout(context.Background(), workspace, productionAURPackageName, "0.1.60-1", packagePath, asset, assetSHA256); err == nil || !strings.Contains(err.Error(), "T1 package still exposes") {
 		t.Fatalf("T1 compatibility-link error=%v", err)
 	}
 }

--- a/deploy/production/test-go-package-roundtrip.sh
+++ b/deploy/production/test-go-package-roundtrip.sh
@@ -236,11 +236,11 @@ package() {
 }
 EOF
 (cd "$legacy_deploy_work" && PKGDEST="$transition_packages" makepkg --force --nodeps --noconfirm >/dev/null)
-build_transition_go_package t0 0.1.58
-build_transition_go_package t1 0.1.59
+build_transition_go_package t0 0.1.59
+build_transition_go_package t1 0.1.60
 
-t0_package=$(find "$transition_packages" -maxdepth 1 -type f -name 'lmm-api-go-bin-0.1.58-1-*.pkg.tar.*' -print -quit)
-t1_package=$(find "$transition_packages" -maxdepth 1 -type f -name 'lmm-api-go-bin-0.1.59-1-*.pkg.tar.*' -print -quit)
+t0_package=$(find "$transition_packages" -maxdepth 1 -type f -name 'lmm-api-go-bin-0.1.59-1-*.pkg.tar.*' -print -quit)
+t1_package=$(find "$transition_packages" -maxdepth 1 -type f -name 'lmm-api-go-bin-0.1.60-1-*.pkg.tar.*' -print -quit)
 legacy_deploy_package=$(find "$transition_packages" -maxdepth 1 -type f -name 'lmm-api-deploy-bin-*.pkg.tar.*' -print -quit)
 [[ -n $t0_package && -n $t1_package && -n $legacy_deploy_package ]] || {
   printf 'go-package-roundtrip: T0/T1 transition package fixture is incomplete\n' >&2
@@ -256,7 +256,7 @@ transition_install=(pacman "${transition_common[@]}" --noconfirm --noscriptlet -
 transition_query=(pacman "${transition_common[@]}")
 
 fakeroot -- "${transition_install[@]}" -U "$legacy_deploy_package" "$t0_package" >/dev/null
-[[ $("${transition_query[@]}" -Q lmm-api-go-bin 2>/dev/null) == 'lmm-api-go-bin 0.1.58-1' ]]
+[[ $("${transition_query[@]}" -Q lmm-api-go-bin 2>/dev/null) == 'lmm-api-go-bin 0.1.59-1' ]]
 [[ $("${transition_query[@]}" -Q lmm-api-deploy-bin 2>/dev/null) == 'lmm-api-deploy-bin 0.1.57-1' ]]
 [[ -x $transition_pacman_root/usr/bin/lmm-api && -L $transition_pacman_root/usr/bin/lmm-api-go ]]
 [[ -x $transition_pacman_root/usr/bin/lmm-api-deploy ]]
@@ -265,7 +265,7 @@ fakeroot -- "${transition_install[@]}" -U "$legacy_deploy_package" "$t0_package"
 # rollback watchdog is armed; pacman -U does not apply replaces to local files.
 fakeroot -- "${transition_install[@]}" --remove -- lmm-api-deploy-bin >/dev/null
 fakeroot -- "${transition_install[@]}" -U "$t1_package" >/dev/null
-[[ $("${transition_query[@]}" -Q lmm-api-go-bin 2>/dev/null) == 'lmm-api-go-bin 0.1.59-1' ]]
+[[ $("${transition_query[@]}" -Q lmm-api-go-bin 2>/dev/null) == 'lmm-api-go-bin 0.1.60-1' ]]
 if "${transition_query[@]}" -Qq | grep -Fxq lmm-api-deploy-bin; then
   printf 'go-package-roundtrip: controller removal left the legacy deploy package installed\n' >&2
   exit 1
@@ -275,7 +275,7 @@ fi
 [[ -f $transition_pacman_root/etc/sudoers.d/lmm-api-operator ]]
 
 fakeroot -- "${transition_install[@]}" -U "$t0_package" >/dev/null
-[[ $("${transition_query[@]}" -Q lmm-api-go-bin 2>/dev/null) == 'lmm-api-go-bin 0.1.58-1' ]]
+[[ $("${transition_query[@]}" -Q lmm-api-go-bin 2>/dev/null) == 'lmm-api-go-bin 0.1.59-1' ]]
 [[ -x $transition_pacman_root/usr/bin/lmm-api && -L $transition_pacman_root/usr/bin/lmm-api-go ]]
 [[ $(readlink "$transition_pacman_root/usr/bin/lmm-api-go") == lmm-api ]]
 [[ ! -e $transition_pacman_root/usr/bin/lmm-api-deploy ]]

--- a/deploy/production/test-release-artifact-contract.sh
+++ b/deploy/production/test-release-artifact-contract.sh
@@ -75,7 +75,7 @@ require_literal "$GO_PKGBUILD" '_legacy_cli_archive_version=0.1.57' \
   'Go package lost the explicit legacy CLI archive boundary'
 require_literal "$GO_PKGBUILD" 'RELEASE_ASSET_SHA256' \
   'Go package does not preserve its signed release-asset digest'
-require_literal "$GO_PKGBUILD" '_t1_cli_version=0.1.59' \
+require_literal "$GO_PKGBUILD" '_t1_cli_version=0.1.60' \
   'Go package lost the explicit T1 single-CLI boundary'
 require_literal "$GO_PKGBUILD" "conflicts+=('lmm-api-deploy' 'lmm-api-deploy-bin')" \
   'T1 Go package does not conflict with legacy deploy packages'

--- a/packaging/aur/lmm-api-go-bin/PKGBUILD
+++ b/packaging/aur/lmm-api-go-bin/PKGBUILD
@@ -31,7 +31,8 @@ _release_tag="go-v${pkgver}"
 _legacy_bundled_version=0.1.34
 _legacy_cli_archive_version=0.1.57
 _legacy_external_operator_version=0.1.57
-_t1_cli_version=0.1.59
+# go-v0.1.58 produced no release assets; 0.1.59 is T0 and 0.1.60 is T1.
+_t1_cli_version=0.1.60
 _set_cli_transition_metadata
 _artifact="lmm-api-go-${pkgver}-linux"
 _release_base="${url}/releases/download/${_release_tag}"

--- a/packaging/aur/lmm-api-go/.SRCINFO
+++ b/packaging/aur/lmm-api-go/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go
 	pkgdesc = LMM API Go backend, native CLI, systemd service, and web frontend
-	pkgver = 0.1.1.r1114.ga864eda26
+	pkgver = 0.1.1.r1119.g241aff9d7
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64
@@ -20,7 +20,7 @@ pkgbase = lmm-api-go
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api=0.1.1.r1114.ga864eda26
+	provides = lmm-api=0.1.1.r1119.g241aff9d7
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git
@@ -31,7 +31,7 @@ pkgbase = lmm-api-go
 	replaces = lmm-api-deploy-bin
 	options = !strip
 	backup = etc/lmm-api-go/lmm-api-go.env
-	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#commit=a864eda26852940c4e7735c8cde267422798075d
+	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#commit=241aff9d75884fb20a070a6d513e5830a6295b3b
 	sha256sums = SKIP
 
 pkgname = lmm-api-go

--- a/packaging/aur/lmm-api-go/PKGBUILD
+++ b/packaging/aur/lmm-api-go/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction
 
 pkgname=lmm-api-go
-pkgver=0.1.1.r1114.ga864eda26
+pkgver=0.1.1.r1119.g241aff9d7
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, systemd service, and web frontend'
 arch=('x86_64' 'aarch64')
@@ -19,7 +19,7 @@ replaces=('lmm-api-deploy-bin')
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
 
-_commit=a864eda26852940c4e7735c8cde267422798075d
+_commit=241aff9d75884fb20a070a6d513e5830a6295b3b
 source=("lmm-api-go::git+${url}.git#commit=${_commit}")
 sha256sums=('SKIP')
 

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -149,11 +149,11 @@ contains_srcinfo lmm-api-go-git $'\tmakedepends = go>=1.25.1'
 contains_srcinfo lmm-api-go $'\tmakedepends = bun'
 contains_srcinfo lmm-api-go $'\tmakedepends = git'
 contains_srcinfo lmm-api-go $'\tmakedepends = go>=1.25.1'
-go_release_commit=a864eda26852940c4e7735c8cde267422798075d
+go_release_commit=241aff9d75884fb20a070a6d513e5830a6295b3b
 readonly go_release_commit
 grep -Fqx "_commit=$go_release_commit" "$HERE/lmm-api-go/PKGBUILD" ||
   die 'canonical Go package is not pinned to the reviewed direct-package revision'
-readonly reviewed_go_release_pkgver=0.1.1.r1114.ga864eda26
+readonly reviewed_go_release_pkgver=0.1.1.r1119.g241aff9d7
 if go_release_description=$(git -C "$ROOT" describe --long --tags --match='v[0-9]*' --abbrev=9 "$go_release_commit" 2>/dev/null); then
   go_release_pkgver=$(printf '%s\n' "$go_release_description" |
     sed -E 's/^v//; s/([^-]*-g)/r\1/; s/-/./g')

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -238,7 +238,7 @@ printf 'fixture archive\n' >"$stage/go-next/lmm-api-go-${go_bin_pkgver}-linux-am
   pkgdir="$tmp/pkg-go-t0"
   # shellcheck disable=SC1091
   source "$HERE/lmm-api-go-bin/PKGBUILD"
-  pkgver=0.1.58
+  pkgver=0.1.59
   package
 )
 (


### PR DESCRIPTION
## Summary
- install libarchive in the immutable Go release test job
- reserve 0.1.59 for the compatibility T0 release after go-v0.1.58 produced no assets
- move the single-CLI T1 boundary to 0.1.60 and update package/roundtrip contracts
- repin the reviewed source AUR package to the corrected release contract

## Verification
- Go appcli tests
- AUR matrix and real makepkg smoke tests
- release artifact contract
- T0 -> T1 -> T0 package roundtrip
- actionlint and LSP diagnostics

## Sourcery 摘要

通过修正兼容性版本边界和单 CLI 版本边界，并更新其软件包契约，恢复统一 CLI 的发布流程。

错误修复：
- 在 0.1.58 版本发布未生成任何构建产物后，通过为兼容性 T0 版本预留 0.1.59，恢复统一 CLI 的发布过渡流程。

增强功能：
- 将单 CLI 的 T1 边界移至 0.1.60 版本，并根据修正后的 T0/T1 顺序，对齐发布、软件包和往返测试契约。
- 将经过审查的源代码 AUR 软件包重新固定到修正后的 Go 发布版本。

构建：
- 在不可变 Go 发布测试任务中安装 libarchive 工具，以支持生产构建产物契约验证。

测试：
- 更新发布过渡、构建产物契约、AUR 矩阵和软件包往返测试，以适配 0.1.59 T0 和 0.1.60 T1 版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Recover the unified CLI release flow by correcting the compatibility and single-CLI version boundaries and updating their package contracts.

Bug Fixes:
- Restore the unified CLI release transition after the 0.1.58 release produced no artifacts by reserving 0.1.59 for the compatibility T0 release.

Enhancements:
- Move the single-CLI T1 boundary to version 0.1.60 and align release, package, and roundtrip contracts with the corrected T0/T1 sequence.
- Repin the reviewed source AUR package to the corrected Go release revision.

Build:
- Install libarchive tools in the immutable Go release test job to support production artifact contract validation.

Tests:
- Update release transition, artifact contract, AUR matrix, and package roundtrip tests for the 0.1.59 T0 and 0.1.60 T1 versions.

</details>