### PR TITLE
fix(security): bound subscription method allocation

### DIFF
--- a/apps/api-go/controller/subscription_checkout.go
+++ b/apps/api-go/controller/subscription_checkout.go
@@ -21,8 +21,10 @@ func subscriptionConfiguredPaymentMethods(plan *model.SubscriptionPlan) []string
 		return []string{}
 	}
 
-	methods := make([]string, 0, len(operation_setting.PayMethods)+4)
-	seen := make(map[string]struct{}, cap(methods))
+	// Keep configuration-derived capacity arithmetic overflow-free. The four
+	// built-in methods can grow the slice normally when they are enabled.
+	methods := make([]string, 0, len(operation_setting.PayMethods))
+	seen := make(map[string]struct{}, len(operation_setting.PayMethods))
 	appendConfigured := func(method string, configured bool) {
 		if !configured {
 			return

--- a/apps/api-go/controller/subscription_checkout_test.go
+++ b/apps/api-go/controller/subscription_checkout_test.go
@@ -125,6 +125,26 @@ func TestSubscriptionConfiguredPaymentMethodsRequireUsableGatewayConfiguration(t
 	)
 }
 
+func TestSubscriptionConfiguredPaymentMethodsGrowsPastConfigurationCapacity(t *testing.T) {
+	confirmPaymentComplianceForTest(t)
+	preservePaymentGatewaySettings(t)
+
+	operation_setting.PayAddress = "https://epay.example.test"
+	operation_setting.EpayId = "merchant"
+	operation_setting.EpayKey = "secret"
+	const configuredCount = 4096
+	operation_setting.PayMethods = make([]map[string]string, configuredCount)
+	expected := make([]string, 0, configuredCount+1)
+	expected = append(expected, model.PaymentMethodBalance)
+	for index := range configuredCount {
+		method := fmt.Sprintf("custom-%04d", index)
+		operation_setting.PayMethods[index] = map[string]string{"name": method, "type": method}
+		expected = append(expected, method)
+	}
+
+	require.Equal(t, expected, subscriptionConfiguredPaymentMethods(&model.SubscriptionPlan{Enabled: true}))
+}
+
 func TestEnabledSubscriptionPlanRequiresConfiguredPaymentMethod(t *testing.T) {
 	confirmPaymentComplianceForTest(t)
 	preservePaymentGatewaySettings(t)


### PR DESCRIPTION
## Summary
- remove overflow-prone `len(PayMethods) + 4` preallocation
- let enabled built-in methods grow the slice normally
- cover growth beyond the configuration-derived capacity with 4096 methods

Closes the code path reported by CodeQL alert #51 (`go/allocation-size-overflow`).

## Verification
- `go test -p 2 ./controller`
- LSP diagnostics clean

## Sourcery 摘要

限制订阅支付方式分配容量，同时保留对已配置和内置支付方式的支持。

Bug 修复：
- 防止由配置派生的容量算术导致订阅支付方式分配大小溢出。

测试：
- 添加测试覆盖，确认在配置了 4096 种支付方式时，支付方式数量能够正确增长并超过由配置派生的容量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bound subscription payment-method allocation capacity while preserving support for configured and built-in methods.

Bug Fixes:
- Prevent subscription payment-method allocation size overflow from configuration-derived capacity arithmetic.

Tests:
- Add coverage confirming payment methods grow correctly beyond the configuration-derived capacity with 4096 configured methods.

</details>