### PR TITLE
fix(release): harden T0 promotion and AUR pins

### DIFF
--- a/.agents/skills/lmm-deploy-safely/SKILL.md
+++ b/.agents/skills/lmm-deploy-safely/SKILL.md
@@ -424,7 +424,11 @@ database/cache.
 3. Build once, record artifact/package/frontend SHA-256, and run Go/frontend
    tests plus the native CLI preflight. Do not build on the production host.
 4. If backups were explicitly requested, create target, controller, and
-   off-host copies, verify encrypted archives offline, and compare checksums.
+off-host copies, verify encrypted archives offline, and compare checksums.
+Before activation, persist the exact transient unit and bounded attempt number.
+After any ambiguous SSH result, reconcile that unit plus the target manifest and
+status. Only three-way absence permits one redispatch of the same plan/workspace;
+any observed evidence means observe the existing job and never resend apply.
 5. Arm the persistent 600-second rollback watchdog, apply the immutable package,
    run migrations only when N/N-1 compatible, and observe for at least 120
    seconds while checking the resource and error-journal gates.

--- a/.agents/skills/lmm-deploy-safely/references/safety-contract.md
+++ b/.agents/skills/lmm-deploy-safely/references/safety-contract.md
@@ -68,6 +68,11 @@ For a local T1 package, do not assume `replaces` removes an installed package:
 after the watchdog is armed, require package-owned T0 sudoers/sysusers/tmpfiles,
 verify the exact legacy package owner and zero altered files, remove only that
 package, and then install T1.
+- Persist the activation transient-unit identity and bounded attempt count before
+remote dispatch. A transport-ambiguous result must reconcile the unit, target
+manifest, and target status. Only when all three are absent may the exact same
+plan/workspace be redispatched once. If any evidence exists, observe that job;
+never issue another apply.
 - Before any operator invocation, require `pacman -Qo` to identify the approved
   Go package as owner of `/usr/bin/lmm-api`; require a real non-symlink binary
   and zero altered package files. Verify the package payload against the signed

--- a/.github/required-release-checks.txt
+++ b/.github/required-release-checks.txt
@@ -1,0 +1,12 @@
+Workflow and resource-safety contracts
+Release artifact contract
+Go default backend, relaykit, and static build
+Rust backend formatting, lint, and tests
+Web checks, route manifest, and production build
+AUR direct-backend package contract
+Go and Rust route/behavior alignment gates
+Analyze (actions)
+Analyze (go)
+Analyze (javascript-typescript)
+Analyze (python)
+Analyze (rust)

--- a/.github/required-release-checks.txt
+++ b/.github/required-release-checks.txt
@@ -1,12 +1,12 @@
-Workflow and resource-safety contracts
-Release artifact contract
-Go default backend, relaykit, and static build
-Rust backend formatting, lint, and tests
-Web checks, route manifest, and production build
-AUR direct-backend package contract
-Go and Rust route/behavior alignment gates
-Analyze (actions)
-Analyze (go)
-Analyze (javascript-typescript)
-Analyze (python)
-Analyze (rust)
+Workflow and resource-safety contracts|.github/workflows/ci.yml|push|main
+Release artifact contract|.github/workflows/ci.yml|push|main
+Go default backend, relaykit, and static build|.github/workflows/ci.yml|push|main
+Rust backend formatting, lint, and tests|.github/workflows/ci.yml|push|main
+Web checks, route manifest, and production build|.github/workflows/ci.yml|push|main
+AUR direct-backend package contract|.github/workflows/ci.yml|push|main
+Go and Rust route/behavior alignment gates|.github/workflows/ci.yml|push|main
+Analyze (actions)|dynamic/github-code-scanning/codeql|dynamic|main
+Analyze (go)|dynamic/github-code-scanning/codeql|dynamic|main
+Analyze (javascript-typescript)|dynamic/github-code-scanning/codeql|dynamic|main
+Analyze (python)|dynamic/github-code-scanning/codeql|dynamic|main
+Analyze (rust)|dynamic/github-code-scanning/codeql|dynamic|main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,13 @@ jobs:
           bash scripts/test-verify-release-commit-checks.sh
           node --test scripts/release.test.mjs
 
+      - name: Test Nginx API preflight policy
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes nginx
+          shellcheck deploy/test-nginx-access-policy-preflight.sh
+          bash deploy/check-frontend-split.sh
+
   release-artifact-contract:
     name: Release artifact contract
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,12 @@ jobs:
 
       - name: Test release version, governance, and changelog tooling
         run: |
-          shellcheck scripts/verify-release-commit-checks.sh scripts/test-verify-release-commit-checks.sh
+          shellcheck \
+            scripts/verify-release-commit-checks.sh \
+            scripts/test-verify-release-commit-checks.sh \
+            packaging/aur/check-candidate-version.sh \
+            packaging/aur/export-go-package-base.sh \
+            packaging/aur/test-export-go-package-base.sh
           bash scripts/test-verify-release-commit-checks.sh
           node --test scripts/release.test.mjs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,29 @@ jobs:
           bash .agents/skills/lmm-deploy-safely/scripts/tests/test-inspect-state.sh
           bash .agents/skills/lmm-deploy-safely/scripts/tests/test-resource-pressure-report.sh
 
-      - name: Test release version and changelog tooling
-        run: node --test scripts/release.test.mjs
+      - name: Test release version, governance, and changelog tooling
+        run: |
+          shellcheck scripts/verify-release-commit-checks.sh scripts/test-verify-release-commit-checks.sh
+          bash scripts/test-verify-release-commit-checks.sh
+          node --test scripts/release.test.mjs
+
+  release-artifact-contract:
+    name: Release artifact contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify immutable release and package contracts
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: |
+          shellcheck deploy/production/test-release-artifact-contract.sh
+          bash deploy/production/test-release-artifact-contract.sh
 
   web:
     name: Web checks, route manifest, and production build
@@ -322,12 +343,12 @@ jobs:
   aur-package-matrix:
     name: AUR direct-backend package contract
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     container: archlinux:base-devel
     steps:
       - name: Install checkout and package validation tools
         run: |
-          pacman --sync --refresh --noconfirm clang curl git jq libarchive rust shellcheck
+          pacman --sync --refresh --noconfirm clang cosign curl git jq libarchive rust shellcheck
           paru_revision=9ac3578807a87858651e81a02586ceb947686e7c
           paru_archive=/tmp/paru.tar.gz
           curl --fail --location --silent --show-error \
@@ -351,6 +372,10 @@ jobs:
         run: |
           chown --recursive package-builder:package-builder "$GITHUB_WORKSPACE"
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-matrix.sh
+          runuser --user package-builder -- env \
+            TMPDIR=/home/package-builder/lmm-ci-tmp \
+            GITHUB_TOKEN='${{ github.token }}' \
+            bash packaging/aur/verify-go-release-pins.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-bin-makepkg.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash packaging/aur/test-web-activation.sh
           runuser --user package-builder -- env TMPDIR=/home/package-builder/lmm-ci-tmp bash deploy/production/test-precutover-packages.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends --yes nginx
-          shellcheck deploy/test-nginx-access-policy-preflight.sh
+          shellcheck \
+            deploy/test-nginx-access-policy-preflight.sh \
+            deploy/test-nginx-mime.sh
           bash deploy/check-frontend-split.sh
 
   release-artifact-contract:

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -22,7 +22,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout the exact CI-verified revision
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   actions: write
+  checks: read
   contents: write
 
 concurrency:
@@ -51,6 +52,8 @@ jobs:
             echo 'VERSION did not change in this revision; no release promotion is required.'
             exit 0
           fi
+
+          GITHUB_TOKEN=$GH_TOKEN bash scripts/verify-release-commit-checks.sh "$revision"
 
           version=$(tr -d '[:space:]' < VERSION)
           [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -6,6 +6,7 @@ on:
       - 'go-v*.*.*'
 
 permissions:
+  checks: read
   contents: read
 
 concurrency:
@@ -20,7 +21,7 @@ jobs:
   prepare:
     name: Verify immutable Go release identity
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     outputs:
       contract_revision: ${{ steps.identity.outputs.contract_revision }}
       revision: ${{ steps.identity.outputs.revision }}
@@ -68,6 +69,11 @@ jobs:
             echo "version=$version"
             echo "revision=$revision"
           } >>"$GITHUB_OUTPUT"
+
+      - name: Require successful CI, CodeQL, and release contracts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bash scripts/verify-release-commit-checks.sh "${GITHUB_SHA}"
 
   test:
     name: Test Go backend

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -6,6 +6,7 @@ on:
       - 'go-v*.*.*'
 
 permissions:
+  actions: read
   checks: read
   contents: read
 

--- a/apps/api-go/controller/access_policy_error.go
+++ b/apps/api-go/controller/access_policy_error.go
@@ -3,8 +3,10 @@ package controller
 import (
 	"fmt"
 	"html/template"
+	"mime"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,9 +15,14 @@ import (
 )
 
 const (
-	accessPolicyErrorHeader  = "access-policy"
-	accessPolicyResultHeader = "X-LMM-Access-Policy"
-	accessPolicyDenied       = "denied"
+	accessPolicyErrorHeader          = "access-policy"
+	accessPolicyResultHeader         = "X-LMM-Access-Policy"
+	accessPolicyOriginalURIHeader    = "X-LMM-Original-URI"
+	accessPolicyOriginalAcceptHeader = "X-LMM-Original-Accept"
+	accessPolicyDenied               = "denied"
+	accessPolicyRejectedErrorCode    = "IP_ACCESS_ROUTE_REJECTED"
+	accessPolicyRejectedErrorType    = "access_policy_error"
+	accessPolicyRejectedMessage      = "Request rejected by IP access policy."
 )
 
 // GetAccessPolicyErrorPage renders the edge-policy response through the Go
@@ -30,17 +37,90 @@ func GetAccessPolicyErrorPage(c *gin.Context) {
 		return
 	}
 
+	requestID := accessPolicyRequestID(c)
+	c.Header(common.RequestIdKey, requestID)
+	c.Header("Cache-Control", "private, no-store, max-age=0")
+	c.Header("Pragma", "no-cache")
+	c.Header("Vary", "Accept, Origin")
+	c.Header("X-Content-Type-Options", "nosniff")
+	if accessPolicyWantsJSON(c) {
+		applyAccessPolicyJSONCORS(c)
+		c.JSON(http.StatusUnavailableForLegalReasons, gin.H{
+			"error": gin.H{
+				"code":       accessPolicyRejectedErrorCode,
+				"message":    accessPolicyRejectedMessage,
+				"request_id": requestID,
+				"type":       accessPolicyRejectedErrorType,
+			},
+		})
+		return
+	}
+
 	language := "zh"
 	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.GetHeader("Accept-Language"))), "en") {
 		language = "en"
 	}
-	requestID := accessPolicyRequestID(c)
-	c.Header(common.RequestIdKey, requestID)
 	page := accessPolicyErrorPage(language, accessPolicyErrorDiagnostics(c, requestID))
-	c.Header("Cache-Control", "private, no-store, max-age=0")
-	c.Header("Pragma", "no-cache")
-	c.Header("X-Content-Type-Options", "nosniff")
 	c.Data(http.StatusUnavailableForLegalReasons, "text/html; charset=utf-8", []byte(page))
+}
+
+func applyAccessPolicyJSONCORS(c *gin.Context) {
+	if strings.TrimSpace(c.GetHeader("Origin")) == "" {
+		return
+	}
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.Header("Access-Control-Expose-Headers", common.RequestIdKey)
+}
+
+func accessPolicyWantsJSON(c *gin.Context) bool {
+	originalURI := strings.TrimSpace(c.GetHeader(accessPolicyOriginalURIHeader))
+	if queryStart := strings.IndexByte(originalURI, '?'); queryStart >= 0 {
+		originalURI = originalURI[:queryStart]
+	}
+	if accessPolicyAPIPath(originalURI) {
+		return true
+	}
+
+	for mediaRange := range strings.SplitSeq(strings.ToLower(c.GetHeader(accessPolicyOriginalAcceptHeader)), ",") {
+		mediaType, parameters, err := mime.ParseMediaType(strings.TrimSpace(mediaRange))
+		if err != nil {
+			continue
+		}
+		if quality, ok := parameters["q"]; ok {
+			parsedQuality, err := strconv.ParseFloat(quality, 64)
+			if err != nil || parsedQuality <= 0 {
+				continue
+			}
+		}
+		if mediaType == "application/json" || mediaType == "text/json" || strings.HasSuffix(mediaType, "+json") {
+			return true
+		}
+	}
+	return false
+}
+
+func accessPolicyAPIPath(path string) bool {
+	for _, prefix := range []string{
+		"/api",
+		"/mcp",
+		"/v1",
+		"/v1beta",
+		"/pg",
+		"/mj",
+		"/suno",
+		"/kling/v1",
+		"/jimeng",
+	} {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+	if path == "/dashboard/billing/subscription" || path == "/dashboard/billing/usage" {
+		return true
+	}
+
+	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	return len(segments) >= 2 && segments[0] != "" && segments[1] == "mj"
 }
 
 type accessPolicyErrorDetails struct {

--- a/apps/api-go/controller/access_policy_error.go
+++ b/apps/api-go/controller/access_policy_error.go
@@ -120,7 +120,12 @@ func accessPolicyAPIPath(path string) bool {
 	}
 
 	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
-	return len(segments) >= 2 && segments[0] != "" && segments[1] == "mj"
+	if len(segments) < 2 || segments[0] == "" || segments[1] != "mj" {
+		return false
+	}
+	// These ^~ frontend prefixes win before the dynamic /:mode/mj Nginx
+	// regex, so their matching paths must keep the browser-facing HTML page.
+	return segments[0] != "oauth" && segments[0] != "static"
 }
 
 type accessPolicyErrorDetails struct {

--- a/apps/api-go/controller/personal_access_ip_test.go
+++ b/apps/api-go/controller/personal_access_ip_test.go
@@ -1,10 +1,12 @@
 package controller
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/LIghtJUNction/api.lmm.best/common"
 	"github.com/LIghtJUNction/api.lmm.best/setting"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -17,6 +19,32 @@ func TestLoopbackPeerAcceptsOnlyLoopbackAddresses(t *testing.T) {
 	assert.False(t, loopbackPeer("10.0.0.2:3000"))
 	assert.False(t, loopbackPeer("198.51.100.2:3000"))
 	assert.False(t, loopbackPeer("not-an-address"))
+}
+
+func TestAccessPolicyAPIPathMatchesNginxBackendFamilies(t *testing.T) {
+	for _, path := range []string{
+		"/api/status",
+		"/mcp",
+		"/v1/models",
+		"/v1beta/models/gemini:generateContent",
+		"/pg/chat/completions",
+		"/mj/submit",
+		"/suno/generate",
+		"/kling/v1/videos",
+		"/jimeng/generations",
+		"/dashboard/billing/subscription",
+		"/dashboard/billing/usage",
+		"/openai/mj/image/task",
+	} {
+		t.Run(path, func(t *testing.T) {
+			assert.True(t, accessPolicyAPIPath(path))
+		})
+	}
+	for _, path := range []string{"/", "/pricing", "/v1beta-docs", "/apiary", "/foo/mjpeg"} {
+		t.Run("browser "+path, func(t *testing.T) {
+			assert.False(t, accessPolicyAPIPath(path))
+		})
+	}
 }
 
 func TestPersonalAccessIPCompatibilityEndpointIsRetired(t *testing.T) {
@@ -151,6 +179,55 @@ func TestAccessPolicyErrorPageRequiresCapturedDenial(t *testing.T) {
 	assert.Contains(t, body, "IPv4")
 	assert.Contains(t, body, "route_reject")
 	assert.NotContains(t, body, "符合条件的账号")
+
+	jsonHeaders := make(map[string]string, len(validHeaders)+4)
+	for name, value := range validHeaders {
+		jsonHeaders[name] = value
+	}
+	jsonHeaders[accessPolicyOriginalURIHeader] = "/v1/models?debug=1"
+	jsonHeaders[accessPolicyOriginalAcceptHeader] = "*/*"
+	jsonHeaders["Origin"] = "https://sdk.example"
+	jsonHeaders["Authorization"] = "Bearer must-not-leak"
+	jsonHeaders["Cookie"] = "session=must-not-leak"
+	status, response = request("127.0.0.1:42000", jsonHeaders)
+	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
+	assert.Contains(t, response.Header().Get("Content-Type"), "application/json")
+	assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, response.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, common.RequestIdKey, response.Header().Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Accept, Origin", response.Header().Get("Vary"))
+	assert.Less(t, response.Body.Len(), 512)
+	assert.NotContains(t, response.Body.String(), "must-not-leak")
+	assert.NotContains(t, response.Body.String(), "203.0.113.42")
+	var payload struct {
+		Error struct {
+			Code      string `json:"code"`
+			Message   string `json:"message"`
+			RequestID string `json:"request_id"`
+			Type      string `json:"type"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &payload))
+	assert.Equal(t, accessPolicyRejectedErrorCode, payload.Error.Code)
+	assert.Equal(t, accessPolicyRejectedMessage, payload.Error.Message)
+	assert.Equal(t, accessPolicyRejectedErrorType, payload.Error.Type)
+	assert.NotEmpty(t, payload.Error.RequestID)
+
+	jsonHeaders[accessPolicyOriginalURIHeader] = "/api/status"
+	jsonHeaders[accessPolicyOriginalAcceptHeader] = "text/plain, application/problem+json; q=0.9"
+	status, response = request("127.0.0.1:42000", jsonHeaders)
+	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
+	assert.Contains(t, response.Header().Get("Content-Type"), "application/json")
+
+	jsonHeaders[accessPolicyOriginalURIHeader] = "/"
+	jsonHeaders[accessPolicyOriginalAcceptHeader] = "application/json; q=0, text/html"
+	status, response = request("127.0.0.1:42000", jsonHeaders)
+	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
+	assert.Contains(t, response.Header().Get("Content-Type"), "text/html")
+	assert.Empty(t, response.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, response.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "Accept, Origin", response.Header().Get("Vary"))
+	assert.NotContains(t, response.Body.String(), "must-not-leak")
 
 	status, _ = request("127.0.0.1:42000", map[string]string{
 		"X-LMM-Internal-Error": accessPolicyErrorHeader,

--- a/apps/api-go/controller/personal_access_ip_test.go
+++ b/apps/api-go/controller/personal_access_ip_test.go
@@ -40,7 +40,16 @@ func TestAccessPolicyAPIPathMatchesNginxBackendFamilies(t *testing.T) {
 			assert.True(t, accessPolicyAPIPath(path))
 		})
 	}
-	for _, path := range []string{"/", "/pricing", "/v1beta-docs", "/apiary", "/foo/mjpeg"} {
+	for _, path := range []string{
+		"/",
+		"/pricing",
+		"/v1beta-docs",
+		"/apiary",
+		"/foo/mjpeg",
+		"/oauth/mj",
+		"/oauth/mj/callback",
+		"/static/mj/asset.js",
+	} {
 		t.Run("browser "+path, func(t *testing.T) {
 			assert.False(t, accessPolicyAPIPath(path))
 		})
@@ -219,15 +228,17 @@ func TestAccessPolicyErrorPageRequiresCapturedDenial(t *testing.T) {
 	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
 	assert.Contains(t, response.Header().Get("Content-Type"), "application/json")
 
-	jsonHeaders[accessPolicyOriginalURIHeader] = "/"
-	jsonHeaders[accessPolicyOriginalAcceptHeader] = "application/json; q=0, text/html"
-	status, response = request("127.0.0.1:42000", jsonHeaders)
-	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
-	assert.Contains(t, response.Header().Get("Content-Type"), "text/html")
-	assert.Empty(t, response.Header().Get("Access-Control-Allow-Origin"))
-	assert.Empty(t, response.Header().Get("Access-Control-Allow-Credentials"))
-	assert.Equal(t, "Accept, Origin", response.Header().Get("Vary"))
-	assert.NotContains(t, response.Body.String(), "must-not-leak")
+	for _, frontendURI := range []string{"/", "/oauth/mj", "/static/mj/asset.js"} {
+		jsonHeaders[accessPolicyOriginalURIHeader] = frontendURI
+		jsonHeaders[accessPolicyOriginalAcceptHeader] = "application/json; q=0, text/html"
+		status, response = request("127.0.0.1:42000", jsonHeaders)
+		require.Equal(t, http.StatusUnavailableForLegalReasons, status)
+		assert.Contains(t, response.Header().Get("Content-Type"), "text/html")
+		assert.Empty(t, response.Header().Get("Access-Control-Allow-Origin"))
+		assert.Empty(t, response.Header().Get("Access-Control-Allow-Credentials"))
+		assert.Equal(t, "Accept, Origin", response.Header().Get("Vary"))
+		assert.NotContains(t, response.Body.String(), "must-not-leak")
+	}
 
 	status, _ = request("127.0.0.1:42000", map[string]string{
 		"X-LMM-Internal-Error": accessPolicyErrorHeader,

--- a/apps/api-go/controller/relay_image_validation_test.go
+++ b/apps/api-go/controller/relay_image_validation_test.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LIghtJUNction/api.lmm.best/common"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayRejectsUnsupportedImageBeforeBillingAndChannelSelection(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	part, err := writer.CreateFormFile("image[]", "image.png")
+	require.NoError(t, err)
+	_, err = part.Write([]byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'})
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	context.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	context.Set(common.RequestIdKey, "image-validation-test")
+	t.Cleanup(func() { common.CleanupBodyStorage(context) })
+
+	Relay(context, types.RelayFormatOpenAIImage)
+
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	var payload struct {
+		Error types.OpenAIError `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &payload))
+	require.Equal(t, "new_api_error", payload.Error.Type)
+	require.Equal(t, string(types.ErrorCodeInvalidRequest), payload.Error.Code)
+	require.Contains(t, payload.Error.Message, "unsupported image content type")
+	require.Empty(t, context.GetStringSlice("use_channel"), "validation must stop before upstream selection")
+}

--- a/apps/api-go/internal/appcli/deploy_edge_policy.go
+++ b/apps/api-go/internal/appcli/deploy_edge_policy.go
@@ -165,8 +165,16 @@ func (runtime *productionRuntime) validateEdgePolicyAssets(assetRoot string) err
 	}{
 		{name: "nginx/http-map.conf", need: "geoip2 /var/lib/geoip2/DBIP-Country-Lite.mmdb {"},
 		{name: "nginx/new-api.conf", need: "include /etc/nginx/lmm-api-region-policy.conf;"},
+		{name: "nginx/lmm-api-locations.conf", need: "error_page 418 = @lmm_api_cors_preflight;"},
+		{name: "nginx/lmm-api-locations.conf", need: "location @lmm_api_cors_preflight {"},
+		{name: "nginx/lmm-api-locations.conf", need: "auth_request off;"},
+		{name: "nginx/lmm-api-locations.conf", need: "set $lmm_access_policy_original_uri $uri;"},
+		{name: "nginx/lmm-api-locations.conf", need: "if ($request_method = OPTIONS) { return 418; }"},
+		{name: "nginx/lmm-api-locations.conf", need: "add_header Access-Control-Allow-Methods $http_access_control_request_method always;"},
+		{name: "nginx/lmm-api-locations.conf", need: "add_header Access-Control-Allow-Headers $http_access_control_request_headers always;"},
+		{name: "nginx/lmm-api-locations.conf", need: "add_header Vary \"Origin, Access-Control-Request-Method, Access-Control-Request-Headers\" always;"},
 		{name: "nginx/lmm-api-region-policy.conf", need: "auth_request /internal/access-ip-policy;"},
-		{name: "nginx/lmm-api-region-policy.conf", need: "proxy_set_header X-LMM-Original-URI $request_uri;"},
+		{name: "nginx/lmm-api-region-policy.conf", need: "proxy_set_header X-LMM-Original-URI $lmm_access_policy_original_uri;"},
 		{name: "nginx/lmm-api-region-policy.conf", need: "proxy_set_header X-LMM-Original-Accept $http_accept;"},
 	} {
 		content, err := os.ReadFile(filepath.Join(assetRoot, check.name))

--- a/apps/api-go/internal/appcli/deploy_edge_policy.go
+++ b/apps/api-go/internal/appcli/deploy_edge_policy.go
@@ -166,6 +166,8 @@ func (runtime *productionRuntime) validateEdgePolicyAssets(assetRoot string) err
 		{name: "nginx/http-map.conf", need: "geoip2 /var/lib/geoip2/DBIP-Country-Lite.mmdb {"},
 		{name: "nginx/new-api.conf", need: "include /etc/nginx/lmm-api-region-policy.conf;"},
 		{name: "nginx/lmm-api-region-policy.conf", need: "auth_request /internal/access-ip-policy;"},
+		{name: "nginx/lmm-api-region-policy.conf", need: "proxy_set_header X-LMM-Original-URI $request_uri;"},
+		{name: "nginx/lmm-api-region-policy.conf", need: "proxy_set_header X-LMM-Original-Accept $http_accept;"},
 	} {
 		content, err := os.ReadFile(filepath.Join(assetRoot, check.name))
 		if err != nil || !strings.Contains(string(content), check.need) {

--- a/apps/api-go/internal/appcli/deploy_edge_policy_test.go
+++ b/apps/api-go/internal/appcli/deploy_edge_policy_test.go
@@ -74,9 +74,18 @@ func TestEdgePolicyInstallBacksUpRemovesLegacyAndRestores(t *testing.T) {
 			candidate += "geoip2 /var/lib/geoip2/DBIP-Country-Lite.mmdb {\n"
 		case "server":
 			candidate += "include /etc/nginx/lmm-api-region-policy.conf;\n"
+		case "locations":
+			candidate += "error_page 418 = @lmm_api_cors_preflight;\n"
+			candidate += "location @lmm_api_cors_preflight {\n"
+			candidate += "auth_request off;\n"
+			candidate += "set $lmm_access_policy_original_uri $uri;\n"
+			candidate += "if ($request_method = OPTIONS) { return 418; }\n"
+			candidate += "add_header Access-Control-Allow-Methods $http_access_control_request_method always;\n"
+			candidate += "add_header Access-Control-Allow-Headers $http_access_control_request_headers always;\n"
+			candidate += "add_header Vary \"Origin, Access-Control-Request-Method, Access-Control-Request-Headers\" always;\n"
 		case "region-policy":
 			candidate += "auth_request /internal/access-ip-policy;\n"
-			candidate += "proxy_set_header X-LMM-Original-URI $request_uri;\n"
+			candidate += "proxy_set_header X-LMM-Original-URI $lmm_access_policy_original_uri;\n"
 			candidate += "proxy_set_header X-LMM-Original-Accept $http_accept;\n"
 		}
 		if err := os.WriteFile(assetPath, []byte(candidate), 0o644); err != nil {

--- a/apps/api-go/internal/appcli/deploy_edge_policy_test.go
+++ b/apps/api-go/internal/appcli/deploy_edge_policy_test.go
@@ -76,6 +76,8 @@ func TestEdgePolicyInstallBacksUpRemovesLegacyAndRestores(t *testing.T) {
 			candidate += "include /etc/nginx/lmm-api-region-policy.conf;\n"
 		case "region-policy":
 			candidate += "auth_request /internal/access-ip-policy;\n"
+			candidate += "proxy_set_header X-LMM-Original-URI $request_uri;\n"
+			candidate += "proxy_set_header X-LMM-Original-Accept $http_accept;\n"
 		}
 		if err := os.WriteFile(assetPath, []byte(candidate), 0o644); err != nil {
 			t.Fatal(err)

--- a/apps/api-go/internal/appcli/deploy_production.go
+++ b/apps/api-go/internal/appcli/deploy_production.go
@@ -68,6 +68,8 @@ func runProductionDeploy(args []string, stdout, stderr io.Writer) int {
 		return ExitOK
 	case "edge-policy":
 		return runProductionEdgePolicy(args[1:], stdout, stderr)
+	case "dispatch-evidence":
+		return runProductionDispatchEvidence(args[1:], stdout, stderr)
 	case "apply":
 		return runProductionTransaction(args[0], args[1:], stdout, stderr)
 	case "status", "confirm", "rollback":

--- a/apps/api-go/internal/appcli/deploy_production_controller.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller.go
@@ -282,11 +282,7 @@ func (runtime *productionReleaseRuntime) promote(ctx context.Context, options pr
 	if err != nil {
 		return productionReleaseControllerResult{}, err
 	}
-	state.Phase = status.Phase
-	state.Version = status.Version
-	state.RollbackTimer = status.RollbackTimer
-	state.UpdatedUTC = utcSecond(runtime.now())
-	if err := writeProductionReleaseControllerState(plan, state); err != nil {
+	if err := persistRemoteReleaseControllerStatus(plan, &state, status, runtime.now()); err != nil {
 		return productionReleaseControllerResult{}, err
 	}
 	expected := "CONFIRMED"
@@ -333,14 +329,18 @@ func (runtime *productionReleaseRuntime) control(ctx context.Context, action str
 	if err != nil {
 		return productionReleaseControllerResult{}, err
 	}
-	state.Phase = status.Phase
-	state.Version = status.Version
-	state.RollbackTimer = status.RollbackTimer
-	state.UpdatedUTC = utcSecond(runtime.now())
-	if err := writeProductionReleaseControllerState(plan, state); err != nil {
+	if err := persistRemoteReleaseControllerStatus(plan, &state, status, runtime.now()); err != nil {
 		return productionReleaseControllerResult{}, err
 	}
 	return releaseControllerResult(plan, state), nil
+}
+
+func persistRemoteReleaseControllerStatus(plan productionReleasePlan, state *productionReleaseControllerState, status productionStatus, now time.Time) error {
+	state.Phase = status.Phase
+	state.Version = status.Version
+	state.RollbackTimer = status.RollbackTimer
+	state.UpdatedUTC = utcSecond(now)
+	return writeProductionReleaseControllerState(plan, *state)
 }
 
 func (runtime *productionReleaseRuntime) productionApplyArguments(plan productionReleasePlan, state productionReleaseControllerState) []string {
@@ -903,6 +903,7 @@ func validateProductionReleaseControllerState(plan productionReleasePlan, planSH
 		"ROLLED_BACK":           true,
 		"FAILED_PREARM":         true,
 		"ROLLBACK_FAILED":       true,
+		"ABORTED":               true,
 	}
 	if !phases[state.Phase] {
 		return errors.New("controller release state phase is invalid")

--- a/apps/api-go/internal/appcli/deploy_production_controller.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller.go
@@ -463,8 +463,19 @@ func (runtime *productionReleaseRuntime) awaitRemoteReleaseStatus(ctx context.Co
 	defer cancel()
 	for {
 		status, err := runtime.readRemoteReleaseStatus(waitCtx, plan, *state)
-		if err == nil {
+		if err == nil && productionActivationStatusTerminal(status.Phase) {
 			return status, nil
+		}
+		if err == nil {
+			state.DispatchObserved = true
+			state.UpdatedUTC = utcSecond(runtime.now())
+			if writeErr := writeProductionReleaseControllerState(plan, *state); writeErr != nil {
+				return productionStatus{}, writeErr
+			}
+			if waitErr := runtime.waitForDispatchObservation(waitCtx, 2*time.Second); waitErr != nil {
+				return productionStatus{}, fmt.Errorf("wait for terminal production activation status: %w", waitErr)
+			}
+			continue
 		}
 		evidence, reconcileErr := runtime.remoteDispatchEvidence(waitCtx, plan, *state)
 		if reconcileErr != nil {
@@ -481,6 +492,15 @@ func (runtime *productionReleaseRuntime) awaitRemoteReleaseStatus(ctx context.Co
 		if waitErr := runtime.waitForDispatchObservation(waitCtx, 2*time.Second); waitErr != nil {
 			return productionStatus{}, fmt.Errorf("wait for production activation status: %w", waitErr)
 		}
+	}
+}
+
+func productionActivationStatusTerminal(phase string) bool {
+	switch phase {
+	case "AWAITING_CONFIRMATION", "CONFIRMED", "ROLLED_BACK", "FAILED_PREARM", "ROLLBACK_FAILED", "ABORTED":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -817,12 +837,29 @@ func loadProductionReleaseControllerState(plan productionReleasePlan, planSHA256
 	if err := decoder.Decode(&state); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
 		return productionReleaseControllerState{}, false, errors.New("controller release state is invalid")
 	}
-	if err := validateProductionReleaseControllerState(plan, planSHA256, state); err != nil {
-		return productionReleaseControllerState{}, false, err
-	}
 	canonical, err := canonicalProductionReleaseControllerState(state)
 	if err != nil || !bytes.Equal(canonical, raw) {
 		return productionReleaseControllerState{}, false, errors.New("controller release state is not canonical JSON")
+	}
+	migrated := false
+	if state.Format == 1 {
+		if state.ActivationUnit != "" || state.DispatchAttempts != 0 || state.DispatchObserved {
+			return productionReleaseControllerState{}, false, errors.New("legacy controller release state contains unsupported dispatch fields")
+		}
+		state.Format = productionReleaseStateFormat
+		if state.Phase == productionReleasePhaseActivationDispatched {
+			state.ActivationUnit = productionActivationUnit(plan.DeploymentID)
+			state.DispatchAttempts = 1
+		}
+		migrated = true
+	}
+	if err := validateProductionReleaseControllerState(plan, planSHA256, state); err != nil {
+		return productionReleaseControllerState{}, false, err
+	}
+	if migrated {
+		if err := writeProductionReleaseControllerState(plan, state); err != nil {
+			return productionReleaseControllerState{}, false, fmt.Errorf("migrate controller release state: %w", err)
+		}
 	}
 	return state, true, nil
 }

--- a/apps/api-go/internal/appcli/deploy_production_controller.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller.go
@@ -41,6 +41,9 @@ type productionReleaseControllerState struct {
 	OffhostBackup    string    `json:"offhost_backup,omitempty"`
 	Version          string    `json:"version,omitempty"`
 	RollbackTimer    string    `json:"rollback_timer,omitempty"`
+	ActivationUnit   string    `json:"activation_unit,omitempty"`
+	DispatchAttempts int       `json:"dispatch_attempts,omitempty"`
+	DispatchObserved bool      `json:"dispatch_observed,omitempty"`
 	UpdatedUTC       time.Time `json:"updated_utc"`
 }
 
@@ -54,6 +57,8 @@ type productionReleaseControllerResult struct {
 	ControllerBackup string `json:"controller_backup,omitempty"`
 	OffhostBackup    string `json:"offhost_backup,omitempty"`
 	RollbackTimer    string `json:"rollback_timer,omitempty"`
+	ActivationUnit   string `json:"activation_unit,omitempty"`
+	DispatchAttempts int    `json:"dispatch_attempts,omitempty"`
 	Workspace        string `json:"workspace"`
 }
 
@@ -266,18 +271,14 @@ func (runtime *productionReleaseRuntime) promote(ctx context.Context, options pr
 			return productionReleaseControllerResult{}, err
 		}
 	}
-	if state.Phase == productionReleasePhaseStaged || state.Phase == productionReleasePhaseBackupsReady {
-		applyArgs := runtime.productionApplyArguments(plan, state)
-		state.Phase = productionReleasePhaseActivationDispatched
-		state.UpdatedUTC = utcSecond(runtime.now())
-		if err := writeProductionReleaseControllerState(plan, state); err != nil {
+	if state.Phase == productionReleasePhaseStaged ||
+		state.Phase == productionReleasePhaseBackupsReady ||
+		state.Phase == productionReleasePhaseActivationDispatched {
+		if err := runtime.dispatchProductionActivation(ctx, plan, &state); err != nil {
 			return productionReleaseControllerResult{}, err
 		}
-		if _, err := runtime.ssh(ctx, plan.TargetAlias, 20*time.Minute, applyArgs...); err != nil {
-			return productionReleaseControllerResult{}, fmt.Errorf("production activation failed or became transport-ambiguous; transaction retained and must be inspected with status: %w", err)
-		}
 	}
-	status, err := runtime.readRemoteReleaseStatus(ctx, plan, state)
+	status, err := runtime.awaitRemoteReleaseStatus(ctx, plan, &state)
 	if err != nil {
 		return productionReleaseControllerResult{}, err
 	}
@@ -346,7 +347,7 @@ func (runtime *productionReleaseRuntime) productionApplyArguments(plan productio
 	remoteStage := filepath.Join(state.RemoteWorkspace, "staging")
 	remoteProbe := filepath.Join(remoteStage, filepath.Base(plan.ProbeBinary.Path))
 	arguments := []string{
-		"systemd-run", "--quiet", "--wait", "--collect", "--unit", "lmm-api-deploy-" + plan.DeploymentID,
+		"systemd-run", "--quiet", "--wait", "--collect", "--unit", productionActivationUnit(plan.DeploymentID),
 		"--property=Type=oneshot", "--property=TimeoutStartSec=18min",
 		remoteProbe, "deploy", "production", "apply",
 		"--workspace", state.RemoteWorkspace,
@@ -381,6 +382,120 @@ func (runtime *productionReleaseRuntime) productionApplyArguments(plan productio
 		arguments = append(arguments, "--preserve-edge-policy")
 	}
 	return arguments
+}
+
+func (runtime *productionReleaseRuntime) remoteDispatchEvidence(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) (productionDispatchEvidence, error) {
+	remoteProbe := filepath.Join(state.RemoteWorkspace, "staging", filepath.Base(plan.ProbeBinary.Path))
+	output, err := runtime.ssh(ctx, plan.TargetAlias, 30*time.Second,
+		remoteProbe, "deploy", "production", "dispatch-evidence",
+		"--workspace", state.RemoteWorkspace, "--unit", state.ActivationUnit)
+	if err != nil {
+		return productionDispatchEvidence{}, fmt.Errorf("reconcile production activation dispatch: %w", err)
+	}
+	var evidence productionDispatchEvidence
+	if err := json.Unmarshal(output, &evidence); err != nil ||
+		evidence.Format != 1 || evidence.DeploymentID != plan.DeploymentID ||
+		evidence.Unit != state.ActivationUnit || evidence.UnitLoadState == "" {
+		return productionDispatchEvidence{}, errors.New("production activation dispatch evidence is invalid")
+	}
+	return evidence, nil
+}
+
+func productionDispatchHasEvidence(evidence productionDispatchEvidence) bool {
+	return evidence.UnitPresent || evidence.ManifestPresent || evidence.StatusPresent
+}
+
+func (runtime *productionReleaseRuntime) dispatchProductionActivation(ctx context.Context, plan productionReleasePlan, state *productionReleaseControllerState) error {
+	expectedUnit := productionActivationUnit(plan.DeploymentID)
+	if state.Phase == productionReleasePhaseActivationDispatched {
+		if state.ActivationUnit != expectedUnit || state.DispatchAttempts < 1 || state.DispatchAttempts > 2 {
+			return errors.New("persisted activation dispatch identity is incomplete")
+		}
+		evidence, err := runtime.remoteDispatchEvidence(ctx, plan, *state)
+		if err != nil {
+			return err
+		}
+		if productionDispatchHasEvidence(evidence) {
+			state.DispatchObserved = true
+			state.UpdatedUTC = utcSecond(runtime.now())
+			return writeProductionReleaseControllerState(plan, *state)
+		}
+		if state.DispatchObserved || state.DispatchAttempts >= 2 {
+			return errors.New("activation dispatch has no remote evidence and its single redispatch is exhausted")
+		}
+	}
+	for state.DispatchAttempts < 2 {
+		state.Phase = productionReleasePhaseActivationDispatched
+		state.ActivationUnit = expectedUnit
+		state.DispatchAttempts++
+		state.UpdatedUTC = utcSecond(runtime.now())
+		if err := writeProductionReleaseControllerState(plan, *state); err != nil {
+			return err
+		}
+		applyArgs := runtime.productionApplyArguments(plan, *state)
+		if _, err := runtime.ssh(ctx, plan.TargetAlias, 20*time.Minute, applyArgs...); err == nil {
+			state.DispatchObserved = true
+			state.UpdatedUTC = utcSecond(runtime.now())
+			return writeProductionReleaseControllerState(plan, *state)
+		} else {
+			evidence, reconcileErr := runtime.remoteDispatchEvidence(ctx, plan, *state)
+			if reconcileErr != nil {
+				return fmt.Errorf("production activation became transport-ambiguous and reconciliation failed: dispatch=%v reconcile=%w", err, reconcileErr)
+			}
+			if productionDispatchHasEvidence(evidence) {
+				state.DispatchObserved = true
+				state.UpdatedUTC = utcSecond(runtime.now())
+				if writeErr := writeProductionReleaseControllerState(plan, *state); writeErr != nil {
+					return writeErr
+				}
+				return nil
+			}
+			if state.DispatchAttempts >= 2 {
+				return fmt.Errorf("production activation failed before remote acceptance after the single safe redispatch: %w", err)
+			}
+		}
+	}
+	return errors.New("activation dispatch retry invariant failed")
+}
+
+func (runtime *productionReleaseRuntime) awaitRemoteReleaseStatus(ctx context.Context, plan productionReleasePlan, state *productionReleaseControllerState) (productionStatus, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, 20*time.Minute)
+	defer cancel()
+	for {
+		status, err := runtime.readRemoteReleaseStatus(waitCtx, plan, *state)
+		if err == nil {
+			return status, nil
+		}
+		evidence, reconcileErr := runtime.remoteDispatchEvidence(waitCtx, plan, *state)
+		if reconcileErr != nil {
+			return productionStatus{}, fmt.Errorf("observe production activation: status=%v evidence=%w", err, reconcileErr)
+		}
+		if !productionDispatchHasEvidence(evidence) {
+			return productionStatus{}, errors.New("accepted production activation lost its unit, manifest, and status evidence")
+		}
+		state.DispatchObserved = true
+		state.UpdatedUTC = utcSecond(runtime.now())
+		if writeErr := writeProductionReleaseControllerState(plan, *state); writeErr != nil {
+			return productionStatus{}, writeErr
+		}
+		if waitErr := runtime.waitForDispatchObservation(waitCtx, 2*time.Second); waitErr != nil {
+			return productionStatus{}, fmt.Errorf("wait for production activation status: %w", waitErr)
+		}
+	}
+}
+
+func (runtime *productionReleaseRuntime) waitForDispatchObservation(ctx context.Context, delay time.Duration) error {
+	if runtime.wait != nil {
+		return runtime.wait(ctx, delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (runtime *productionReleaseRuntime) readRemoteReleaseStatus(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) (productionStatus, error) {
@@ -762,6 +877,19 @@ func validateProductionReleaseControllerState(plan productionReleasePlan, planSH
 	if state.UpdatedUTC.IsZero() || state.UpdatedUTC.Location() != time.UTC || state.UpdatedUTC.Nanosecond() != 0 {
 		return errors.New("controller release state timestamp is invalid")
 	}
+	if state.DispatchAttempts < 0 || state.DispatchAttempts > 2 ||
+		(state.DispatchObserved && state.DispatchAttempts == 0) {
+		return errors.New("controller release state dispatch attempts are invalid")
+	}
+	if state.ActivationUnit != "" && state.ActivationUnit != productionActivationUnit(plan.DeploymentID) {
+		return errors.New("controller release state activation unit is invalid")
+	}
+	if (state.DispatchAttempts > 0) != (state.ActivationUnit != "") {
+		return errors.New("controller release state dispatch identity is incomplete")
+	}
+	if state.Phase == productionReleasePhaseActivationDispatched && state.DispatchAttempts == 0 {
+		return errors.New("controller release state activation phase lacks a dispatch attempt")
+	}
 	for _, path := range []string{state.TargetBackup, state.ControllerBackup, state.OffhostBackup} {
 		if path != "" && !filepath.IsAbs(path) {
 			return errors.New("controller release state contains a non-absolute backup path")
@@ -781,6 +909,8 @@ func releaseControllerResult(plan productionReleasePlan, state productionRelease
 		ControllerBackup: state.ControllerBackup,
 		OffhostBackup:    state.OffhostBackup,
 		RollbackTimer:    state.RollbackTimer,
+		ActivationUnit:   state.ActivationUnit,
+		DispatchAttempts: state.DispatchAttempts,
 		Workspace:        state.RemoteWorkspace,
 	}
 }

--- a/apps/api-go/internal/appcli/deploy_production_controller.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller.go
@@ -463,7 +463,7 @@ func (runtime *productionReleaseRuntime) awaitRemoteReleaseStatus(ctx context.Co
 	defer cancel()
 	for {
 		status, err := runtime.readRemoteReleaseStatus(waitCtx, plan, *state)
-		if err == nil && productionActivationStatusTerminal(status.Phase) {
+		if err == nil && productionActivationStatusTerminalForPlan(plan, status) {
 			return status, nil
 		}
 		if err == nil {
@@ -493,6 +493,13 @@ func (runtime *productionReleaseRuntime) awaitRemoteReleaseStatus(ctx context.Co
 			return productionStatus{}, fmt.Errorf("wait for production activation status: %w", waitErr)
 		}
 	}
+}
+
+func productionActivationStatusTerminalForPlan(plan productionReleasePlan, status productionStatus) bool {
+	if status.Phase == "AWAITING_CONFIRMATION" && !plan.ManualConfirm && status.AutoConfirm {
+		return false
+	}
+	return productionActivationStatusTerminal(status.Phase)
 }
 
 func productionActivationStatusTerminal(phase string) bool {

--- a/apps/api-go/internal/appcli/deploy_production_dispatch.go
+++ b/apps/api-go/internal/appcli/deploy_production_dispatch.go
@@ -1,0 +1,112 @@
+package appcli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+type productionDispatchEvidence struct {
+	Format          int    `json:"format"`
+	DeploymentID    string `json:"deployment_id"`
+	Unit            string `json:"unit"`
+	UnitLoadState   string `json:"unit_load_state"`
+	UnitPresent     bool   `json:"unit_present"`
+	ManifestPresent bool   `json:"manifest_present"`
+	StatusPresent   bool   `json:"status_present"`
+}
+
+func runProductionDispatchEvidence(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("deploy production dispatch-evidence", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	workspacePath := flags.String("workspace", "", "canonical target workspace")
+	unit := flags.String("unit", "", "exact activation unit")
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return ExitOK
+		}
+		return ExitUsage
+	}
+	if flags.NArg() != 0 || *workspacePath == "" || *unit == "" {
+		_, _ = fmt.Fprintln(stderr, "--workspace and --unit are required")
+		return ExitUsage
+	}
+	runtime := defaultProductionRuntime()
+	evidence, err := runtime.productionDispatchEvidence(context.Background(), *workspacePath, *unit)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s deploy production dispatch-evidence: %v\n", ProgramName, err)
+		return ExitError
+	}
+	encoded, err := json.Marshal(evidence)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "%s deploy production dispatch-evidence: encode result: %v\n", ProgramName, err)
+		return ExitError
+	}
+	_, _ = stdout.Write(append(encoded, '\n'))
+	return ExitOK
+}
+
+func (runtime *productionRuntime) productionDispatchEvidence(ctx context.Context, workspacePath, unit string) (productionDispatchEvidence, error) {
+	workspace, err := runtime.openWorkspace(workspacePath)
+	if err != nil {
+		return productionDispatchEvidence{}, err
+	}
+	expectedUnit := productionActivationUnit(workspace.id)
+	if unit != expectedUnit {
+		return productionDispatchEvidence{}, errors.New("activation unit does not match the workspace deployment")
+	}
+	manifestPresent, err := dispatchEvidenceFilePresent(workspace.manifestPath)
+	if err != nil {
+		return productionDispatchEvidence{}, fmt.Errorf("inspect activation manifest: %w", err)
+	}
+	statusPresent, err := dispatchEvidenceFilePresent(workspace.statusPath)
+	if err != nil {
+		return productionDispatchEvidence{}, fmt.Errorf("inspect activation status: %w", err)
+	}
+	output, err := runtime.runner.Run(ctx, productionCommand{
+		Name:    commandSystemctl,
+		Args:    []string{"show", "--property=LoadState", "--value", "--", unit},
+		Timeout: 30 * time.Second,
+		Env:     append(os.Environ(), "LC_ALL=C"),
+	})
+	if err != nil {
+		return productionDispatchEvidence{}, fmt.Errorf("inspect activation unit: %w", err)
+	}
+	loadState := strings.TrimSpace(string(output))
+	if loadState == "" || strings.ContainsAny(loadState, "\r\n\t ") {
+		return productionDispatchEvidence{}, errors.New("activation unit returned an invalid load state")
+	}
+	return productionDispatchEvidence{
+		Format:          1,
+		DeploymentID:    workspace.id,
+		Unit:            unit,
+		UnitLoadState:   loadState,
+		UnitPresent:     loadState != "not-found",
+		ManifestPresent: manifestPresent,
+		StatusPresent:   statusPresent,
+	}, nil
+}
+
+func dispatchEvidenceFilePresent(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return false, errors.New("evidence path is not a regular file")
+	}
+	return true, nil
+}
+
+func productionActivationUnit(deploymentID string) string {
+	return "lmm-api-deploy-" + deploymentID + ".service"
+}

--- a/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
@@ -4,11 +4,33 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
+
+type productionDispatchStatusRunner struct {
+	phases []string
+	calls  int
+}
+
+func (runner *productionDispatchStatusRunner) Run(_ context.Context, command productionCommand) ([]byte, error) {
+	if command.Name != commandSSH || len(command.Args) < 7 {
+		return nil, errors.New("unexpected status test command")
+	}
+	remote := command.Args[3:]
+	if len(remote) >= 4 && remote[1] == "deploy" && remote[2] == "production" && remote[3] == "status" {
+		index := runner.calls
+		if index >= len(runner.phases) {
+			index = len(runner.phases) - 1
+		}
+		runner.calls++
+		return json.Marshal(productionStatus{Phase: runner.phases[index]})
+	}
+	return nil, errors.New("unexpected status test remote command")
+}
 
 type productionDispatchFaultRunner struct {
 	evidence       productionDispatchEvidence
@@ -35,6 +57,72 @@ func (runner *productionDispatchFaultRunner) Run(_ context.Context, command prod
 		return append(encoded, '\n'), err
 	}
 	return nil, errors.New("unexpected remote dispatch test command")
+}
+
+func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
+	const deploymentID = "prod-20260824T115800Z-status-fixture"
+	controllerWorkspace := t.TempDir()
+	plan := productionReleasePlan{
+		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
+		ControllerWorkspace: controllerWorkspace, TargetAlias: productionTargetAlias,
+		ProbeBinary: productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, "lmm-api")},
+	}
+	state := productionReleaseControllerState{
+		Format: productionReleaseStateFormat, DeploymentID: deploymentID,
+		PlanSHA256: strings.Repeat("c", 64), Phase: productionReleasePhaseActivationDispatched,
+		RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, deploymentID),
+		ActivationUnit:  productionActivationUnit(deploymentID), DispatchAttempts: 1,
+		UpdatedUTC: time.Date(2026, 8, 24, 11, 58, 0, 0, time.UTC),
+	}
+	runner := &productionDispatchStatusRunner{phases: []string{"PREPARING", "DEPLOYING_GO", "AWAITING_CONFIRMATION"}}
+	waits := 0
+	runtime := &productionReleaseRuntime{
+		runner: runner,
+		now:    func() time.Time { return time.Date(2026, 8, 24, 11, 59, 0, 0, time.UTC) },
+		wait:   func(context.Context, time.Duration) error { waits++; return nil },
+	}
+	status, err := runtime.awaitRemoteReleaseStatus(context.Background(), plan, &state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Phase != "AWAITING_CONFIRMATION" || runner.calls != 3 || waits != 2 {
+		t.Fatalf("status=%#v calls=%d waits=%d", status, runner.calls, waits)
+	}
+}
+
+func TestLoadProductionReleaseControllerStateMigratesLegacyDispatch(t *testing.T) {
+	const deploymentID = "prod-20260824T115900Z-legacy-dispatch"
+	controllerWorkspace := t.TempDir()
+	planSHA256 := strings.Repeat("b", 64)
+	plan := productionReleasePlan{
+		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
+		ControllerWorkspace: controllerWorkspace,
+	}
+	legacy := productionReleaseControllerState{
+		Format: 1, DeploymentID: deploymentID, PlanSHA256: planSHA256,
+		Phase:           productionReleasePhaseActivationDispatched,
+		RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, deploymentID),
+		UpdatedUTC:      time.Date(2026, 8, 24, 11, 59, 0, 0, time.UTC),
+	}
+	raw, err := canonicalProductionReleaseControllerState(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(controllerWorkspace, productionReleaseStateFilename), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	migrated, exists, err := loadProductionReleaseControllerState(plan, planSHA256)
+	if err != nil || !exists {
+		t.Fatalf("load legacy state: exists=%t err=%v", exists, err)
+	}
+	if migrated.Format != productionReleaseStateFormat || migrated.DispatchAttempts != 1 ||
+		migrated.ActivationUnit != productionActivationUnit(deploymentID) || migrated.DispatchObserved {
+		t.Fatalf("migrated state=%#v", migrated)
+	}
+	persisted, err := os.ReadFile(filepath.Join(controllerWorkspace, productionReleaseStateFilename))
+	if err != nil || !strings.Contains(string(persisted), `"dispatch_attempts": 1`) {
+		t.Fatalf("persisted migrated state=%s err=%v", persisted, err)
+	}
 }
 
 func TestProductionActivationDispatchFaultReconciliation(t *testing.T) {

--- a/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
@@ -1,0 +1,105 @@
+package appcli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type productionDispatchFaultRunner struct {
+	evidence       productionDispatchEvidence
+	dispatchCalls  int
+	evidenceCalls  int
+	secondAccepted bool
+}
+
+func (runner *productionDispatchFaultRunner) Run(_ context.Context, command productionCommand) ([]byte, error) {
+	if command.Name != commandSSH || len(command.Args) < 4 {
+		return nil, errors.New("unexpected dispatch test command")
+	}
+	remote := command.Args[3:]
+	if remote[0] == "systemd-run" {
+		runner.dispatchCalls++
+		if runner.dispatchCalls == 1 || !runner.secondAccepted {
+			return nil, errors.New("injected SSH transport failure")
+		}
+		return []byte("accepted\n"), nil
+	}
+	if len(remote) >= 4 && remote[1] == "deploy" && remote[2] == "production" && remote[3] == "dispatch-evidence" {
+		runner.evidenceCalls++
+		encoded, err := json.Marshal(runner.evidence)
+		return append(encoded, '\n'), err
+	}
+	return nil, errors.New("unexpected remote dispatch test command")
+}
+
+func TestProductionActivationDispatchFaultReconciliation(t *testing.T) {
+	const deploymentID = "prod-20260824T120000Z-dispatch-fixture"
+	unit := productionActivationUnit(deploymentID)
+	cases := []struct {
+		name           string
+		evidence       productionDispatchEvidence
+		secondAccepted bool
+		wantDispatches int
+		wantObserved   bool
+		wantAttempts   int
+	}{
+		{
+			name: "failure before SSH acceptance redispatches exactly once",
+			evidence: productionDispatchEvidence{
+				Format: 1, DeploymentID: deploymentID, Unit: unit, UnitLoadState: "not-found",
+			},
+			secondAccepted: true, wantDispatches: 2, wantObserved: true, wantAttempts: 2,
+		},
+		{
+			name: "failure after unit creation only observes existing job",
+			evidence: productionDispatchEvidence{
+				Format: 1, DeploymentID: deploymentID, Unit: unit, UnitLoadState: "loaded", UnitPresent: true,
+			},
+			wantDispatches: 1, wantObserved: true, wantAttempts: 1,
+		},
+		{
+			name: "result transport failure with status only observes existing job",
+			evidence: productionDispatchEvidence{
+				Format: 1, DeploymentID: deploymentID, Unit: unit, UnitLoadState: "not-found", StatusPresent: true,
+			},
+			wantDispatches: 1, wantObserved: true, wantAttempts: 1,
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			controllerWorkspace := t.TempDir()
+			planSHA256 := strings.Repeat("a", 64)
+			plan := productionReleasePlan{
+				Format: productionReleasePlanFormat, DeploymentID: deploymentID,
+				ControllerWorkspace: controllerWorkspace, TargetAlias: productionTargetAlias,
+				ProbeBinary: productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, "lmm-api")},
+			}
+			state := productionReleaseControllerState{
+				Format: productionReleaseStateFormat, DeploymentID: deploymentID,
+				PlanSHA256: planSHA256, Phase: productionReleasePhaseStaged,
+				RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, deploymentID),
+				UpdatedUTC:      time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC),
+			}
+			runner := &productionDispatchFaultRunner{evidence: test.evidence, secondAccepted: test.secondAccepted}
+			runtime := &productionReleaseRuntime{runner: runner, now: func() time.Time { return time.Date(2026, 8, 24, 12, 1, 0, 0, time.UTC) }}
+			if err := runtime.dispatchProductionActivation(context.Background(), plan, &state); err != nil {
+				t.Fatal(err)
+			}
+			if runner.dispatchCalls != test.wantDispatches || state.DispatchAttempts != test.wantAttempts || state.DispatchObserved != test.wantObserved {
+				t.Fatalf("dispatches=%d attempts=%d observed=%t state=%#v", runner.dispatchCalls, state.DispatchAttempts, state.DispatchObserved, state)
+			}
+			persisted, exists, err := loadProductionReleaseControllerState(plan, planSHA256)
+			if err != nil || !exists {
+				t.Fatalf("load persisted dispatch state: exists=%t err=%v", exists, err)
+			}
+			if persisted.ActivationUnit != unit || persisted.DispatchAttempts != test.wantAttempts || persisted.DispatchObserved != test.wantObserved {
+				t.Fatalf("persisted state=%#v", persisted)
+			}
+		})
+	}
+}

--- a/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
@@ -34,8 +34,10 @@ func (runner *productionDispatchStatusRunner) Run(_ context.Context, command pro
 
 type productionDispatchFaultRunner struct {
 	evidence       productionDispatchEvidence
+	statusPhase    string
 	dispatchCalls  int
 	evidenceCalls  int
+	statusCalls    int
 	secondAccepted bool
 }
 
@@ -55,6 +57,10 @@ func (runner *productionDispatchFaultRunner) Run(_ context.Context, command prod
 		runner.evidenceCalls++
 		encoded, err := json.Marshal(runner.evidence)
 		return append(encoded, '\n'), err
+	}
+	if len(remote) >= 4 && remote[1] == "deploy" && remote[2] == "production" && remote[3] == "status" && runner.statusPhase != "" {
+		runner.statusCalls++
+		return json.Marshal(productionStatus{Phase: runner.statusPhase})
 	}
 	return nil, errors.New("unexpected remote dispatch test command")
 }
@@ -87,6 +93,81 @@ func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
 	}
 	if status.Phase != "AWAITING_CONFIRMATION" || runner.calls != 3 || waits != 2 {
 		t.Fatalf("status=%#v calls=%d waits=%d", status, runner.calls, waits)
+	}
+}
+
+func TestTerminalRemotePhasesAreValidControllerStatePhases(t *testing.T) {
+	const deploymentID = "prod-20260824T115825Z-phase-contract"
+	planSHA256 := strings.Repeat("e", 64)
+	plan := productionReleasePlan{
+		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
+		ControllerWorkspace: t.TempDir(),
+	}
+	for _, phase := range []string{"AWAITING_CONFIRMATION", "CONFIRMED", "ROLLED_BACK", "FAILED_PREARM", "ROLLBACK_FAILED", "ABORTED"} {
+		t.Run(phase, func(t *testing.T) {
+			if !productionActivationStatusTerminal(phase) {
+				t.Fatalf("terminal phase %s is not recognized", phase)
+			}
+			state := productionReleaseControllerState{
+				Format: productionReleaseStateFormat, DeploymentID: deploymentID,
+				PlanSHA256: planSHA256, Phase: phase,
+				RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, deploymentID),
+				UpdatedUTC:      time.Date(2026, 8, 24, 11, 58, 25, 0, time.UTC),
+			}
+			if err := validateProductionReleaseControllerState(plan, planSHA256, state); err != nil {
+				t.Fatalf("terminal phase %s violates the persisted phase contract: %v", phase, err)
+			}
+		})
+	}
+}
+
+func TestAmbiguousDispatchRemoteAbortedPersistsAcrossStatusAndReload(t *testing.T) {
+	const deploymentID = "prod-20260824T115850Z-aborted-fixture"
+	controllerWorkspace := t.TempDir()
+	planSHA256 := strings.Repeat("d", 64)
+	plan := productionReleasePlan{
+		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
+		ControllerWorkspace: controllerWorkspace, TargetAlias: productionTargetAlias,
+		ExpectedVersion: "0.1.59",
+		ProbeBinary:     productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, "lmm-api")},
+	}
+	state := productionReleaseControllerState{
+		Format: productionReleaseStateFormat, DeploymentID: deploymentID,
+		PlanSHA256: planSHA256, Phase: productionReleasePhaseStaged,
+		RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, deploymentID),
+		UpdatedUTC:      time.Date(2026, 8, 24, 11, 58, 30, 0, time.UTC),
+	}
+	runner := &productionDispatchFaultRunner{
+		evidence: productionDispatchEvidence{
+			Format: 1, DeploymentID: deploymentID, Unit: productionActivationUnit(deploymentID),
+			UnitLoadState: "not-found", StatusPresent: true,
+		},
+		statusPhase: "ABORTED",
+	}
+	now := time.Date(2026, 8, 24, 11, 58, 31, 0, time.UTC)
+	runtime := &productionReleaseRuntime{runner: runner, now: func() time.Time { return now }}
+	if err := runtime.dispatchProductionActivation(context.Background(), plan, &state); err != nil {
+		t.Fatal(err)
+	}
+	status, err := runtime.awaitRemoteReleaseStatus(context.Background(), plan, &state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Phase != "ABORTED" || runner.dispatchCalls != 1 || runner.statusCalls != 1 {
+		t.Fatalf("status=%#v dispatches=%d status_calls=%d", status, runner.dispatchCalls, runner.statusCalls)
+	}
+	if err := persistRemoteReleaseControllerStatus(plan, &state, status, now); err != nil {
+		t.Fatal(err)
+	}
+	if result := releaseControllerResult(plan, state); result.Status != "ABORTED" {
+		t.Fatalf("controller result=%#v", result)
+	}
+	reloaded, exists, err := loadProductionReleaseControllerState(plan, planSHA256)
+	if err != nil || !exists {
+		t.Fatalf("reload aborted state: exists=%t err=%v", exists, err)
+	}
+	if reloaded.Phase != "ABORTED" || reloaded.DispatchAttempts != 1 || !reloaded.DispatchObserved {
+		t.Fatalf("reloaded state=%#v", reloaded)
 	}
 }
 

--- a/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 type productionDispatchStatusRunner struct {
-	phases []string
-	calls  int
+	statuses []productionStatus
+	calls    int
 }
 
 func (runner *productionDispatchStatusRunner) Run(_ context.Context, command productionCommand) ([]byte, error) {
@@ -23,11 +23,11 @@ func (runner *productionDispatchStatusRunner) Run(_ context.Context, command pro
 	remote := command.Args[3:]
 	if len(remote) >= 4 && remote[1] == "deploy" && remote[2] == "production" && remote[3] == "status" {
 		index := runner.calls
-		if index >= len(runner.phases) {
-			index = len(runner.phases) - 1
+		if index >= len(runner.statuses) {
+			index = len(runner.statuses) - 1
 		}
 		runner.calls++
-		return json.Marshal(productionStatus{Phase: runner.phases[index]})
+		return json.Marshal(runner.statuses[index])
 	}
 	return nil, errors.New("unexpected status test remote command")
 }
@@ -71,7 +71,8 @@ func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
 	plan := productionReleasePlan{
 		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
 		ControllerWorkspace: controllerWorkspace, TargetAlias: productionTargetAlias,
-		ProbeBinary: productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, "lmm-api")},
+		ProbeBinary:   productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, "lmm-api")},
+		ManualConfirm: true,
 	}
 	state := productionReleaseControllerState{
 		Format: productionReleaseStateFormat, DeploymentID: deploymentID,
@@ -80,7 +81,11 @@ func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
 		ActivationUnit:  productionActivationUnit(deploymentID), DispatchAttempts: 1,
 		UpdatedUTC: time.Date(2026, 8, 24, 11, 58, 0, 0, time.UTC),
 	}
-	runner := &productionDispatchStatusRunner{phases: []string{"PREPARING", "DEPLOYING_GO", "AWAITING_CONFIRMATION"}}
+	runner := &productionDispatchStatusRunner{statuses: []productionStatus{
+		{Phase: "PREPARING"},
+		{Phase: "DEPLOYING_GO"},
+		{Phase: "AWAITING_CONFIRMATION"},
+	}}
 	waits := 0
 	runtime := &productionReleaseRuntime{
 		runner: runner,
@@ -92,6 +97,42 @@ func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
 		t.Fatal(err)
 	}
 	if status.Phase != "AWAITING_CONFIRMATION" || runner.calls != 3 || waits != 2 {
+		t.Fatalf("status=%#v calls=%d waits=%d", status, runner.calls, waits)
+	}
+}
+
+func TestAwaitRemoteReleaseStatusContinuesAutoConfirmObservation(t *testing.T) {
+	const deploymentID = "prod-20260824T115815Z-auto-confirm-fixture"
+	controllerWorkspace := t.TempDir()
+	plan := productionReleasePlan{
+		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
+		ControllerWorkspace: controllerWorkspace, TargetAlias: productionTargetAlias,
+		ProbeBinary:   productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, "lmm-api")},
+		ManualConfirm: false,
+	}
+	state := productionReleaseControllerState{
+		Format: productionReleaseStateFormat, DeploymentID: deploymentID,
+		PlanSHA256: strings.Repeat("f", 64), Phase: productionReleasePhaseActivationDispatched,
+		RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, deploymentID),
+		ActivationUnit:  productionActivationUnit(deploymentID), DispatchAttempts: 1,
+		UpdatedUTC: time.Date(2026, 8, 24, 11, 58, 15, 0, time.UTC),
+	}
+	runner := &productionDispatchStatusRunner{statuses: []productionStatus{
+		{Phase: "AWAITING_CONFIRMATION", AutoConfirm: true},
+		{Phase: "AWAITING_CONFIRMATION", AutoConfirm: true},
+		{Phase: "CONFIRMED", AutoConfirm: true},
+	}}
+	waits := 0
+	runtime := &productionReleaseRuntime{
+		runner: runner,
+		now:    func() time.Time { return time.Date(2026, 8, 24, 11, 59, 15, 0, time.UTC) },
+		wait:   func(context.Context, time.Duration) error { waits++; return nil },
+	}
+	status, err := runtime.awaitRemoteReleaseStatus(context.Background(), plan, &state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Phase != "CONFIRMED" || runner.calls != 3 || waits != 2 {
 		t.Fatalf("status=%#v calls=%d waits=%d", status, runner.calls, waits)
 	}
 }

--- a/apps/api-go/internal/appcli/deploy_production_release.go
+++ b/apps/api-go/internal/appcli/deploy_production_release.go
@@ -115,6 +115,7 @@ type productionReleasePlanResult struct {
 type productionReleaseRuntime struct {
 	runner productionCommandRunner
 	now    func() time.Time
+	wait   func(context.Context, time.Duration) error
 }
 
 func runProductionReleasePlan(args []string, stdout, stderr io.Writer) int {

--- a/apps/api-go/internal/appcli/deploy_production_release.go
+++ b/apps/api-go/internal/appcli/deploy_production_release.go
@@ -24,7 +24,7 @@ const (
 	productionOffhostExpectedHost     = "archczy"
 	productionOffhostRoot             = "/home/arch/.local/state/lmm-api-production-backups"
 	productionReleasePlanFormat       = 1
-	productionReleaseStateFormat      = 1
+	productionReleaseStateFormat      = 2
 	productionReleasePlanFilename     = "release-plan.json"
 	productionReleasePlanHashFilename = "release-plan.sha256"
 	productionReleaseStateFilename    = "release-state.json"

--- a/apps/api-go/relay/channel/openai/adaptor.go
+++ b/apps/api-go/relay/channel/openai/adaptor.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
@@ -502,6 +501,12 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 			// Process all image files
 			for i, fileHeader := range imageFiles {
+				// Determine MIME type from a bounded byte prefix before forwarding.
+				mimeType, err := relaycommon.DetectSupportedImageUploadMediaType(fileHeader)
+				if err != nil {
+					return nil, err
+				}
+
 				file, err := fileHeader.Open()
 				if err != nil {
 					return nil, fmt.Errorf("failed to open image file %d: %w", i, err)
@@ -512,9 +517,6 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 				if len(imageFiles) > 1 {
 					fieldName = "image[]"
 				}
-
-				// Determine MIME type based on file extension
-				mimeType := detectImageMimeType(fileHeader.Filename)
 
 				// Create a form file with the appropriate content type
 				h := make(textproto.MIMEHeader)
@@ -536,14 +538,17 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 			// Handle mask file if present
 			if maskFiles, exists := mf.File["mask"]; exists && len(maskFiles) > 0 {
+				// Determine the mask MIME type from bytes rather than its filename.
+				mimeType, err := relaycommon.DetectSupportedImageUploadMediaType(maskFiles[0])
+				if err != nil {
+					return nil, err
+				}
+
 				maskFile, err := maskFiles[0].Open()
 				if err != nil {
 					return nil, errors.New("failed to open mask file")
 				}
 				// 复制完立即关闭，避免在循环内使用 defer 占用资源
-
-				// Determine MIME type for mask file
-				mimeType := detectImageMimeType(maskFiles[0].Filename)
 
 				// Create a form file with the appropriate content type
 				h := make(textproto.MIMEHeader)
@@ -579,26 +584,6 @@ func isJSONRequest(c *gin.Context) bool {
 		return false
 	}
 	return strings.HasPrefix(c.Request.Header.Get("Content-Type"), "application/json")
-}
-
-// detectImageMimeType determines the MIME type based on the file extension
-func detectImageMimeType(filename string) string {
-	ext := strings.ToLower(filepath.Ext(filename))
-	switch ext {
-	case ".jpg", ".jpeg":
-		return "image/jpeg"
-	case ".png":
-		return "image/png"
-	case ".webp":
-		return "image/webp"
-	default:
-		// Try to detect from extension if possible
-		if strings.HasPrefix(ext, ".jp") {
-			return "image/jpeg"
-		}
-		// Default to png as a fallback
-		return "image/png"
-	}
 }
 
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {

--- a/apps/api-go/relay/channel/openai/adaptor_mime_test.go
+++ b/apps/api-go/relay/channel/openai/adaptor_mime_test.go
@@ -1,0 +1,70 @@
+package openai
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+var testPNGBytes = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}
+var testHEICBytes = []byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'}
+
+func TestConvertImageRequestRejectsUnsupportedMaskContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	imagePart, err := writer.CreateFormFile("image", "input.png")
+	require.NoError(t, err)
+	_, err = imagePart.Write(testPNGBytes)
+	require.NoError(t, err)
+	maskPart, err := writer.CreateFormFile("mask", "mask.png")
+	require.NoError(t, err)
+	_, err = maskPart.Write(testHEICBytes)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	require.NoError(t, c.Request.ParseMultipartForm(32<<20))
+
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeImagesEdits}
+	converted, err := (&Adaptor{}).ConvertImageRequest(c, info, dto.ImageRequest{Model: "gpt-image-1"})
+
+	require.Nil(t, converted)
+	require.EqualError(t, err, `unsupported image content type "application/octet-stream"; supported formats: JPEG, PNG, WebP`)
+}
+
+func TestConvertImageRequestRejectsUnsupportedImageContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	part, err := writer.CreateFormFile("image", "input.png")
+	require.NoError(t, err)
+	_, err = part.Write(testHEICBytes)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	require.NoError(t, c.Request.ParseMultipartForm(32<<20))
+
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeImagesEdits}
+	converted, err := (&Adaptor{}).ConvertImageRequest(c, info, dto.ImageRequest{Model: "gpt-image-1"})
+
+	require.Nil(t, converted)
+	require.EqualError(t, err, `unsupported image content type "application/octet-stream"; supported formats: JPEG, PNG, WebP`)
+}

--- a/apps/api-go/relay/channel/openai/image_edit_test.go
+++ b/apps/api-go/relay/channel/openai/image_edit_test.go
@@ -32,7 +32,7 @@ func TestConvertImageEditRequestMultipart(t *testing.T) {
 		require.NoError(t, writer.WriteField("partial_images", "3"))
 		part, err := writer.CreateFormFile("image", "input.png")
 		require.NoError(t, err)
-		_, err = part.Write([]byte("fake image"))
+		_, err = part.Write(testPNGBytes)
 		require.NoError(t, err)
 		require.NoError(t, writer.Close())
 
@@ -66,13 +66,14 @@ func TestConvertImageEditRequestMultipart(t *testing.T) {
 		require.Equal(t, "true", replayedRequest.PostForm.Get("stream"))
 		require.Equal(t, "3", replayedRequest.PostForm.Get("partial_images"))
 		require.Len(t, replayedRequest.MultipartForm.File["image"], 1)
+		require.Equal(t, "image/png", replayedRequest.MultipartForm.File["image"][0].Header.Get("Content-Type"))
 
 		file, err := replayedRequest.MultipartForm.File["image"][0].Open()
 		require.NoError(t, err)
 		defer file.Close()
 		fileBytes, err := io.ReadAll(file)
 		require.NoError(t, err)
-		require.Equal(t, []byte("fake image"), fileBytes)
+		require.Equal(t, testPNGBytes, fileBytes)
 	}
 
 	t.Run("with pre-parsed form", func(t *testing.T) {

--- a/apps/api-go/relay/common/image_upload.go
+++ b/apps/api-go/relay/common/image_upload.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+const imageUploadSignatureLimit = 512
+
+// DetectSupportedImageUploadMediaType identifies an image from a bounded byte
+// prefix. Filenames and client-provided Content-Type values are not trusted.
+func DetectSupportedImageUploadMediaType(fileHeader *multipart.FileHeader) (string, error) {
+	if fileHeader == nil {
+		return "", errors.New("image file is missing")
+	}
+	file, err := fileHeader.Open()
+	if err != nil {
+		return "", fmt.Errorf("open image file: %w", err)
+	}
+	defer file.Close()
+
+	signature := make([]byte, imageUploadSignatureLimit)
+	read, err := io.ReadFull(file, signature)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return "", fmt.Errorf("read image signature: %w", err)
+	}
+	if read == 0 {
+		return "", errors.New("image file is empty")
+	}
+
+	mediaType := http.DetectContentType(signature[:read])
+	switch mediaType {
+	case "image/jpeg", "image/png", "image/webp":
+		return mediaType, nil
+	default:
+		return "", fmt.Errorf("unsupported image content type %q; supported formats: JPEG, PNG, WebP", mediaType)
+	}
+}
+
+// ValidateImageEditMultipartFiles validates every image or mask that the
+// OpenAI-compatible image-edit adaptor can forward.
+func ValidateImageEditMultipartFiles(form *multipart.Form) error {
+	if form == nil {
+		return errors.New("multipart image edit form is missing")
+	}
+
+	imageFiles := append([]*multipart.FileHeader(nil), form.File["image"]...)
+	imageFiles = append(imageFiles, form.File["image[]"]...)
+	imageArrayFields := make([]string, 0)
+	for field := range form.File {
+		if strings.HasPrefix(field, "image[") && field != "image[]" {
+			imageArrayFields = append(imageArrayFields, field)
+		}
+	}
+	sort.Strings(imageArrayFields)
+	for _, field := range imageArrayFields {
+		imageFiles = append(imageFiles, form.File[field]...)
+	}
+	if len(imageFiles) == 0 {
+		return errors.New("image file is required")
+	}
+	for index, fileHeader := range imageFiles {
+		if _, err := DetectSupportedImageUploadMediaType(fileHeader); err != nil {
+			return fmt.Errorf("image file %d: %w", index+1, err)
+		}
+	}
+	for index, fileHeader := range form.File["mask"] {
+		if _, err := DetectSupportedImageUploadMediaType(fileHeader); err != nil {
+			return fmt.Errorf("mask file %d: %w", index+1, err)
+		}
+	}
+	return nil
+}

--- a/apps/api-go/relay/common/image_upload_test.go
+++ b/apps/api-go/relay/common/image_upload_test.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var imageUploadPNG = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}
+var imageUploadJPEG = []byte{0xff, 0xd8, 0xff, 0xe0, 0, 0x10, 'J', 'F', 'I', 'F'}
+var imageUploadWebP = []byte{'R', 'I', 'F', 'F', 4, 0, 0, 0, 'W', 'E', 'B', 'P', 'V', 'P', '8', ' '}
+var imageUploadHEIC = []byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'}
+
+func imageUploadForm(t *testing.T, files map[string][]struct {
+	name string
+	data []byte
+}) *multipart.Form {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for field, entries := range files {
+		for _, entry := range entries {
+			part, err := writer.CreateFormFile(field, entry.name)
+			require.NoError(t, err)
+			_, err = part.Write(entry.data)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, writer.Close())
+	request := httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	require.NoError(t, request.ParseMultipartForm(1<<20))
+	t.Cleanup(func() { _ = request.MultipartForm.RemoveAll() })
+	return request.MultipartForm
+}
+
+func TestDetectSupportedImageUploadMediaTypeUsesBytesNotFilename(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		filename  string
+		content   []byte
+		mediaType string
+		wantError string
+	}{
+		{name: "extensionless PNG", filename: "blob", content: imageUploadPNG, mediaType: "image/png"},
+		{name: "JPEG with wrong extension", filename: "image.heic", content: imageUploadJPEG, mediaType: "image/jpeg"},
+		{name: "WebP uppercase", filename: "IMAGE.WEBP", content: imageUploadWebP, mediaType: "image/webp"},
+		{name: "fake PNG", filename: "image.png", content: []byte("not an image"), wantError: "unsupported image content type"},
+		{name: "HEIC named PNG", filename: "image.png", content: imageUploadHEIC, wantError: "unsupported image content type"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			form := imageUploadForm(t, map[string][]struct {
+				name string
+				data []byte
+			}{"image": {{name: test.filename, data: test.content}}})
+			mediaType, err := DetectSupportedImageUploadMediaType(form.File["image"][0])
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				require.Empty(t, mediaType)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.mediaType, mediaType)
+		})
+	}
+}
+
+func TestValidateImageEditMultipartFilesCoversImageArraysAndMask(t *testing.T) {
+	valid := imageUploadForm(t, map[string][]struct {
+		name string
+		data []byte
+	}{
+		"image":   {{name: "blob", data: imageUploadPNG}},
+		"image[]": {{name: "second.bin", data: imageUploadJPEG}},
+		"mask":    {{name: "mask.dat", data: imageUploadWebP}},
+	})
+	require.NoError(t, ValidateImageEditMultipartFiles(valid))
+
+	for _, test := range []struct {
+		name  string
+		files map[string][]struct {
+			name string
+			data []byte
+		}
+		wantError string
+	}{
+		{name: "missing image", files: map[string][]struct {
+			name string
+			data []byte
+		}{"mask": {{name: "mask.png", data: imageUploadPNG}}}, wantError: "image file is required"},
+		{name: "image array HEIC", files: map[string][]struct {
+			name string
+			data []byte
+		}{"image[]": {{name: "blob", data: imageUploadHEIC}}}, wantError: "image file 1"},
+		{name: "mask HEIC", files: map[string][]struct {
+			name string
+			data []byte
+		}{
+			"image": {{name: "image.png", data: imageUploadPNG}},
+			"mask":  {{name: "mask.png", data: imageUploadHEIC}},
+		}, wantError: "mask file 1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.ErrorContains(t, ValidateImageEditMultipartFiles(imageUploadForm(t, test.files)), test.wantError)
+		})
+	}
+}

--- a/apps/api-go/relay/helper/image_edit_validation.go
+++ b/apps/api-go/relay/helper/image_edit_validation.go
@@ -1,0 +1,52 @@
+package helper
+
+import (
+	"errors"
+	"mime"
+	"net/http"
+	"strings"
+
+	basecommon "github.com/LIghtJUNction/api.lmm.best/common"
+	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/gin-gonic/gin"
+)
+
+const imageEditFilesValidatedKey = "lmm_image_edit_files_validated"
+
+// ValidateOpenAIImageEditMultipart validates files independently of channel
+// selection and pass-through settings. A successful validation is reusable on
+// retries of the same replayable request body.
+func ValidateOpenAIImageEditMultipart(c *gin.Context) *types.NewAPIError {
+	if c == nil || c.Request == nil || c.GetBool(imageEditFilesValidatedKey) {
+		return nil
+	}
+	rawContentType := c.Request.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(rawContentType)
+	if err != nil {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(rawContentType)), "multipart/form-data") {
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		return nil
+	}
+	if mediaType != "multipart/form-data" {
+		return nil
+	}
+
+	form := c.Request.MultipartForm
+	if form == nil {
+		form, err = basecommon.ParseMultipartFormReusable(c)
+		if err != nil {
+			if basecommon.IsRequestBodyTooLargeError(err) || errors.Is(err, basecommon.ErrRequestBodyTooLarge) {
+				return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusRequestEntityTooLarge, types.ErrOptionWithSkipRetry())
+			}
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		c.Request.MultipartForm = form
+	}
+	if err := relaycommon.ValidateImageEditMultipartFiles(form); err != nil {
+		return types.NewErrorWithStatusCode(err, types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+	c.Set(imageEditFilesValidatedKey, true)
+	return nil
+}

--- a/apps/api-go/relay/helper/image_edit_validation_test.go
+++ b/apps/api-go/relay/helper/image_edit_validation_test.go
@@ -1,0 +1,85 @@
+package helper
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	basecommon "github.com/LIghtJUNction/api.lmm.best/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/LIghtJUNction/api.lmm.best/setting/model_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func imageValidationContext(t *testing.T, field, filename string, content []byte, validImage bool) *gin.Context {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	if validImage && field != "image" && field != "image[]" {
+		image, err := writer.CreateFormFile("image", "blob")
+		require.NoError(t, err)
+		_, err = image.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0})
+		require.NoError(t, err)
+	}
+	part, err := writer.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	context.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	t.Cleanup(func() { basecommon.CleanupBodyStorage(context) })
+	return context
+}
+
+func requireInvalidImageAPIError(t *testing.T, err error) {
+	t.Helper()
+	var apiErr *types.NewAPIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	require.Equal(t, types.ErrorCodeInvalidRequest, apiErr.GetErrorCode())
+	require.True(t, types.IsSkipRetryError(apiErr))
+}
+
+func TestImageEditValidationRejectsEveryForwardedFileFieldBeforeRelay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	heic := []byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'}
+	originalPassThrough := model_setting.GetGlobalSettings().PassThroughRequestEnabled
+	t.Cleanup(func() { model_setting.GetGlobalSettings().PassThroughRequestEnabled = originalPassThrough })
+
+	for _, passThrough := range []bool{false, true} {
+		model_setting.GetGlobalSettings().PassThroughRequestEnabled = passThrough
+		for _, test := range []struct {
+			field      string
+			validImage bool
+		}{
+			{field: "image"},
+			{field: "image[]"},
+			{field: "mask", validImage: true},
+		} {
+			t.Run(test.field+"/pass-through="+map[bool]string{false: "off", true: "on"}[passThrough], func(t *testing.T) {
+				context := imageValidationContext(t, test.field, "image.png", heic, test.validImage)
+				_, err := GetAndValidOpenAIImageRequest(context, relayconstant.RelayModeImagesEdits)
+				requireInvalidImageAPIError(t, err)
+				require.False(t, context.GetBool(imageEditFilesValidatedKey))
+			})
+		}
+	}
+}
+
+func TestImageEditValidationAcceptsExtensionlessPNGAndCachesSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context := imageValidationContext(t, "image", "blob", []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}, false)
+
+	_, err := GetAndValidOpenAIImageRequest(context, relayconstant.RelayModeImagesEdits)
+	require.NoError(t, err)
+	require.True(t, context.GetBool(imageEditFilesValidatedKey))
+	require.Nil(t, ValidateOpenAIImageEditMultipart(context))
+}

--- a/apps/api-go/relay/helper/openai_image_request_test.go
+++ b/apps/api-go/relay/helper/openai_image_request_test.go
@@ -32,7 +32,7 @@ func TestGetAndValidOpenAIImageRequestMultipartStream(t *testing.T) {
 		if withImage {
 			part, err := writer.CreateFormFile("image", "input.png")
 			require.NoError(t, err)
-			_, err = part.Write([]byte("fake image"))
+			_, err = part.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0})
 			require.NoError(t, err)
 		}
 		require.NoError(t, writer.Close())

--- a/apps/api-go/relay/helper/valid_request.go
+++ b/apps/api-go/relay/helper/valid_request.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -184,13 +185,16 @@ func GetAndValidOpenAIImageRequest(c *gin.Context, relayMode int) (*dto.ImageReq
 
 	switch relayMode {
 	case relayconstant.RelayModeImagesEdits:
-		if strings.Contains(c.Request.Header.Get("Content-Type"), "multipart/form-data") {
+		if strings.Contains(strings.ToLower(c.Request.Header.Get("Content-Type")), "multipart/form-data") {
 			form, err := common.ParseMultipartFormReusable(c)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse image edit form request: %w", err)
+				if common.IsRequestBodyTooLargeError(err) || errors.Is(err, common.ErrRequestBodyTooLarge) {
+					return nil, types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusRequestEntityTooLarge, types.ErrOptionWithSkipRetry())
+				}
+				return nil, types.NewErrorWithStatusCode(fmt.Errorf("failed to parse image edit form request: %w", err), types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
 			}
-			formData := url.Values(form.Value)
 			c.Request.MultipartForm = form
+			formData := url.Values(form.Value)
 			c.Request.PostForm = formData
 			imageRequest.Prompt = formData.Get("prompt")
 			imageRequest.Model = formData.Get("model")
@@ -227,6 +231,9 @@ func GetAndValidOpenAIImageRequest(c *gin.Context, relayMode int) (*dto.ImageReq
 			if hasWatermark {
 				watermark := formData.Get("watermark") == "true"
 				imageRequest.Watermark = &watermark
+			}
+			if validationErr := ValidateOpenAIImageEditMultipart(c); validationErr != nil {
+				return nil, validationErr
 			}
 			break
 		}

--- a/apps/api-go/relay/image_handler.go
+++ b/apps/api-go/relay/image_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LIghtJUNction/api.lmm.best/constant"
 	"github.com/LIghtJUNction/api.lmm.best/logger"
 	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
 	"github.com/LIghtJUNction/api.lmm.best/relay/helper"
 	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
 	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
@@ -21,6 +22,11 @@ import (
 )
 
 func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
+	if info.RelayMode == relayconstant.RelayModeImagesEdits {
+		if validationErr := helper.ValidateOpenAIImageEditMultipart(c); validationErr != nil {
+			return validationErr
+		}
+	}
 	info.InitChannelMeta(c)
 
 	imageReq, ok := info.Request.(*dto.ImageRequest)

--- a/apps/api-go/relay/image_validation_test.go
+++ b/apps/api-go/relay/image_validation_test.go
@@ -1,0 +1,71 @@
+package relay
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	basecommon "github.com/LIghtJUNction/api.lmm.best/common"
+	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/LIghtJUNction/api.lmm.best/setting/model_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func invalidImageEditContext(t *testing.T) *gin.Context {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	part, err := writer.CreateFormFile("image", "image.png")
+	require.NoError(t, err)
+	_, err = part.Write([]byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'})
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	context.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	t.Cleanup(func() { basecommon.CleanupBodyStorage(context) })
+	return context
+}
+
+func TestImageHelperCannotBypassValidationWithPassThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	originalPassThrough := model_setting.GetGlobalSettings().PassThroughRequestEnabled
+	t.Cleanup(func() { model_setting.GetGlobalSettings().PassThroughRequestEnabled = originalPassThrough })
+
+	for _, test := range []struct {
+		name           string
+		globalSetting  bool
+		channelSetting bool
+	}{
+		{name: "pass-through off"},
+		{name: "global pass-through", globalSetting: true},
+		{name: "channel pass-through", channelSetting: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model_setting.GetGlobalSettings().PassThroughRequestEnabled = test.globalSetting
+			context := invalidImageEditContext(t)
+			info := &relaycommon.RelayInfo{
+				RelayMode: relayconstant.RelayModeImagesEdits,
+				Request:   &dto.ImageRequest{Model: "gpt-image-1"},
+				ChannelMeta: &relaycommon.ChannelMeta{
+					ChannelSetting: dto.ChannelSettings{PassThroughBodyEnabled: test.channelSetting},
+				},
+			}
+
+			apiErr := ImageHelper(context, info)
+			require.NotNil(t, apiErr)
+			require.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+			require.Equal(t, types.ErrorCodeInvalidRequest, apiErr.GetErrorCode())
+			require.True(t, types.IsSkipRetryError(apiErr))
+			require.Nil(t, info.Billing, "local validation must not create a billing session")
+			require.Empty(t, context.GetStringSlice("use_channel"), "local validation must not select or contact an upstream")
+		})
+	}
+}

--- a/apps/web/src/features/email-activations/i18n.ts
+++ b/apps/web/src/features/email-activations/i18n.ts
@@ -45,7 +45,7 @@ export const heroSmsTranslations = {
       'For security, the browser never reads back the saved secret. Enter a new key only when rotating it.',
     'HeroSMS API key cleared': 'HeroSMS API key cleared',
     'HeroSMS connection test passed': 'HeroSMS connection test passed',
-    'HeroSMS Email': 'HeroSMS Email',
+    'HeroSMS temporary activations': 'HeroSMS temporary activations',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -210,7 +210,7 @@ export const heroSmsTranslations = {
       '出于安全考虑，浏览器不会读回已保存的密钥。只有在轮换时才输入新密钥。',
     'HeroSMS API key cleared': '已清除 HeroSMS API 密钥',
     'HeroSMS connection test passed': 'HeroSMS 连接测试通过',
-    'HeroSMS Email': 'HeroSMS 邮箱接码',
+    'HeroSMS temporary activations': 'HeroSMS 临时接码',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS 暂时不可用，请保持页面打开并稍后重试。',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -370,7 +370,7 @@ export const heroSmsTranslations = {
       '基於安全考量，瀏覽器不會讀回已儲存的密鑰。只有在輪換時才輸入新金鑰。',
     'HeroSMS API key cleared': '已清除 HeroSMS API 金鑰',
     'HeroSMS connection test passed': 'HeroSMS 連線測試通過',
-    'HeroSMS Email': 'HeroSMS 郵箱接碼',
+    'HeroSMS temporary activations': 'HeroSMS 臨時接碼',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS 暫時不可用，請保持頁面開啟並稍後重試。',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -532,7 +532,7 @@ export const heroSmsTranslations = {
       'Pour des raisons de sécurité, le navigateur ne relit jamais le secret enregistré. Saisissez une nouvelle clé uniquement lors de sa rotation.',
     'HeroSMS API key cleared': 'Clé API HeroSMS effacée',
     'HeroSMS connection test passed': 'Test de connexion HeroSMS réussi',
-    'HeroSMS Email': 'E-mail HeroSMS',
+    'HeroSMS temporary activations': 'Activations temporaires HeroSMS',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS est temporairement indisponible. Laissez cette page ouverte et réessayez sous peu.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -701,7 +701,7 @@ export const heroSmsTranslations = {
       'セキュリティのため、ブラウザーは保存済みシークレットを読み戻しません。新しいキーはローテーション時のみ入力してください。',
     'HeroSMS API key cleared': 'HeroSMS API キーを消去しました',
     'HeroSMS connection test passed': 'HeroSMS 接続テストに成功しました',
-    'HeroSMS Email': 'HeroSMS メール認証受信',
+    'HeroSMS temporary activations': 'HeroSMS 一時認証',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS は一時的に利用できません。このページを開いたまま、しばらくしてから再試行してください。',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -867,7 +867,7 @@ export const heroSmsTranslations = {
     'HeroSMS API key cleared': 'API-ключ HeroSMS очищен',
     'HeroSMS connection test passed':
       'Проверка подключения HeroSMS прошла успешно',
-    'HeroSMS Email': 'Почта HeroSMS',
+    'HeroSMS temporary activations': 'Временные активации HeroSMS',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS временно недоступен. Оставьте эту страницу открытой и попробуйте снова чуть позже.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -1034,7 +1034,7 @@ export const heroSmsTranslations = {
       'Vì lý do bảo mật, trình duyệt không bao giờ đọc lại bí mật đã lưu. Chỉ nhập khóa mới khi bạn xoay vòng khóa.',
     'HeroSMS API key cleared': 'Đã xóa API key HeroSMS',
     'HeroSMS connection test passed': 'Kiểm tra kết nối HeroSMS thành công',
-    'HeroSMS Email': 'Email HeroSMS',
+    'HeroSMS temporary activations': 'Kích hoạt tạm thời HeroSMS',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS tạm thời không khả dụng. Hãy giữ trang này mở và thử lại sau ít phút.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':

--- a/apps/web/src/features/profile/components/dialogs/change-password-dialog.test.tsx
+++ b/apps/web/src/features/profile/components/dialogs/change-password-dialog.test.tsx
@@ -1,0 +1,251 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+
+const domWindow = new Window({
+  url: 'https://console.example.test/profile',
+})
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'HTMLInputElement',
+  'SVGElement',
+  'Node',
+  'Element',
+  'Event',
+  'MouseEvent',
+  'PointerEvent',
+  'FocusEvent',
+  'CustomEvent',
+  'MutationObserver',
+  'ResizeObserver',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+Object.defineProperties(globalThis, {
+  requestAnimationFrame: {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => setTimeout(() => callback(0), 0),
+  },
+  cancelAnimationFrame: {
+    configurable: true,
+    value: (handle: number) => clearTimeout(handle),
+  },
+  getComputedStyle: {
+    configurable: true,
+    value: domWindow.getComputedStyle.bind(domWindow),
+  },
+})
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { createInstance } = await import('i18next')
+const { I18nextProvider, initReactI18next } = await import('react-i18next')
+const { toast } = await import('sonner')
+const { api } = await import('@/lib/api')
+const { ChangePasswordDialog } = await import('./change-password-dialog')
+
+const originalPut = api.put
+const originalToastSuccess = toast.success
+const originalToastError = toast.error
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+const i18n = createInstance()
+await i18n.use(initReactI18next).init({
+  lng: 'en',
+  resources: { en: { translation: {} } },
+})
+
+async function flushEffects() {
+  await new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+function dialogElement(
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+  username = 'alice'
+) {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <ChangePasswordDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        username={username}
+      />
+    </I18nextProvider>
+  )
+}
+
+async function renderDialog(onOpenChange: (open: boolean) => void) {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(dialogElement(true, onOpenChange))
+    await flushEffects()
+  })
+  return { root }
+}
+
+async function rerenderDialog(
+  root: ReturnType<typeof createRoot>,
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+  username = 'alice'
+) {
+  await act(async () => {
+    root.render(dialogElement(open, onOpenChange, username))
+    await flushEffects()
+  })
+}
+
+async function setInputValue(id: string, value: string) {
+  const input = document.querySelector<HTMLInputElement>(`#${id}`)
+  assert.ok(input)
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set
+  assert.ok(setValue)
+  await act(async () => {
+    setValue.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushEffects()
+  })
+}
+
+function passwordValues() {
+  return ['currentPassword', 'newPassword', 'confirmPassword'].map((id) => {
+    const input = document.querySelector<HTMLInputElement>(`#${id}`)
+    assert.ok(input)
+    return input.value
+  })
+}
+
+function findButton(text: string) {
+  const button = [
+    ...document.querySelectorAll<HTMLButtonElement>('button'),
+  ].find((candidate) => candidate.textContent?.trim() === text)
+  assert.ok(button, `Could not find button ${text}`)
+  return button
+}
+
+async function enterPasswords() {
+  await setInputValue('currentPassword', 'old-password')
+  await setInputValue('newPassword', 'new-password')
+  await setInputValue('confirmPassword', 'new-password')
+}
+
+async function unmount(root: ReturnType<typeof createRoot>) {
+  await act(async () => root.unmount())
+}
+
+afterEach(() => {
+  api.put = originalPut
+  toast.success = originalToastSuccess
+  toast.error = originalToastError
+  document.body.replaceChildren()
+})
+
+after(() => domWindow.close())
+
+describe('ChangePasswordDialog secret reset', () => {
+  test('keeps fields while open but clears them across controlled close and reopen', async () => {
+    const onOpenChange = () => undefined
+    const { root } = await renderDialog(onOpenChange)
+    try {
+      await enterPasswords()
+      await rerenderDialog(root, true, onOpenChange, 'alice-renamed')
+      assert.deepEqual(passwordValues(), [
+        'old-password',
+        'new-password',
+        'new-password',
+      ])
+
+      await rerenderDialog(root, false, onOpenChange)
+      await rerenderDialog(root, true, onOpenChange)
+      assert.deepEqual(passwordValues(), ['', '', ''])
+    } finally {
+      await unmount(root)
+    }
+  })
+
+  test('clears secrets immediately when Cancel requests close', async () => {
+    const openChanges: boolean[] = []
+    const onOpenChange = (open: boolean) => openChanges.push(open)
+    const { root } = await renderDialog(onOpenChange)
+    try {
+      await enterPasswords()
+      await act(async () => {
+        findButton('Cancel').click()
+        await flushEffects()
+      })
+      assert.deepEqual(openChanges, [false])
+      assert.deepEqual(passwordValues(), ['', '', ''])
+    } finally {
+      await unmount(root)
+    }
+  })
+
+  test('clears secrets immediately after a successful password change', async () => {
+    const requests: unknown[] = []
+    api.put = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true } }
+    }) as typeof api.put
+    toast.success = (() => 'success-toast') as typeof toast.success
+    toast.error = (() => 'error-toast') as typeof toast.error
+    const openChanges: boolean[] = []
+    const onOpenChange = (open: boolean) => openChanges.push(open)
+    const { root } = await renderDialog(onOpenChange)
+    try {
+      await enterPasswords()
+      await act(async () => {
+        findButton('Change Password').click()
+        await flushEffects()
+      })
+      assert.deepEqual(requests, [
+        {
+          url: '/api/user/self',
+          data: {
+            original_password: 'old-password',
+            password: 'new-password',
+          },
+        },
+      ])
+      assert.deepEqual(openChanges, [false])
+      assert.deepEqual(passwordValues(), ['', '', ''])
+    } finally {
+      await unmount(root)
+    }
+  })
+})

--- a/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
+++ b/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Loader2 } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -32,6 +32,12 @@ import { updateUserProfile } from '../../api'
 // Change Password Dialog Component
 // ============================================================================
 
+const EMPTY_FORM_DATA = {
+  originalPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+}
+
 interface ChangePasswordDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -45,11 +51,16 @@ export function ChangePasswordDialog({
 }: ChangePasswordDialogProps) {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
-  const [formData, setFormData] = useState({
-    originalPassword: '',
-    newPassword: '',
-    confirmPassword: '',
-  })
+  const [formData, setFormData] = useState(EMPTY_FORM_DATA)
+
+  useEffect(() => {
+    if (!open) setFormData(EMPTY_FORM_DATA)
+  }, [open])
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setFormData(EMPTY_FORM_DATA)
+    onOpenChange(nextOpen)
+  }
 
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
@@ -93,12 +104,7 @@ export function ChangePasswordDialog({
 
       if (response.success) {
         toast.success(t('Password changed successfully'))
-        onOpenChange(false)
-        setFormData({
-          originalPassword: '',
-          newPassword: '',
-          confirmPassword: '',
-        })
+        handleOpenChange(false)
       } else {
         toast.error(response.message || t('Failed to change password'))
       }
@@ -114,7 +120,7 @@ export function ChangePasswordDialog({
   return (
     <Dialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       title={t('Change Password')}
       description={
         <>
@@ -129,7 +135,7 @@ export function ChangePasswordDialog({
           <Button
             type='button'
             variant='outline'
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
             disabled={loading}
           >
             {t('Cancel')}

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
@@ -1,0 +1,677 @@
+/*
+Copyright (C) 2026 LIghtJUNction
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+
+import type {
+  ApiResponse,
+  PlanRecord,
+  UserSubscriptionRecord,
+} from '../../types'
+
+const domWindow = new Window({
+  url: 'https://console.example.test/admin/users',
+})
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'SVGElement',
+  'Node',
+  'Element',
+  'Event',
+  'MouseEvent',
+  'PointerEvent',
+  'FocusEvent',
+  'CustomEvent',
+  'MutationObserver',
+  'ResizeObserver',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'getComputedStyle',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { createInstance } = await import('i18next')
+const { I18nextProvider, initReactI18next } = await import('react-i18next')
+const { toast } = await import('sonner')
+const { api } = await import('@/lib/api')
+const { UserSubscriptionsDialog } = await import('./user-subscriptions-dialog')
+
+const originalGet = api.get
+const originalPost = api.post
+const originalDelete = api.delete
+const originalToastError = toast.error
+const originalToastSuccess = toast.success
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+const i18n = createInstance()
+await i18n.use(initReactI18next).init({
+  lng: 'en',
+  resources: { en: { translation: {} } },
+})
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+}
+
+type PendingRequest = {
+  url: string
+  response: { promise: Promise<unknown> }
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve']
+  let reject!: Deferred<T>['reject']
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function installDeferredTransport(requests: PendingRequest[]) {
+  let requestIndex = 0
+  api.get = (async (url: string) => {
+    const request = requests[requestIndex++]
+    assert.ok(request, `Unexpected GET request: ${url}`)
+    assert.equal(url, request.url)
+    return { data: await request.response.promise }
+  }) as typeof api.get
+}
+
+function plansResponse(id: number, title: string): ApiResponse<PlanRecord[]> {
+  return {
+    success: true,
+    data: [
+      {
+        plan: { id, title } as PlanRecord['plan'],
+      },
+    ],
+  }
+}
+
+function subscriptionsResponse(
+  id: number,
+  userId: number,
+  planId: number
+): ApiResponse<UserSubscriptionRecord[]> {
+  return {
+    success: true,
+    data: [
+      {
+        subscription: {
+          id,
+          user_id: userId,
+          plan_id: planId,
+          status: 'active',
+          source: 'test',
+          start_time: 1,
+          end_time: 4_000_000_000,
+          amount_total: 100,
+          amount_used: 0,
+        },
+      },
+    ],
+  }
+}
+
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function dialogElement(
+  open: boolean,
+  user: { id: number; username?: string } | null,
+  onSuccess?: () => void
+) {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <UserSubscriptionsDialog
+        open={open}
+        user={user}
+        onOpenChange={() => undefined}
+        onSuccess={onSuccess}
+      />
+    </I18nextProvider>
+  )
+}
+
+async function renderDialog(
+  open: boolean,
+  user: { id: number; username?: string } | null,
+  onSuccess?: () => void
+) {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(dialogElement(open, user, onSuccess))
+    await flush()
+  })
+  return { container, root }
+}
+
+async function rerenderDialog(
+  root: ReturnType<typeof createRoot>,
+  open: boolean,
+  user: { id: number; username?: string } | null,
+  onSuccess?: () => void
+) {
+  await act(async () => {
+    root.render(dialogElement(open, user, onSuccess))
+    await flush()
+  })
+}
+
+async function unmountDialog(
+  rendered: Awaited<ReturnType<typeof renderDialog>>
+) {
+  await act(async () => rendered.root.unmount())
+  rendered.container.remove()
+}
+
+function dialogText() {
+  return document.body.textContent ?? ''
+}
+
+function installImmediateReads() {
+  const requests: string[] = []
+  api.get = (async (url: string) => {
+    requests.push(url)
+    if (url === '/api/subscription/admin/plans') {
+      return { data: plansResponse(11, 'Plan') }
+    }
+    const userMatch = url.match(
+      /^\/api\/subscription\/admin\/users\/(\d+)\/subscriptions$/
+    )
+    assert.ok(userMatch, `Unexpected GET request: ${url}`)
+    const userId = Number(userMatch[1])
+    return {
+      data: subscriptionsResponse(userId * 111, userId, 11),
+    }
+  }) as typeof api.get
+  return requests
+}
+
+async function clickElement(element: Element | undefined | null) {
+  assert.ok(element instanceof HTMLElement, 'interactive element was not found')
+  await act(async () => {
+    element.click()
+    await flush()
+  })
+}
+
+function elementWithText(selector: string, text: string) {
+  return [...document.querySelectorAll(selector)].find(
+    (element) => element.textContent?.trim() === text
+  )
+}
+
+async function selectFirstPlan() {
+  await clickElement(document.querySelector('[role="combobox"]'))
+  await clickElement(document.querySelector('[role="option"]'))
+}
+
+async function chooseRowAction(label: string) {
+  await clickElement(document.querySelector('button[aria-label="Actions"]'))
+  await clickElement(elementWithText('[role="menuitem"]', label))
+}
+
+async function confirmDialogAction(label: string) {
+  await clickElement(elementWithText('button', label))
+}
+
+function captureMutationEffects() {
+  const successes: unknown[] = []
+  const errors: unknown[] = []
+  let onSuccessCalls = 0
+  toast.success = ((message: unknown) => {
+    successes.push(message)
+    return 'success-toast'
+  }) as typeof toast.success
+  toast.error = ((message: unknown) => {
+    errors.push(message)
+    return 'error-toast'
+  }) as typeof toast.error
+  return {
+    successes,
+    errors,
+    onSuccess: () => {
+      onSuccessCalls += 1
+    },
+    onSuccessCalls: () => onSuccessCalls,
+  }
+}
+
+afterEach(() => {
+  api.get = originalGet
+  api.post = originalPost
+  api.delete = originalDelete
+  toast.error = originalToastError
+  toast.success = originalToastSuccess
+  document.body.replaceChildren()
+})
+
+after(() => domWindow.close())
+
+describe('UserSubscriptionsDialog request isolation', () => {
+  test('keeps the latest user when the earlier load resolves last', async () => {
+    const plansA = deferred<ApiResponse<PlanRecord[]>>()
+    const subsA = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const plansB = deferred<ApiResponse<PlanRecord[]>>()
+    const subsB = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansA,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: subsA,
+      },
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansB,
+      },
+      {
+        url: '/api/subscription/admin/users/2/subscriptions',
+        response: subsB,
+      },
+    ])
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await rerenderDialog(rendered.root, true, { id: 2, username: 'B' })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.doesNotMatch(dialogText(), /101/)
+
+      await act(async () => {
+        plansB.resolve(plansResponse(20, 'B plan'))
+        subsB.resolve(subscriptionsResponse(202, 2, 20))
+        await flush()
+      })
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /A plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+      assert.doesNotMatch(dialogText(), /Loading\.\.\./)
+
+      await act(async () => {
+        plansA.resolve(plansResponse(10, 'A plan'))
+        subsA.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /A plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('clears a rendered previous-user row immediately on switch', async () => {
+    const plansA = deferred<ApiResponse<PlanRecord[]>>()
+    const subsA = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const plansB = deferred<ApiResponse<PlanRecord[]>>()
+    const subsB = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      { url: '/api/subscription/admin/plans', response: plansA },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: subsA,
+      },
+      { url: '/api/subscription/admin/plans', response: plansB },
+      {
+        url: '/api/subscription/admin/users/2/subscriptions',
+        response: subsB,
+      },
+    ])
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await act(async () => {
+        plansA.resolve(plansResponse(10, 'A plan'))
+        subsA.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /A plan/)
+      assert.match(dialogText(), /101/)
+
+      await rerenderDialog(rendered.root, true, { id: 2, username: 'B' })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.doesNotMatch(dialogText(), /101/)
+
+      await act(async () => {
+        plansB.resolve(plansResponse(20, 'B plan'))
+        subsB.resolve(subscriptionsResponse(202, 2, 20))
+        await flush()
+      })
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('ignores a stale partial failure, error, and finally state', async () => {
+    const plansA = deferred<ApiResponse<PlanRecord[]>>()
+    const subsA = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const plansB = deferred<ApiResponse<PlanRecord[]>>()
+    const subsB = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansA,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: subsA,
+      },
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansB,
+      },
+      {
+        url: '/api/subscription/admin/users/2/subscriptions',
+        response: subsB,
+      },
+    ])
+    const errors: string[] = []
+    toast.error = ((message: unknown) => {
+      errors.push(String(message))
+      return 1
+    }) as typeof toast.error
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await rerenderDialog(rendered.root, true, { id: 2, username: 'B' })
+
+      await act(async () => {
+        plansA.reject(new Error('A plans failed'))
+        await flush()
+      })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.deepEqual(errors, [])
+
+      await act(async () => {
+        subsA.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.deepEqual(errors, [])
+
+      await act(async () => {
+        plansB.resolve(plansResponse(20, 'B plan'))
+        subsB.resolve(subscriptionsResponse(202, 2, 20))
+        await flush()
+      })
+      assert.doesNotMatch(dialogText(), /Loading\.\.\./)
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
+      assert.deepEqual(errors, [])
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('does not revive the previous user after a deferred create completes', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let postCalls = 0
+    api.post = (async (url: string) => {
+      postCalls += 1
+      assert.equal(url, '/api/subscription/admin/users/1/subscriptions')
+      return mutation.promise
+    }) as typeof api.post
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+    try {
+      assert.match(dialogText(), /111/)
+      await selectFirstPlan()
+      await clickElement(elementWithText('button', 'Add subscription'))
+      assert.equal(postCalls, 1)
+
+      await rerenderDialog(
+        rendered.root,
+        true,
+        { id: 2, username: 'B' },
+        effects.onSuccess
+      )
+      assert.match(dialogText(), /222/)
+      assert.doesNotMatch(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+
+      await act(async () => {
+        mutation.resolve({
+          data: { success: true, data: { message: 'created A' } },
+        })
+        await flush()
+      })
+      assert.match(dialogText(), /222/)
+      assert.doesNotMatch(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+      assert.deepEqual(effects.successes, [])
+      assert.deepEqual(effects.errors, [])
+      assert.equal(effects.onSuccessCalls(), 0)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('suppresses a deferred invalidate completion after close', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let postCalls = 0
+    api.post = (async (url: string) => {
+      postCalls += 1
+      assert.equal(
+        url,
+        '/api/subscription/admin/user_subscriptions/111/invalidate'
+      )
+      return mutation.promise
+    }) as typeof api.post
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+    try {
+      await chooseRowAction('Invalidate')
+      await confirmDialogAction('Continue')
+      assert.equal(postCalls, 1)
+
+      await rerenderDialog(
+        rendered.root,
+        false,
+        { id: 1, username: 'A' },
+        effects.onSuccess
+      )
+      await act(async () => {
+        mutation.reject(new Error('stale invalidate failed'))
+        await flush()
+      })
+      assert.equal(requests.length, 2)
+      assert.deepEqual(effects.successes, [])
+      assert.deepEqual(effects.errors, [])
+      assert.equal(effects.onSuccessCalls(), 0)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('does not let a deferred delete affect the same user after reopen', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let deleteCalls = 0
+    api.delete = (async (url: string) => {
+      deleteCalls += 1
+      assert.equal(url, '/api/subscription/admin/user_subscriptions/111')
+      return mutation.promise
+    }) as typeof api.delete
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+    try {
+      await chooseRowAction('Delete')
+      await confirmDialogAction('Continue')
+      assert.equal(deleteCalls, 1)
+
+      await rerenderDialog(
+        rendered.root,
+        false,
+        { id: 1, username: 'A' },
+        effects.onSuccess
+      )
+      await rerenderDialog(
+        rendered.root,
+        true,
+        { id: 1, username: 'A reopened' },
+        effects.onSuccess
+      )
+      assert.match(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+
+      await act(async () => {
+        mutation.resolve({ data: { success: true } })
+        await flush()
+      })
+      assert.match(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+      assert.deepEqual(effects.successes, [])
+      assert.deepEqual(effects.errors, [])
+      assert.equal(effects.onSuccessCalls(), 0)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('suppresses a deferred reset completion after unmount', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let postCalls = 0
+    api.post = (async (url: string) => {
+      postCalls += 1
+      assert.equal(url, '/api/subscription/admin/users/1/subscriptions/reset')
+      return mutation.promise
+    }) as typeof api.post
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+
+    await chooseRowAction('Reset quota')
+    await confirmDialogAction('Reset quota')
+    assert.equal(postCalls, 1)
+    await unmountDialog(rendered)
+    await act(async () => {
+      mutation.resolve({
+        data: { success: true, data: { reset_count: 1 } },
+      })
+      await flush()
+    })
+    assert.equal(requests.length, 2)
+    assert.deepEqual(effects.successes, [])
+    assert.deepEqual(effects.errors, [])
+    assert.equal(effects.onSuccessCalls(), 0)
+    assert.equal(dialogText(), '')
+  })
+
+  test('invalidates responses from a closed dialog before reopening it', async () => {
+    const oldPlans = deferred<ApiResponse<PlanRecord[]>>()
+    const oldSubs = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const reopenedPlans = deferred<ApiResponse<PlanRecord[]>>()
+    const reopenedSubs = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      {
+        url: '/api/subscription/admin/plans',
+        response: oldPlans,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: oldSubs,
+      },
+      {
+        url: '/api/subscription/admin/plans',
+        response: reopenedPlans,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: reopenedSubs,
+      },
+    ])
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await rerenderDialog(rendered.root, false, { id: 1, username: 'A' })
+      await rerenderDialog(rendered.root, true, {
+        id: 1,
+        username: 'A reopened',
+      })
+
+      await act(async () => {
+        reopenedPlans.resolve(plansResponse(20, 'Reopened plan'))
+        reopenedSubs.resolve(subscriptionsResponse(202, 1, 20))
+        await flush()
+      })
+      assert.match(dialogText(), /Reopened plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /Old plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+
+      await act(async () => {
+        oldPlans.resolve(plansResponse(10, 'Old plan'))
+        oldSubs.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /Reopened plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /Old plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+})

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
@@ -17,7 +17,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Ban, Plus, RotateCcw, Trash2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -75,6 +82,20 @@ interface Props {
   onSuccess?: () => void
 }
 
+type DialogRequestScope = Readonly<{
+  open: boolean
+  userId: number | null
+  epoch: number
+  mounted: boolean
+}>
+
+type ActiveDialogRequestScope = DialogRequestScope &
+  Readonly<{
+    open: true
+    userId: number
+    mounted: true
+  }>
+
 function SubscriptionStatusBadge(props: {
   sub: UserSubscriptionRecord['subscription']
   t: (key: string) => string
@@ -112,7 +133,8 @@ function SubscriptionStatusBadge(props: {
 
 export function UserSubscriptionsDialog(props: Props) {
   const { t } = useTranslation()
-  const [loading, setLoading] = useState(false)
+  const userId = props.user?.id ?? null
+  const [loading, setLoading] = useState(props.open && userId !== null)
   const [creating, setCreating] = useState(false)
   const [plans, setPlans] = useState<PlanRecord[]>([])
   const [subs, setSubs] = useState<UserSubscriptionRecord[]>([])
@@ -127,6 +149,69 @@ export function UserSubscriptionsDialog(props: Props) {
     type: 'invalidate' | 'delete'
     subId: number
   } | null>(null)
+  const requestGenerationRef = useRef(0)
+  const currentScopeRef = useRef<DialogRequestScope>({
+    open: props.open,
+    userId,
+    epoch: 0,
+    mounted: true,
+  })
+
+  useLayoutEffect(() => {
+    const currentScope = currentScopeRef.current
+    if (!currentScope.mounted) {
+      currentScopeRef.current = {
+        ...currentScope,
+        epoch: currentScope.epoch + 1,
+        mounted: true,
+      }
+    }
+
+    return () => {
+      const scopeAtUnmount = currentScopeRef.current
+      currentScopeRef.current = {
+        ...scopeAtUnmount,
+        epoch: scopeAtUnmount.epoch + 1,
+        mounted: false,
+      }
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    const currentScope = currentScopeRef.current
+    if (currentScope.open !== props.open || currentScope.userId !== userId) {
+      currentScopeRef.current = {
+        open: props.open,
+        userId,
+        epoch: currentScope.epoch + 1,
+        mounted: currentScope.mounted,
+      }
+      requestGenerationRef.current += 1
+      setSubs([])
+      setSelectedPlanId('')
+      setCreating(false)
+      setResetting(false)
+      setConfirmAction(null)
+      setResetAction(null)
+      setLoading(props.open && userId !== null)
+    }
+  }, [props.open, userId])
+
+  const isCurrentOpenScope = useCallback(
+    (scope: DialogRequestScope): scope is ActiveDialogRequestScope => {
+      const currentScope = currentScopeRef.current
+      return (
+        scope.mounted &&
+        scope.open &&
+        scope.userId !== null &&
+        currentScope.mounted &&
+        currentScope.open &&
+        currentScope.userId === scope.userId &&
+        currentScope.epoch === scope.epoch
+      )
+    },
+    []
+  )
 
   const planTitleMap = useMemo(() => {
     const map = new Map<number, string>()
@@ -136,100 +221,131 @@ export function UserSubscriptionsDialog(props: Props) {
     return map
   }, [plans])
 
-  const loadData = useCallback(async () => {
-    if (!props.user?.id) return
-    setLoading(true)
-    try {
-      const [plansRes, subsRes] = await Promise.all([
-        getAdminPlans(),
-        getUserSubscriptions(props.user.id),
-      ])
-      if (plansRes.success) setPlans(plansRes.data || [])
-      if (subsRes.success) setSubs(subsRes.data || [])
-    } catch {
-      toast.error(t('Loading failed'))
-    } finally {
-      setLoading(false)
-    }
-  }, [props.user?.id, t])
+  const loadData = useCallback(
+    async (scope: DialogRequestScope) => {
+      if (!isCurrentOpenScope(scope) || scope.userId === null) return
+
+      const requestGeneration = ++requestGenerationRef.current
+      const isCurrentRequest = () =>
+        requestGenerationRef.current === requestGeneration &&
+        isCurrentOpenScope(scope)
+
+      setLoading(true)
+      try {
+        const [plansRes, subsRes] = await Promise.all([
+          getAdminPlans(),
+          getUserSubscriptions(scope.userId),
+        ])
+        if (!isCurrentRequest()) return
+        if (plansRes.success) setPlans(plansRes.data || [])
+        if (subsRes.success) setSubs(subsRes.data || [])
+      } catch {
+        if (isCurrentRequest()) toast.error(t('Loading failed'))
+      } finally {
+        if (isCurrentRequest()) setLoading(false)
+      }
+    },
+    [isCurrentOpenScope, t]
+  )
 
   useEffect(() => {
-    if (props.open && props.user?.id) {
-      setSelectedPlanId('')
-      loadData()
+    const scope = currentScopeRef.current
+    requestGenerationRef.current += 1
+    if (!isCurrentOpenScope(scope)) return
+
+    void loadData(scope)
+
+    return () => {
+      requestGenerationRef.current += 1
     }
-  }, [props.open, props.user?.id, loadData])
+  }, [props.open, userId, isCurrentOpenScope, loadData])
 
   const handleCreate = async () => {
-    if (!props.user?.id || !selectedPlanId) {
-      toast.error(t('Please select a subscription plan'))
+    const scope = currentScopeRef.current
+    if (!isCurrentOpenScope(scope) || !selectedPlanId) {
+      if (isCurrentOpenScope(scope)) {
+        toast.error(t('Please select a subscription plan'))
+      }
       return
     }
+
     setCreating(true)
     try {
-      const res = await createUserSubscription(props.user.id, {
+      const res = await createUserSubscription(scope.userId, {
         plan_id: Number(selectedPlanId),
       })
+      if (!isCurrentOpenScope(scope)) return
       if (res.success) {
         toast.success(res.data?.message || t('Added successfully'))
         setSelectedPlanId('')
-        await loadData()
-        props.onSuccess?.()
+        await loadData(scope)
+        if (isCurrentOpenScope(scope)) props.onSuccess?.()
       }
     } catch {
-      toast.error(t('Request failed'))
+      if (isCurrentOpenScope(scope)) toast.error(t('Request failed'))
     } finally {
-      setCreating(false)
+      if (isCurrentOpenScope(scope)) setCreating(false)
     }
   }
 
   const handleConfirmAction = async () => {
-    if (!confirmAction) return
+    const scope = currentScopeRef.current
+    const action = confirmAction
+    if (!isCurrentOpenScope(scope) || !action) return
+
     try {
-      if (confirmAction.type === 'invalidate') {
-        const res = await invalidateUserSubscription(confirmAction.subId)
+      if (action.type === 'invalidate') {
+        const res = await invalidateUserSubscription(action.subId)
+        if (!isCurrentOpenScope(scope)) return
         if (res.success) {
           toast.success(res.data?.message || t('Has been invalidated'))
-          await loadData()
-          props.onSuccess?.()
+          await loadData(scope)
+          if (isCurrentOpenScope(scope)) props.onSuccess?.()
         }
       } else {
-        const res = await deleteUserSubscription(confirmAction.subId)
+        const res = await deleteUserSubscription(action.subId)
+        if (!isCurrentOpenScope(scope)) return
         if (res.success) {
           toast.success(t('Deleted'))
-          await loadData()
-          props.onSuccess?.()
+          await loadData(scope)
+          if (isCurrentOpenScope(scope)) props.onSuccess?.()
         }
       }
     } catch {
-      toast.error(t('Operation failed'))
+      if (isCurrentOpenScope(scope)) toast.error(t('Operation failed'))
     } finally {
-      setConfirmAction(null)
+      if (isCurrentOpenScope(scope)) setConfirmAction(null)
     }
   }
 
   const handleResetConfirm = async () => {
-    if (!props.user?.id || !resetAction) return
+    const scope = currentScopeRef.current
+    const action = resetAction
+    if (!isCurrentOpenScope(scope) || !action) return
+
     setResetting(true)
     try {
-      const res = await resetUserSubscriptionsByPlan(props.user.id, {
-        plan_id: resetAction.planId,
+      const res = await resetUserSubscriptionsByPlan(scope.userId, {
+        plan_id: action.planId,
         advance_reset_time: advanceResetTime,
       })
+      if (!isCurrentOpenScope(scope)) return
       if (res.success) {
         toast.success(
           t('Reset {{count}} active subscriptions', {
             count: res.data?.reset_count || 0,
           })
         )
-        await loadData()
-        props.onSuccess?.()
+        await loadData(scope)
+        if (isCurrentOpenScope(scope)) props.onSuccess?.()
       }
     } catch {
-      toast.error(t('Operation failed'))
+      if (isCurrentOpenScope(scope)) toast.error(t('Operation failed'))
     } finally {
-      setResetting(false)
-      setResetAction(null)
+      if (isCurrentOpenScope(scope)) {
+        setResetting(false)
+        setResetAction(null)
+      }
     }
   }
 

--- a/apps/web/src/features/system-settings/operations/section-registry.test.tsx
+++ b/apps/web/src/features/system-settings/operations/section-registry.test.tsx
@@ -1,0 +1,31 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { getOperationsSectionMeta } from './section-registry.js'
+
+describe('operations section registry', () => {
+  test('names the shared HeroSMS email and SMS settings accurately', () => {
+    assert.equal(
+      getOperationsSectionMeta('hero-sms').titleKey,
+      'HeroSMS temporary activations'
+    )
+  })
+})

--- a/apps/web/src/features/system-settings/operations/section-registry.tsx
+++ b/apps/web/src/features/system-settings/operations/section-registry.tsx
@@ -111,7 +111,7 @@ const OPERATIONS_SECTIONS = [
   },
   {
     id: 'hero-sms',
-    titleKey: 'HeroSMS Email',
+    titleKey: 'HeroSMS temporary activations',
     build: () => <LazyHeroSmsSettingsSection />,
   },
   {

--- a/apps/web/src/features/users/components/user-quota-dialog.test.tsx
+++ b/apps/web/src/features/users/components/user-quota-dialog.test.tsx
@@ -1,0 +1,255 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+
+const domWindow = new Window({
+  url: 'https://console.example.test/admin/users',
+})
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'HTMLInputElement',
+  'HTMLLabelElement',
+  'SVGElement',
+  'Node',
+  'Element',
+  'Event',
+  'MouseEvent',
+  'PointerEvent',
+  'FocusEvent',
+  'CustomEvent',
+  'MutationObserver',
+  'ResizeObserver',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+Object.defineProperties(globalThis, {
+  requestAnimationFrame: {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => setTimeout(() => callback(0), 0),
+  },
+  cancelAnimationFrame: {
+    configurable: true,
+    value: (handle: number) => clearTimeout(handle),
+  },
+  getComputedStyle: {
+    configurable: true,
+    value: domWindow.getComputedStyle.bind(domWindow),
+  },
+})
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { createInstance } = await import('i18next')
+const { I18nextProvider, initReactI18next } = await import('react-i18next')
+const { api } = await import('@/lib/api')
+const { UserQuotaDialog } = await import('./user-quota-dialog')
+
+const originalPost = api.post
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+const i18n = createInstance()
+await i18n.use(initReactI18next).init({
+  lng: 'en',
+  resources: { en: { translation: {} } },
+})
+
+async function flushEffects() {
+  await new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+function findButton(text: string) {
+  const button = [
+    ...document.querySelectorAll<HTMLButtonElement>('button'),
+  ].find((candidate) => candidate.textContent?.includes(text))
+  assert.ok(button, `Could not find button containing ${text}`)
+  return button
+}
+
+function findAmountInput() {
+  const input = document.querySelector<HTMLInputElement>('#user-quota-amount')
+  assert.ok(input, 'Could not find the quota amount input')
+  return input
+}
+
+async function setInputValue(input: HTMLInputElement, value: string) {
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set
+  assert.ok(setValue)
+  await act(async () => {
+    setValue.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushEffects()
+  })
+}
+
+async function renderDialog() {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(
+      <I18nextProvider i18n={i18n}>
+        <UserQuotaDialog
+          open
+          onOpenChange={() => {}}
+          userId={41}
+          currentQuota={100}
+          onSuccess={() => {}}
+        />
+      </I18nextProvider>
+    )
+    await flushEffects()
+  })
+  return { container, root }
+}
+
+afterEach(() => {
+  api.post = originalPost
+  document.body.replaceChildren()
+})
+
+after(() => domWindow.close())
+
+describe('UserQuotaDialog amount validation', () => {
+  test('blocks an empty override, accepts explicit zero, and associates the label', async () => {
+    const requests: unknown[] = []
+    api.post = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true, data: {} } }
+    }) as typeof api.post
+
+    const { root } = await renderDialog()
+    try {
+      const input = findAmountInput()
+      const label = document.querySelector<HTMLLabelElement>(
+        'label[for="user-quota-amount"]'
+      )
+      assert.ok(label)
+      assert.equal(label.htmlFor, input.id)
+
+      await act(async () => {
+        findButton('Override').click()
+        await flushEffects()
+      })
+      const confirm = findButton('Confirm')
+      assert.equal(confirm.disabled, true)
+      confirm.click()
+      await flushEffects()
+      assert.equal(requests.length, 0)
+
+      await setInputValue(input, '0')
+      assert.equal(findButton('Confirm').disabled, false)
+      await act(async () => {
+        findButton('Confirm').click()
+        await flushEffects()
+      })
+
+      assert.deepEqual(requests, [
+        {
+          url: '/api/user/manage',
+          data: { id: 41, action: 'add_quota', mode: 'override', value: 0 },
+        },
+      ])
+    } finally {
+      await act(async () => root.unmount())
+    }
+  })
+
+  test('rejects NaN and non-finite values before submission', async () => {
+    const requests: unknown[] = []
+    api.post = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true, data: {} } }
+    }) as typeof api.post
+
+    for (const value of ['NaN', 'Infinity', '1e309']) {
+      const { root } = await renderDialog()
+      try {
+        const input = findAmountInput()
+        await setInputValue(input, value)
+        assert.equal(
+          findButton('Confirm').disabled,
+          true,
+          `Expected ${value} to be rejected`
+        )
+        findButton('Confirm').click()
+        await flushEffects()
+      } finally {
+        await act(async () => root.unmount())
+        document.body.replaceChildren()
+      }
+    }
+
+    assert.equal(requests.length, 0)
+  })
+
+  test('keeps positive add and subtract submissions unchanged', async () => {
+    const requests: unknown[] = []
+    api.post = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true, data: {} } }
+    }) as typeof api.post
+
+    for (const mode of ['add', 'subtract'] as const) {
+      const { root } = await renderDialog()
+      try {
+        if (mode === 'subtract') {
+          await act(async () => {
+            findButton('Subtract').click()
+            await flushEffects()
+          })
+        }
+        await setInputValue(findAmountInput(), '2')
+        assert.equal(findButton('Confirm').disabled, false)
+        await act(async () => {
+          findButton('Confirm').click()
+          await flushEffects()
+        })
+      } finally {
+        await act(async () => root.unmount())
+        document.body.replaceChildren()
+      }
+    }
+
+    assert.deepEqual(requests, [
+      {
+        url: '/api/user/manage',
+        data: { id: 41, action: 'add_quota', mode: 'add', value: 1000000 },
+      },
+      {
+        url: '/api/user/manage',
+        data: { id: 41, action: 'add_quota', mode: 'subtract', value: 1000000 },
+      },
+    ])
+  })
+})

--- a/apps/web/src/features/users/components/user-quota-dialog.tsx
+++ b/apps/web/src/features/users/components/user-quota-dialog.tsx
@@ -39,6 +39,24 @@ interface UserQuotaDialogProps {
   onSuccess: () => void
 }
 
+function getAmountValidation(amount: string, mode: QuotaAdjustMode) {
+  const trimmedAmount = amount.trim()
+  const parsedAmount = trimmedAmount === '' ? null : Number(trimmedAmount)
+  const amountValue =
+    parsedAmount !== null && Number.isFinite(parsedAmount) ? parsedAmount : 0
+  const quotaValue = parseQuotaFromDollars(Math.abs(amountValue))
+
+  return {
+    amountValue,
+    quotaValue,
+    isValid:
+      parsedAmount !== null &&
+      Number.isFinite(parsedAmount) &&
+      Number.isFinite(quotaValue) &&
+      (mode === 'override' || quotaValue > 0),
+  }
+}
+
 export function UserQuotaDialog(props: UserQuotaDialogProps) {
   const { t } = useTranslation()
   const [mode, setMode] = useState<QuotaAdjustMode>('add')
@@ -49,8 +67,11 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
   const currencyLabel = getCurrencyLabel()
   const tokensOnly = currencyMeta.kind === 'tokens'
 
-  const amountValue = Number.parseFloat(amount) || 0
-  const quotaValue = parseQuotaFromDollars(Math.abs(amountValue))
+  const {
+    amountValue,
+    quotaValue,
+    isValid: isAmountValid,
+  } = getAmountValidation(amount, mode)
 
   const getPreviewText = () => {
     const current = props.currentQuota
@@ -70,13 +91,19 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
   }
 
   const handleConfirm = async () => {
-    if (!amount && mode !== 'override') return
-    if (quotaValue <= 0 && mode !== 'override') return
+    const {
+      amountValue: submittedAmountValue,
+      quotaValue: submittedQuotaValue,
+      isValid,
+    } = getAmountValidation(amount, mode)
+    if (!isValid) return
 
     setLoading(true)
     try {
       const value =
-        mode === 'override' ? parseQuotaFromDollars(amountValue) : quotaValue
+        mode === 'override'
+          ? parseQuotaFromDollars(submittedAmountValue)
+          : submittedQuotaValue
       const result = await adjustUserQuota({
         id: props.userId,
         action: 'add_quota',
@@ -122,7 +149,7 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
           <Button variant='outline' onClick={handleCancel}>
             {t('Cancel')}
           </Button>
-          <Button onClick={handleConfirm} disabled={loading}>
+          <Button onClick={handleConfirm} disabled={loading || !isAmountValid}>
             {loading ? t('Processing...') : t('Confirm')}
           </Button>
         </>
@@ -160,10 +187,11 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
         </div>
 
         <div className='space-y-2'>
-          <Label>
+          <Label htmlFor='user-quota-amount'>
             {t('Amount')} ({currencyLabel})
           </Label>
           <Input
+            id='user-quota-amount'
             type='number'
             step={tokensOnly ? 1 : 0.000001}
             min={mode === 'override' ? undefined : 0}

--- a/apps/web/src/i18n/static-keys.ts
+++ b/apps/web/src/i18n/static-keys.ts
@@ -693,5 +693,5 @@ export const STATIC_I18N_KEYS = [
   'Telegram binding failed. Please try again.',
   'Verification scope is missing',
   'Email Activations',
-  'HeroSMS Email',
+  'HeroSMS temporary activations',
 ] as const

--- a/deploy/check-frontend-split.sh
+++ b/deploy/check-frontend-split.sh
@@ -99,6 +99,10 @@ assert_literal 'auth_request_set $lmm_access_policy_result $upstream_http_x_lmm_
 assert_literal 'X-LMM-CN-Source $lmm_cn_source;' "$region_policy"
 assert_literal 'X-LMM-Access-Policy $lmm_access_policy_result;' "$region_policy"
 assert_literal 'X-LMM-Internal-Error access-policy;' "$region_policy"
+assert_literal 'X-LMM-Original-URI $request_uri;' "$region_policy"
+assert_literal 'X-LMM-Original-Accept $http_accept;' "$region_policy"
+assert_literal 'proxy_set_header Authorization "";' "$region_policy"
+assert_literal 'proxy_set_header Cookie "";' "$region_policy"
 assert_literal 'deploy production edge-policy install|verify' "$repo/apps/api-go/internal/appcli/deploy.go"
 if grep -Fq 'location ^~ /dashboard/' "$config"; then
   fail 'broad /dashboard/ proxy would swallow frontend dashboard routes'

--- a/deploy/check-frontend-split.sh
+++ b/deploy/check-frontend-split.sh
@@ -54,6 +54,17 @@ assert_literal 'max-age=31536000, immutable' "$config"
 assert_literal 'no-cache, must-revalidate' "$config"
 assert_literal 'proxy_buffering off' "$config"
 assert_literal 'Connection $connection_upgrade' "$config"
+assert_literal 'error_page 418 = @lmm_api_cors_preflight;' "$config"
+assert_literal 'location @lmm_api_cors_preflight {' "$config"
+assert_literal 'add_header Access-Control-Allow-Origin "*" always;' "$config"
+assert_literal 'add_header Access-Control-Allow-Methods $http_access_control_request_method always;' "$config"
+assert_literal 'add_header Access-Control-Allow-Headers $http_access_control_request_headers always;' "$config"
+assert_literal 'add_header Vary "Origin, Access-Control-Request-Method, Access-Control-Request-Headers" always;' "$config"
+backend_route_count=$(grep -Fc 'try_files /.__lmm_backend__ @lmm_api_backend;' "$config")
+preflight_guard_count=$(grep -Fc 'if ($request_method = OPTIONS) { return 418; }' "$config")
+normalized_uri_capture_count=$(grep -Fc 'set $lmm_access_policy_original_uri $uri;' "$config")
+[[ $backend_route_count -gt 0 && $preflight_guard_count == "$backend_route_count" && $normalized_uri_capture_count == "$backend_route_count" ]] ||
+  fail "every backend API location must capture its normalized URI and have one OPTIONS guard (routes=$backend_route_count captures=$normalized_uri_capture_count guards=$preflight_guard_count)"
 assert_literal 'geoip2 /var/lib/geoip2/DBIP-Country-Lite.mmdb {' "$repo/deploy/nginx/http-map.conf"
 assert_literal 'map $lmm_geoip_country_code $lmm_cn_source {' "$repo/deploy/nginx/http-map.conf"
 
@@ -99,7 +110,7 @@ assert_literal 'auth_request_set $lmm_access_policy_result $upstream_http_x_lmm_
 assert_literal 'X-LMM-CN-Source $lmm_cn_source;' "$region_policy"
 assert_literal 'X-LMM-Access-Policy $lmm_access_policy_result;' "$region_policy"
 assert_literal 'X-LMM-Internal-Error access-policy;' "$region_policy"
-assert_literal 'X-LMM-Original-URI $request_uri;' "$region_policy"
+assert_literal 'X-LMM-Original-URI $lmm_access_policy_original_uri;' "$region_policy"
 assert_literal 'X-LMM-Original-Accept $http_accept;' "$region_policy"
 assert_literal 'proxy_set_header Authorization "";' "$region_policy"
 assert_literal 'proxy_set_header Cookie "";' "$region_policy"
@@ -124,10 +135,12 @@ done < "$route_manifest"
 
 bash -n "$release"
 bash -n "$nginx_installer"
+bash -n "$repo/deploy/test-nginx-access-policy-preflight.sh"
 if command -v nginx >/dev/null; then
   LMM_NGINX_MIME_TYPES="$mime_types" "$repo/deploy/test-nginx-mime.sh"
+  "$repo/deploy/test-nginx-access-policy-preflight.sh"
 else
-  printf 'split-check: nginx not installed; MIME integration test skipped\n' >&2
+  printf 'split-check: nginx not installed; MIME and access-policy integration tests skipped\n' >&2
 fi
 "$repo/deploy/test-nginx-installer.sh"
 

--- a/deploy/nginx/lmm-api-locations.conf
+++ b/deploy/nginx/lmm-api-locations.conf
@@ -21,26 +21,110 @@ location @lmm_api_backend {
     proxy_read_timeout 3600s;
 }
 
+# A CORS preflight must finish before the server-level access-policy subrequest.
+# The internal 418 only selects this named location; clients always receive 204.
+# Credentials are deliberately unsupported here: the actual request still has
+# to pass both the access policy and the application's CORS middleware.
+error_page 418 = @lmm_api_cors_preflight;
+location @lmm_api_cors_preflight {
+    auth_request off;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Access-Control-Allow-Methods $http_access_control_request_method always;
+    add_header Access-Control-Allow-Headers $http_access_control_request_headers always;
+    add_header Vary "Origin, Access-Control-Request-Method, Access-Control-Request-Headers" always;
+    return 204;
+}
+
 # Administrative API, OAuth API callbacks, relay APIs, and compatibility APIs.
-location ^~ /api/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location = /api { try_files /.__lmm_backend__ @lmm_api_backend; }
-location = /mcp { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /mcp/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /v1/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location = /v1 { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /v1beta/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location = /v1beta { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /pg/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /mj/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /suno/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /kling/v1/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location = /jimeng { try_files /.__lmm_backend__ @lmm_api_backend; }
-location ^~ /jimeng/ { try_files /.__lmm_backend__ @lmm_api_backend; }
-location = /dashboard/billing/subscription { try_files /.__lmm_backend__ @lmm_api_backend; }
-location = /dashboard/billing/usage { try_files /.__lmm_backend__ @lmm_api_backend; }
+# A rewrite-phase return is safe here and is the only path around auth_request;
+# every non-OPTIONS method continues through the inherited access policy.
+location ^~ /api/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location = /api {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location = /mcp {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /mcp/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /v1/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location = /v1 {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /v1beta/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location = /v1beta {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /pg/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /mj/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /suno/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /kling/v1/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location = /jimeng {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location ^~ /jimeng/ {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location = /dashboard/billing/subscription {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
+location = /dashboard/billing/usage {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
 
 # Gin's dynamic /:mode/mj group. Restrict mode to one path segment.
-location ~ ^/[^/]+/mj(?:/|$) { try_files /.__lmm_backend__ @lmm_api_backend; }
+location ~ ^/[^/]+/mj(?:/|$) {
+    set $lmm_access_policy_original_uri $uri;
+    if ($request_method = OPTIONS) { return 418; }
+    try_files /.__lmm_backend__ @lmm_api_backend;
+}
 
 # Build-generated assets are content-addressed. A missing asset must be a 404,
 # never index.html, otherwise an old page can receive HTML as JS or CSS.

--- a/deploy/nginx/lmm-api-region-policy.conf
+++ b/deploy/nginx/lmm-api-region-policy.conf
@@ -48,5 +48,7 @@ location = /internal/errors/access-policy {
     proxy_set_header X-LMM-CN-Source $lmm_cn_source;
     proxy_set_header X-LMM-Access-Policy $lmm_access_policy_result;
     proxy_set_header X-LMM-Internal-Error access-policy;
+    proxy_set_header X-LMM-Original-URI $request_uri;
+    proxy_set_header X-LMM-Original-Accept $http_accept;
     proxy_intercept_errors off;
 }

--- a/deploy/nginx/lmm-api-region-policy.conf
+++ b/deploy/nginx/lmm-api-region-policy.conf
@@ -48,7 +48,7 @@ location = /internal/errors/access-policy {
     proxy_set_header X-LMM-CN-Source $lmm_cn_source;
     proxy_set_header X-LMM-Access-Policy $lmm_access_policy_result;
     proxy_set_header X-LMM-Internal-Error access-policy;
-    proxy_set_header X-LMM-Original-URI $request_uri;
+    proxy_set_header X-LMM-Original-URI $lmm_access_policy_original_uri;
     proxy_set_header X-LMM-Original-Accept $http_accept;
     proxy_intercept_errors off;
 }

--- a/deploy/production/test-go-package-roundtrip.sh
+++ b/deploy/production/test-go-package-roundtrip.sh
@@ -99,7 +99,8 @@ if "${query_args[@]}" -Qq | grep -Fxq lmm-api; then
 fi
 [[ $("${query_args[@]}" -Q lmm-api-go-bin 2>/dev/null) == "lmm-api-go-bin $candidate_version-1" ]]
 [[ -x $pacman_root/usr/bin/lmm-api ]]
-[[ ! -e $pacman_root/usr/bin/lmm-api-go ]]
+[[ -L $pacman_root/usr/bin/lmm-api-go ]]
+[[ $(readlink "$pacman_root/usr/bin/lmm-api-go") == lmm-api ]]
 [[ ! -e $pacman_root/usr/bin/lmm-api-deploy ]]
 [[ $(stat -c '%a' "$pacman_root/etc/lmm-api-go") == 700 ]]
 [[ $(stat -c '%a' "$pacman_root/etc/lmm-api-go/lmm-api-go.env") == 600 ]]
@@ -167,6 +168,8 @@ fakeroot -- "${direct_install[@]}" -Rdd lmm-api-go >/dev/null
 fakeroot -- "${direct_install[@]}" -U "$new_go" >/dev/null
 [[ $("${direct_query[@]}" -Q lmm-api-go-bin 2>/dev/null) == "lmm-api-go-bin $candidate_version-1" ]]
 [[ $("$direct_pacman_root/usr/bin/lmm-api") == "$candidate_version" ]]
+[[ -L $direct_pacman_root/usr/bin/lmm-api-go ]]
+[[ $("$direct_pacman_root/usr/bin/lmm-api-go") == "$candidate_version" ]]
 fakeroot -- "${direct_install[@]}" -Rdd lmm-api-go-bin >/dev/null
 fakeroot -- "${direct_install[@]}" -U "$old_direct" >/dev/null
 [[ $("${direct_query[@]}" -Q lmm-api-go 2>/dev/null) == "lmm-api-go $old_go_version" ]]
@@ -183,15 +186,11 @@ install -d -m0700 "$transition_packages"
 
 build_transition_go_package() {
   local phase version work
-  local transition_conflicts='' transition_replaces=''
   phase=$1
   version=$2
   work=$tmp/transition-$phase
-  if [[ $phase == t1 ]]; then
-    transition_conflicts="'lmm-api-deploy' 'lmm-api-deploy-bin'"
-    transition_replaces="'lmm-api-deploy-bin'"
-  fi
   install -d -m0700 "$work"
+  cp "$repo/packaging/common/lmm-api/lmm-api-cli-phase.sh" "$work/"
   cat >"$work/PKGBUILD" <<EOF
 pkgname=lmm-api-go-bin
 pkgver=$version
@@ -199,25 +198,24 @@ pkgrel=1
 pkgdesc='LMM API unified CLI transition fixture'
 arch=('any')
 license=('AGPL-3.0-only')
-provides=("lmm-api=$version")
-conflicts=($transition_conflicts)
-replaces=($transition_replaces)
+source "\${startdir:?}/lmm-api-cli-phase.sh"
+_lmm_cli_phase=$phase
+lmm_cli_phase_apply_metadata "\$_lmm_cli_phase" "\$pkgver" \\
+  'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-git'
 options=('!strip')
 package() {
   install -Dm0755 /usr/bin/true "\${pkgdir}/usr/bin/lmm-api"
+  lmm_cli_phase_install_compatibility_alias "\$_lmm_cli_phase" "\$pkgdir"
+  install -Dm0644 "$repo/packaging/common/lmm-api/lmm-api.service" \\
+    "\${pkgdir}/usr/lib/systemd/system/lmm-api.service"
   install -Dm0644 "$repo/packaging/common/lmm-api/lmm-api-operator.sysusers" \\
     "\${pkgdir}/usr/lib/sysusers.d/lmm-api-operator.conf"
   install -Dm0644 "$repo/packaging/common/lmm-api/lmm-api-operator.tmpfiles" \\
     "\${pkgdir}/usr/lib/tmpfiles.d/lmm-api-operator.conf"
   install -Dm0440 "$repo/packaging/common/lmm-api/lmm-api-operator.sudoers" \\
     "\${pkgdir}/etc/sudoers.d/lmm-api-operator"
+}
 EOF
-  if [[ $phase == t0 ]]; then
-    cat >>"$work/PKGBUILD" <<'EOF'
-  ln -s lmm-api "${pkgdir}/usr/bin/lmm-api-go"
-EOF
-  fi
-  printf '}\n' >>"$work/PKGBUILD"
   (cd "$work" && PKGDEST="$transition_packages" makepkg --force --nodeps --noconfirm >/dev/null)
 }
 
@@ -246,6 +244,15 @@ legacy_deploy_package=$(find "$transition_packages" -maxdepth 1 -type f -name 'l
   printf 'go-package-roundtrip: T0/T1 transition package fixture is incomplete\n' >&2
   exit 1
 }
+t0_pkginfo=$(bsdtar -xOf "$t0_package" .PKGINFO)
+t1_pkginfo=$(bsdtar -xOf "$t1_package" .PKGINFO)
+grep -Fqx 'provides = lmm-api-go=0.1.59' <<<"$t0_pkginfo"
+if grep -Fq 'lmm-api-deploy' <<<"$t0_pkginfo"; then
+  printf 'go-package-roundtrip: T0 package mutates the legacy deploy package\n' >&2
+  exit 1
+fi
+grep -Fqx 'conflict = lmm-api-deploy-bin' <<<"$t1_pkginfo"
+grep -Fqx 'replaces = lmm-api-deploy-bin' <<<"$t1_pkginfo"
 
 install -d -m0755 "$transition_pacman_root/etc" "$transition_pacman_root/usr" \
   "$transition_pacman_root/var/lib/pacman/local" "$transition_pacman_root/var/cache/pacman/pkg" \
@@ -260,6 +267,8 @@ fakeroot -- "${transition_install[@]}" -U "$legacy_deploy_package" "$t0_package"
 [[ $("${transition_query[@]}" -Q lmm-api-deploy-bin 2>/dev/null) == 'lmm-api-deploy-bin 0.1.57-1' ]]
 [[ -x $transition_pacman_root/usr/bin/lmm-api && -L $transition_pacman_root/usr/bin/lmm-api-go ]]
 [[ -x $transition_pacman_root/usr/bin/lmm-api-deploy ]]
+[[ -f $transition_pacman_root/usr/lib/systemd/system/lmm-api.service ]]
+[[ -f $transition_pacman_root/etc/sudoers.d/lmm-api-operator ]]
 
 # The target controller removes the clean legacy deploy package after the
 # rollback watchdog is armed; pacman -U does not apply replaces to local files.
@@ -272,6 +281,7 @@ if "${transition_query[@]}" -Qq | grep -Fxq lmm-api-deploy-bin; then
 fi
 [[ -x $transition_pacman_root/usr/bin/lmm-api ]]
 [[ ! -e $transition_pacman_root/usr/bin/lmm-api-go && ! -e $transition_pacman_root/usr/bin/lmm-api-deploy ]]
+[[ -f $transition_pacman_root/usr/lib/systemd/system/lmm-api.service ]]
 [[ -f $transition_pacman_root/etc/sudoers.d/lmm-api-operator ]]
 
 fakeroot -- "${transition_install[@]}" -U "$t0_package" >/dev/null
@@ -279,6 +289,7 @@ fakeroot -- "${transition_install[@]}" -U "$t0_package" >/dev/null
 [[ -x $transition_pacman_root/usr/bin/lmm-api && -L $transition_pacman_root/usr/bin/lmm-api-go ]]
 [[ $(readlink "$transition_pacman_root/usr/bin/lmm-api-go") == lmm-api ]]
 [[ ! -e $transition_pacman_root/usr/bin/lmm-api-deploy ]]
+[[ -f $transition_pacman_root/usr/lib/systemd/system/lmm-api.service ]]
 [[ -f $transition_pacman_root/etc/sudoers.d/lmm-api-operator ]]
 
 printf 'split cutover, direct Go, and T0-T1-T0 package roundtrips verified\n'

--- a/deploy/production/test-release-artifact-contract.sh
+++ b/deploy/production/test-release-artifact-contract.sh
@@ -6,6 +6,7 @@ ROOT=$(git -C "$HERE" rev-parse --show-toplevel)
 readonly HERE ROOT
 readonly GO_WORKFLOW="$ROOT/.github/workflows/release-go.yml"
 readonly WEB_WORKFLOW="$ROOT/.github/workflows/release-web.yml"
+readonly PROMOTE_WORKFLOW="$ROOT/.github/workflows/promote-release.yml"
 readonly GO_PKGBUILD="$ROOT/packaging/aur/lmm-api-go-bin/PKGBUILD"
 readonly WEB_PKGBUILD="$ROOT/packaging/aur/lmm-api-web-bin/PKGBUILD"
 
@@ -22,7 +23,7 @@ reject_literal() {
   ! grep -Fq -- "$literal" "$file" || fail "$message"
 }
 
-for file in "$GO_WORKFLOW" "$WEB_WORKFLOW" "$GO_PKGBUILD" "$WEB_PKGBUILD"; do
+for file in "$GO_WORKFLOW" "$WEB_WORKFLOW" "$PROMOTE_WORKFLOW" "$GO_PKGBUILD" "$WEB_PKGBUILD"; do
   [[ -f $file ]] || fail "missing contract input: $file"
 done
 
@@ -53,6 +54,10 @@ for gate in 'git merge-base --is-ancestor' 'git rev-list -n 1' \
   'cosign sign-blob' 'cosign verify-blob' 'sha256sum --check'; do
   require_literal "$GO_WORKFLOW" "$gate" "Go release omits gate: $gate"
 done
+require_literal "$GO_WORKFLOW" 'actions: read' \
+  'Go release verifier cannot read workflow runs'
+require_literal "$PROMOTE_WORKFLOW" 'timeout-minutes: 15' \
+  'promotion job timeout does not cover the full governance poll budget'
 
 # The next Web archive has the same revision generator and remains sole owner
 # of the immutable frontend payload.

--- a/deploy/production/test-release-artifact-contract.sh
+++ b/deploy/production/test-release-artifact-contract.sh
@@ -75,12 +75,16 @@ require_literal "$GO_PKGBUILD" '_legacy_cli_archive_version=0.1.57' \
   'Go package lost the explicit legacy CLI archive boundary'
 require_literal "$GO_PKGBUILD" 'RELEASE_ASSET_SHA256' \
   'Go package does not preserve its signed release-asset digest'
-require_literal "$GO_PKGBUILD" '_t1_cli_version=0.1.60' \
-  'Go package lost the explicit T1 single-CLI boundary'
-require_literal "$GO_PKGBUILD" "conflicts+=('lmm-api-deploy' 'lmm-api-deploy-bin')" \
-  'T1 Go package does not conflict with legacy deploy packages'
-require_literal "$GO_PKGBUILD" "replaces+=('lmm-api-deploy-bin')" \
-  'T1 Go package does not replace the legacy deploy package'
+require_literal "$GO_PKGBUILD" 'lmm_cli_phase_for_binary_release' \
+  'Go package does not derive its phase from the shared transition contract'
+require_literal "$ROOT/packaging/common/lmm-api/lmm-api-cli-phase.sh" \
+  'LMM_CLI_T1_RELEASE=0.1.60' 'shared CLI phase helper lost the T1 boundary'
+require_literal "$ROOT/packaging/common/lmm-api/lmm-api-cli-phase.sh" \
+  "conflicts+=('lmm-api-deploy' 'lmm-api-deploy-bin')" \
+  'T1 helper does not conflict with legacy deploy packages'
+require_literal "$ROOT/packaging/common/lmm-api/lmm-api-cli-phase.sh" \
+  "replaces+=('lmm-api-deploy-bin')" \
+  'T1 helper does not replace the legacy deploy package'
 # shellcheck disable=SC2016 # Deliberately inspect PKGBUILD source literals.
 require_literal "$GO_PKGBUILD" '[[ ! -e ${bundle}/frontend-dist ]]' \
   'future Go packages do not reject a bundled frontend'
@@ -94,9 +98,9 @@ require_literal "$WEB_PKGBUILD" 'RELEASE_ASSET_SHA256' \
   'future Web package does not preserve its signed release-asset digest'
 
 for immutable in \
-  'pkgver=0.1.57' \
-  "'b1d80713438868bcab522d9f1f6f7752c93ea4246e9eae1bab49b346b13f8105'" \
-  "'f41ca227ea711f35d864291693d1182684a2db9b9c4f46254f9e6d9bd274cb44'"; do
+  'pkgver=0.1.59' \
+  "'b170e4e4e5a4fe5d18eb78f61d87bbc19b00c1e19578bef234c0f2c4d12103a9'" \
+  "'0f2086563a321fe5cd32d6ae3cebe53ff3f01ac129d7a4d145d2332745a35b1d'"; do
   require_literal "$GO_PKGBUILD" "$immutable" \
     'tracked Go PKGBUILD no longer pins the existing immutable release'
 done
@@ -115,8 +119,8 @@ for pkgbuild in \
   "$ROOT/packaging/aur/lmm-api-go/PKGBUILD" \
   "$ROOT/packaging/aur/lmm-api-go-git/PKGBUILD" \
   "$ROOT/packaging/local/lmm-api-go/PKGBUILD"; do
-  reject_literal "$pkgbuild" 'usr/bin/lmm-api-go' \
-    "final Go package still installs the legacy CLI: $pkgbuild"
+  require_literal "$pkgbuild" 'lmm_cli_phase_install_compatibility_alias' \
+    "T0 Go package does not preserve the compatibility CLI: $pkgbuild"
 done
 
 TMPDIR=${TMPDIR:?set TMPDIR to a marker-owned test workspace} \

--- a/deploy/test-nginx-access-policy-preflight.sh
+++ b/deploy/test-nginx-access-policy-preflight.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+locations_source=$repo/deploy/nginx/lmm-api-locations.conf
+region_policy_source=$repo/deploy/nginx/lmm-api-region-policy.conf
+mime_source=$repo/deploy/nginx/mime.types
+
+fail() { printf 'nginx-preflight-test: %s\n' "$*" >&2; exit 1; }
+for command in curl nginx python3 sed; do
+  command -v "$command" >/dev/null 2>&1 || fail "required command is unavailable: $command"
+done
+for source in "$locations_source" "$region_policy_source" "$mime_source"; do
+  [[ -f $source && ! -L $source ]] || fail "tracked nginx asset is missing or unsafe: $source"
+done
+
+work=$(mktemp -d)
+backend_pid=
+nginx_pid=
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  if [[ -n $nginx_pid ]] && kill -0 "$nginx_pid" 2>/dev/null; then
+    kill "$nginx_pid" 2>/dev/null || true
+    wait "$nginx_pid" 2>/dev/null || true
+  fi
+  if [[ -n $backend_pid ]] && kill -0 "$backend_pid" 2>/dev/null; then
+    kill "$backend_pid" 2>/dev/null || true
+    wait "$backend_pid" 2>/dev/null || true
+  fi
+  rm -rf -- "$work"
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+upstream_port_file=$work/upstream.port
+upstream_log=$work/upstream.log
+: >"$upstream_log"
+python3 - "$upstream_port_file" "$upstream_log" <<'PY' &
+import http.server
+import pathlib
+import sys
+
+port_file = pathlib.Path(sys.argv[1])
+request_log = pathlib.Path(sys.argv[2])
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+
+    def log_message(self, _format, *_args):
+        return
+
+    def record(self):
+        with request_log.open("a", encoding="utf-8") as stream:
+            stream.write(
+                f"{self.command}\t{self.path}\t"
+                f"{self.headers.get('X-LMM-Internal-Error', '')}\t"
+                f"{self.headers.get('X-LMM-Original-URI', '')}\n"
+            )
+
+    def respond(self):
+        self.record()
+        if self.path == "/internal/access-ip-policy":
+            self.send_response(403)
+            self.send_header("X-LMM-Access-Policy", "denied")
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if self.path == "/internal/errors/access-policy":
+            body = b'{"error":{"code":"IP_ACCESS_ROUTE_REJECTED"}}\n'
+            self.send_response(451)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        body = b'{"unexpected":"backend reached"}\n'
+        self.send_response(500)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    do_GET = respond
+    do_POST = respond
+    do_OPTIONS = respond
+
+
+server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+port_file.write_text(str(server.server_address[1]), encoding="ascii")
+server.serve_forever()
+PY
+backend_pid=$!
+
+for _ in $(seq 1 100); do
+  [[ -s $upstream_port_file ]] && break
+  kill -0 "$backend_pid" 2>/dev/null || fail 'mock policy backend exited before publishing its port'
+  sleep 0.05
+done
+[[ -s $upstream_port_file ]] || fail 'mock policy backend did not become ready'
+upstream_port=$(<"$upstream_port_file")
+[[ $upstream_port =~ ^[0-9]+$ ]] || fail 'mock policy backend published an invalid port'
+
+sed "s#127\\.0\\.0\\.1:3000#127.0.0.1:$upstream_port#g" \
+  "$region_policy_source" >"$work/region-policy.conf"
+sed "s#/etc/nginx/lmm-api-mime.types#$mime_source#g" \
+  "$locations_source" >"$work/locations.conf"
+
+socket=$work/nginx.sock
+mkdir -p "$work/client_temp" "$work/proxy_temp" "$work/fastcgi_temp" \
+  "$work/uwsgi_temp" "$work/scgi_temp"
+cat >"$work/nginx.conf" <<EOF
+worker_processes 1;
+pid $work/nginx.pid;
+error_log $work/error.log notice;
+events { worker_connections 128; }
+http {
+    access_log $work/access.log;
+    client_body_temp_path $work/client_temp;
+    proxy_temp_path $work/proxy_temp;
+    fastcgi_temp_path $work/fastcgi_temp;
+    uwsgi_temp_path $work/uwsgi_temp;
+    scgi_temp_path $work/scgi_temp;
+    map \$http_upgrade \$connection_upgrade {
+        default upgrade;
+        '' close;
+    }
+    server {
+        listen unix:$socket;
+        server_name localhost;
+        set \$lmm_geoip_country_code US;
+        set \$lmm_cn_source 0;
+        include $work/region-policy.conf;
+        include $work/locations.conf;
+    }
+}
+EOF
+nginx -p "$work/" -c "$work/nginx.conf" -t >/dev/null
+nginx -p "$work/" -c "$work/nginx.conf" -g 'daemon off;' &
+nginx_pid=$!
+for _ in $(seq 1 100); do
+  [[ -S $socket ]] && break
+  kill -0 "$nginx_pid" 2>/dev/null || {
+    cat "$work/error.log" >&2 || true
+    fail 'nginx exited before its test socket became ready'
+  }
+  sleep 0.05
+done
+[[ -S $socket ]] || fail 'nginx test socket did not become ready'
+
+assert_header() {
+  local headers=$1 expected=$2
+  grep -Eiq -- "$expected" "$headers" || {
+    cat "$headers" >&2
+    fail "response is missing header pattern: $expected"
+  }
+}
+
+preflight() {
+  local path=$1 headers=$work/headers body=$work/body status
+  : >"$headers"
+  : >"$body"
+  status=$(curl --silent --show-error --unix-socket "$socket" \
+    --request OPTIONS --output "$body" --dump-header "$headers" \
+    --header 'Origin: https://browser.example' \
+    --header 'Access-Control-Request-Method: POST' \
+    --header 'Access-Control-Request-Headers: authorization, content-type' \
+    --write-out '%{http_code}' "http://localhost$path")
+  [[ $status == 204 ]] || fail "OPTIONS $path returned HTTP $status instead of 204"
+  tr -d '\r' <"$headers" >"$headers.normalized"
+  assert_header "$headers.normalized" '^Access-Control-Allow-Origin: \*$'
+  assert_header "$headers.normalized" '^Access-Control-Allow-Methods: POST$'
+  assert_header "$headers.normalized" '^Access-Control-Allow-Headers: authorization, content-type$'
+  assert_header "$headers.normalized" '^Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers$'
+  if grep -Eiq '^Access-Control-Allow-Credentials:' "$headers.normalized"; then
+    fail "OPTIONS $path unexpectedly permits credentialed cross-origin requests"
+  fi
+  [[ ! -s $body ]] || fail "OPTIONS $path returned a non-empty body"
+}
+
+api_paths=(
+  /api/status
+  /api
+  /mcp
+  /mcp/tools
+  /v1
+  /v1/chat/completions
+  /v1beta
+  /v1beta/models
+  /pg/task
+  /mj/task
+  /suno/task
+  /kling/v1/task
+  /jimeng
+  /jimeng/task
+  /dashboard/billing/subscription
+  /dashboard/billing/usage
+  /tenant/mj/task
+)
+for path in "${api_paths[@]}"; do
+  preflight "$path"
+done
+[[ ! -s $upstream_log ]] || {
+  cat "$upstream_log" >&2
+  fail 'an API preflight reached the access-policy or application upstream'
+}
+
+# A non-OPTIONS API request must still run the inherited access policy and
+# surface its structured denial rather than reaching the application route.
+# The duplicate slash also proves that the normalized location-matching URI,
+# rather than raw $request_uri, is preserved across the error-page redirect.
+status=$(curl --silent --show-error --path-as-is --unix-socket "$socket" \
+  --request GET --output "$work/get.body" --dump-header "$work/get.headers" \
+  --header 'Origin: https://browser.example' --header 'Accept: application/json' \
+  --write-out '%{http_code}' 'http://localhost//v1/models')
+[[ $status == 451 ]] || fail "GET //v1/models returned HTTP $status instead of the policy's 451"
+grep -Fq 'IP_ACCESS_ROUTE_REJECTED' "$work/get.body" || fail 'GET policy denial lost its JSON body'
+grep -Fq $'GET\t/internal/access-ip-policy\t' "$upstream_log" || fail 'GET bypassed the access-policy subrequest'
+grep -Fq $'GET\t/internal/errors/access-policy\taccess-policy\t/v1/models' "$upstream_log" || {
+  cat "$upstream_log" >&2
+  fail 'GET denial did not preserve the normalized trusted policy-error URI'
+}
+if grep -Eq $'GET\t/+v1/models\t' "$upstream_log"; then
+  fail 'denied GET reached the application upstream'
+fi
+
+# Frontend routes and lookalike prefixes are not API preflights and therefore
+# must not gain the OPTIONS exception.
+for path in /oauth/mj /static/mj/asset.js /apiary; do
+  status=$(curl --silent --show-error --unix-socket "$socket" \
+    --request OPTIONS --output /dev/null \
+    --header 'Origin: https://browser.example' \
+    --header 'Access-Control-Request-Method: POST' \
+    --write-out '%{http_code}' "http://localhost$path")
+  [[ $status == 451 ]] || fail "non-API OPTIONS $path unexpectedly returned HTTP $status"
+done
+
+printf 'nginx access-policy preflight tests passed\n'

--- a/deploy/test-nginx-mime.sh
+++ b/deploy/test-nginx-mime.sh
@@ -18,7 +18,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p -- "$work/assets"
+mkdir -p -- "$work/assets" "$work/client_temp" "$work/proxy_temp" \
+  "$work/fastcgi_temp" "$work/uwsgi_temp" "$work/scgi_temp"
 printf 'export const ready = true\n' >"$work/assets/app.js"
 printf 'body { color: black; }\n' >"$work/assets/app.css"
 printf '{"ready":true}\n' >"$work/assets/app.json"
@@ -32,6 +33,12 @@ pid $work/nginx.pid;
 error_log $work/error.log notice;
 events { worker_connections 16; }
 http {
+    access_log $work/access.log;
+    client_body_temp_path $work/client_temp;
+    proxy_temp_path $work/proxy_temp;
+    fastcgi_temp_path $work/fastcgi_temp;
+    uwsgi_temp_path $work/uwsgi_temp;
+    scgi_temp_path $work/scgi_temp;
     # Match production: no global mime.types include.
     default_type application/octet-stream;
     server {

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -10,14 +10,17 @@ versioned application packages.
 | Web frontend | — | `lmm-api-web-bin` | — | `/usr/share/lmm-api-web/frontend-dist` |
 | Rust preview | — | `lmm-api-rs-bin` | `lmm-api-rs-git` | `/usr/bin/lmm-api-rs` |
 
-The historical compatibility release T0 kept a package-owned
-`/usr/bin/lmm-api-go` symlink and did not remove an already-installed
-`lmm-api-deploy-bin`, so a rollback to N-1 could not strand the host. New
+The compatibility release T0 (`lmm-api-go-bin` 0.1.59) keeps a package-owned
+`/usr/bin/lmm-api-go` symlink and does not remove an already-installed
+`lmm-api-deploy-bin`, so a rollback to N-1 cannot strand the host. Stable
+source, `-git`, local, and prebuilt recipes all consume the same canonical
+`lmm-api-cli-phase.sh` contract; they must not enter T1 independently. New
 services, docs, automation, and release archives use `lmm-api`. No new
 deploy-only artifact is published.
 
-T1 removes the alias and declares an exact conflict/replacement for
-`lmm-api-deploy-bin`; the historical T0 Go package is its rollback package and
+T1 starts at `lmm-api-go-bin` 0.1.60, removes the alias, and declares an exact
+conflict/replacement for `lmm-api-deploy-bin`; the historical T0 Go package is
+its rollback package and
 already owns the operator user, sudoers, sysusers, and tmpfiles resources
 needed after rollback. Local `pacman -U` does not apply `replaces`, so the armed
 target controller verifies those T0 resources and the legacy package owner/Qkk,
@@ -50,9 +53,12 @@ Run these checks after changing a recipe:
 
 ```bash
 TMPDIR="${TMPDIR:?marker-owned workspace required}" bash packaging/aur/test-matrix.sh
+TMPDIR="$TMPDIR" bash packaging/aur/verify-go-release-pins.sh
 TMPDIR="$TMPDIR" bash packaging/aur/test-bin-makepkg.sh
 TMPDIR="$TMPDIR" bash deploy/production/test-release-artifact-contract.sh
 ```
 
 Regenerate every changed tracked `.SRCINFO` with
-`makepkg --printsrcinfo > .SRCINFO` and compare it before commit.
+`makepkg --printsrcinfo > .SRCINFO` and compare it before commit. When copying a
+recipe into its standalone AUR package base, copy `lmm-api-cli-phase.sh` with
+`cp -L` and require its pinned SHA-256; never publish the monorepo symlink.

--- a/packaging/aur/README.md
+++ b/packaging/aur/README.md
@@ -59,6 +59,15 @@ TMPDIR="$TMPDIR" bash deploy/production/test-release-artifact-contract.sh
 ```
 
 Regenerate every changed tracked `.SRCINFO` with
-`makepkg --printsrcinfo > .SRCINFO` and compare it before commit. When copying a
-recipe into its standalone AUR package base, copy `lmm-api-cli-phase.sh` with
-`cp -L` and require its pinned SHA-256; never publish the monorepo symlink.
+`makepkg --printsrcinfo > .SRCINFO` and compare it before commit. Export a Go
+recipe into a new standalone package-base directory only through the canonical
+stager:
+
+```bash
+packaging/aur/export-go-package-base.sh lmm-api-go-bin "$DESTINATION"
+```
+
+The destination must not already exist. The stager restricts the file
+inventory, verifies the canonical helper digest, and materializes
+`lmm-api-cli-phase.sh` as a regular file. Never copy or publish the monorepo
+symlink directly.

--- a/packaging/aur/check-candidate-version.sh
+++ b/packaging/aur/check-candidate-version.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail() {
+  printf 'check-aur-candidate-version: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -eq 3 ]] || fail 'usage: check-candidate-version.sh PACKAGE CANDIDATE PUBLISHED'
+readonly package=$1 candidate=$2 published=$3
+[[ $package =~ ^[a-z0-9@._+-]+$ && $candidate != *[[:space:]]* && $published != *[[:space:]]* ]] ||
+  fail 'package or version is invalid'
+command -v vercmp >/dev/null 2>&1 || fail 'vercmp is unavailable'
+
+(( $(vercmp "$published" "$candidate") <= 0 )) ||
+  fail "$package candidate $candidate is older than published $published"
+printf '%s candidate %s is not older than published %s\n' "$package" "$candidate" "$published"

--- a/packaging/aur/export-go-package-base.sh
+++ b/packaging/aur/export-go-package-base.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+readonly HERE
+CANONICAL_HELPER="$(cd -- "$HERE/../common/lmm-api" && pwd -P)/lmm-api-cli-phase.sh"
+readonly CANONICAL_HELPER
+readonly CANONICAL_HELPER_SHA256=2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935
+
+fail() {
+  printf 'export-go-package-base: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -eq 2 ]] || fail 'usage: export-go-package-base.sh PACKAGE DESTINATION'
+readonly package=$1 destination=$2
+case $package in
+  lmm-api-go | lmm-api-go-bin | lmm-api-go-git) ;;
+  *) fail "unsupported Go AUR package: $package" ;;
+esac
+
+readonly source_dir="$HERE/$package"
+[[ -d $source_dir && ! -L $source_dir ]] || fail 'package source directory is missing or unsafe'
+[[ -f $CANONICAL_HELPER && ! -L $CANONICAL_HELPER ]] || fail 'canonical CLI phase helper is missing or unsafe'
+actual_helper_sha256=$(sha256sum "$CANONICAL_HELPER")
+actual_helper_sha256=${actual_helper_sha256%% *}
+[[ $actual_helper_sha256 == "$CANONICAL_HELPER_SHA256" ]] ||
+  fail 'canonical CLI phase helper digest changed without updating the export contract'
+
+for required in PKGBUILD .SRCINFO lmm-api-cli-phase.sh; do
+  [[ -e $source_dir/$required || -L $source_dir/$required ]] || fail "package source is missing $required"
+done
+shopt -s dotglob nullglob
+for entry in "$source_dir"/*; do
+  name=${entry##*/}
+  case $name in
+    PKGBUILD | .SRCINFO)
+      [[ -f $entry && ! -L $entry ]] || fail "$package/$name is not a regular file"
+      ;;
+    lmm-api-cli-phase.sh)
+      [[ -L $entry ]] || fail "$package/$name must reference the canonical helper"
+      resolved=$(realpath -e -- "$entry") || fail "$package/$name is dangling"
+      [[ $resolved == "$CANONICAL_HELPER" ]] || fail "$package/$name escapes the canonical helper"
+      ;;
+    *) fail "$package contains an unexpected package-base entry: $name" ;;
+  esac
+done
+shopt -u dotglob nullglob
+
+parent=$(dirname -- "$destination")
+base=$(basename -- "$destination")
+[[ -d $parent && ! -L $parent ]] || fail 'destination parent must already exist and may not be a symlink'
+[[ ! -e $destination && ! -L $destination ]] || fail 'destination already exists'
+stage=$(mktemp -d "$parent/.${base}.export.XXXXXXXX")
+cleanup() { rm -rf -- "$stage"; }
+trap cleanup EXIT
+
+install -m0644 "$source_dir/PKGBUILD" "$stage/PKGBUILD"
+install -m0644 "$source_dir/.SRCINFO" "$stage/.SRCINFO"
+install -m0644 "$CANONICAL_HELPER" "$stage/lmm-api-cli-phase.sh"
+[[ $(find "$stage" -mindepth 1 -maxdepth 1 -type l -print -quit) == "" ]] ||
+  fail 'export unexpectedly contains a symlink'
+mapfile -t exported < <(find "$stage" -mindepth 1 -maxdepth 1 -printf '%f\n' | LC_ALL=C sort)
+[[ ${exported[*]} == '.SRCINFO PKGBUILD lmm-api-cli-phase.sh' ]] ||
+  fail 'exported package-base file inventory is invalid'
+exported_helper_sha256=$(sha256sum "$stage/lmm-api-cli-phase.sh")
+exported_helper_sha256=${exported_helper_sha256%% *}
+[[ $exported_helper_sha256 == "$CANONICAL_HELPER_SHA256" ]] ||
+  fail 'exported CLI phase helper digest is invalid'
+
+mv -- "$stage" "$destination"
+trap - EXIT
+printf '%s\n' "$destination"

--- a/packaging/aur/lmm-api-go-bin/.SRCINFO
+++ b/packaging/aur/lmm-api-go-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go-bin
 	pkgdesc = LMM API Go backend, native CLI, and systemd service (prebuilt)
-	pkgver = 0.1.57
+	pkgver = 0.1.59
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64
@@ -18,28 +18,30 @@ pkgbase = lmm-api-go-bin
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api=0.1.57
-	provides = lmm-api-go=0.1.57
+	provides = lmm-api=0.1.59
+	provides = lmm-api-go=0.1.59
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git
 	conflicts = lmm-api-go
 	conflicts = lmm-api-go-git
-	noextract = lmm-api-go-0.1.57-linux-amd64.tar.gz
-	noextract = lmm-api-go-0.1.57-linux-arm64.tar.gz
+	noextract = lmm-api-go-0.1.59-linux-amd64.tar.gz
+	noextract = lmm-api-go-0.1.59-linux-arm64.tar.gz
 	options = !strip
 	backup = etc/lmm-api-go/lmm-api-go.env
-	source_x86_64 = lmm-api-go-0.1.57-linux-amd64.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.57/lmm-api-go-0.1.57-linux-amd64.tar.gz
-	source_x86_64 = lmm-api-go-0.1.57-linux-amd64.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.57/lmm-api-go-0.1.57-linux-amd64.tar.gz.sha256
-	source_x86_64 = lmm-api-go-0.1.57-linux-amd64.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.57/lmm-api-go-0.1.57-linux-amd64.tar.gz.sigstore.json
-	sha256sums_x86_64 = b1d80713438868bcab522d9f1f6f7752c93ea4246e9eae1bab49b346b13f8105
-	sha256sums_x86_64 = 5653dbf767ec9e62e078c6cdc492da5b2ec19fa5208376291be429bdc295791f
-	sha256sums_x86_64 = ecb422ef10ef6b4c44cd2749e3533d242087be685b9972176a290c248f31ae8c
-	source_aarch64 = lmm-api-go-0.1.57-linux-arm64.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.57/lmm-api-go-0.1.57-linux-arm64.tar.gz
-	source_aarch64 = lmm-api-go-0.1.57-linux-arm64.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.57/lmm-api-go-0.1.57-linux-arm64.tar.gz.sha256
-	source_aarch64 = lmm-api-go-0.1.57-linux-arm64.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.57/lmm-api-go-0.1.57-linux-arm64.tar.gz.sigstore.json
-	sha256sums_aarch64 = f41ca227ea711f35d864291693d1182684a2db9b9c4f46254f9e6d9bd274cb44
-	sha256sums_aarch64 = 1c9f32ecd8988c4a5af7ee1837543dc6d2277f5dd7ea7a22301f37bc812f25b3
-	sha256sums_aarch64 = 9c2d5311d94132653dff91c38771cd6273e5fab20f555fd01b99017f85c7a5bb
+	source = lmm-api-cli-phase.sh
+	sha256sums = 2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935
+	source_x86_64 = lmm-api-go-0.1.59-linux-amd64.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.59/lmm-api-go-0.1.59-linux-amd64.tar.gz
+	source_x86_64 = lmm-api-go-0.1.59-linux-amd64.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.59/lmm-api-go-0.1.59-linux-amd64.tar.gz.sha256
+	source_x86_64 = lmm-api-go-0.1.59-linux-amd64.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.59/lmm-api-go-0.1.59-linux-amd64.tar.gz.sigstore.json
+	sha256sums_x86_64 = b170e4e4e5a4fe5d18eb78f61d87bbc19b00c1e19578bef234c0f2c4d12103a9
+	sha256sums_x86_64 = 5cd8f191b0f9ac121130558ee71f308725e3b5d70f96f7e70817b80a2e37b3dc
+	sha256sums_x86_64 = 6c9a118d46516cb43a8285bf42726861e3540623912fdeb05d0098b026a46bac
+	source_aarch64 = lmm-api-go-0.1.59-linux-arm64.tar.gz::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.59/lmm-api-go-0.1.59-linux-arm64.tar.gz
+	source_aarch64 = lmm-api-go-0.1.59-linux-arm64.tar.gz.sha256::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.59/lmm-api-go-0.1.59-linux-arm64.tar.gz.sha256
+	source_aarch64 = lmm-api-go-0.1.59-linux-arm64.tar.gz.sigstore.json::https://github.com/LIghtJUNction/api.lmm.best/releases/download/go-v0.1.59/lmm-api-go-0.1.59-linux-arm64.tar.gz.sigstore.json
+	sha256sums_aarch64 = 0f2086563a321fe5cd32d6ae3cebe53ff3f01ac129d7a4d145d2332745a35b1d
+	sha256sums_aarch64 = c06599dd776f4a0f722bb3efc5495e87539f49ed29afe743bf76307df933759d
+	sha256sums_aarch64 = 30b322c96a828b97c5395880f5de540c14629b39b2ee6fc8d74e244dec163b9d
 
 pkgname = lmm-api-go-bin

--- a/packaging/aur/lmm-api-go-bin/PKGBUILD
+++ b/packaging/aur/lmm-api-go-bin/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction <support@lmm.best>
 
 pkgname=lmm-api-go-bin
-pkgver=0.1.57
+pkgver=0.1.59
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, and systemd service (prebuilt)'
 arch=('x86_64' 'aarch64')
@@ -13,17 +13,10 @@ optdepends=(
   'postgresql: production database'
   'valkey: cache, rate limiting, and login sessions'
 )
-_set_cli_transition_metadata() {
-  provides=("lmm-api=${pkgver}")
-  conflicts=('lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-git')
-  replaces=()
-  if (( $(vercmp "${pkgver}" "${_t1_cli_version}") < 0 )); then
-    provides+=("lmm-api-go=${pkgver}")
-  else
-    conflicts+=('lmm-api-deploy' 'lmm-api-deploy-bin')
-    replaces+=('lmm-api-deploy-bin')
-  fi
-}
+source "${startdir:?}/lmm-api-cli-phase.sh"
+_lmm_cli_phase=$(lmm_cli_phase_for_binary_release "$pkgver")
+lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
+  'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-git'
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
 
@@ -32,10 +25,9 @@ _legacy_bundled_version=0.1.34
 _legacy_cli_archive_version=0.1.57
 _legacy_external_operator_version=0.1.57
 # go-v0.1.58 produced no release assets; 0.1.59 is T0 and 0.1.60 is T1.
-_t1_cli_version=0.1.60
-_set_cli_transition_metadata
 _artifact="lmm-api-go-${pkgver}-linux"
 _release_base="${url}/releases/download/${_release_tag}"
+source=('lmm-api-cli-phase.sh')
 source_x86_64=(
   "${_artifact}-amd64.tar.gz::${_release_base}/${_artifact}-amd64.tar.gz"
   "${_artifact}-amd64.tar.gz.sha256::${_release_base}/${_artifact}-amd64.tar.gz.sha256"
@@ -47,15 +39,16 @@ source_aarch64=(
   "${_artifact}-arm64.tar.gz.sigstore.json::${_release_base}/${_artifact}-arm64.tar.gz.sigstore.json"
 )
 noextract=("${_artifact}-amd64.tar.gz" "${_artifact}-arm64.tar.gz")
+sha256sums=('2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935')
 sha256sums_x86_64=(
-  'b1d80713438868bcab522d9f1f6f7752c93ea4246e9eae1bab49b346b13f8105'
-  '5653dbf767ec9e62e078c6cdc492da5b2ec19fa5208376291be429bdc295791f'
-  'ecb422ef10ef6b4c44cd2749e3533d242087be685b9972176a290c248f31ae8c'
+  'b170e4e4e5a4fe5d18eb78f61d87bbc19b00c1e19578bef234c0f2c4d12103a9'
+  '5cd8f191b0f9ac121130558ee71f308725e3b5d70f96f7e70817b80a2e37b3dc'
+  '6c9a118d46516cb43a8285bf42726861e3540623912fdeb05d0098b026a46bac'
 )
 sha256sums_aarch64=(
-  'f41ca227ea711f35d864291693d1182684a2db9b9c4f46254f9e6d9bd274cb44'
-  '1c9f32ecd8988c4a5af7ee1837543dc6d2277f5dd7ea7a22301f37bc812f25b3'
-  '9c2d5311d94132653dff91c38771cd6273e5fab20f555fd01b99017f85c7a5bb'
+  '0f2086563a321fe5cd32d6ae3cebe53ff3f01ac129d7a4d145d2332745a35b1d'
+  'c06599dd776f4a0f722bb3efc5495e87539f49ed29afe743bf76307df933759d'
+  '30b322c96a828b97c5395880f5de540c14629b39b2ee6fc8d74e244dec163b9d'
 )
 
 case "${CARCH}" in
@@ -115,9 +108,7 @@ package() {
     cli=lmm-api-go
   fi
   install -Dm0755 "${bundle}/${cli}" "${pkgdir}/usr/bin/lmm-api"
-  if (( $(vercmp "${pkgver}" "${_t1_cli_version}") < 0 )); then
-    ln -s lmm-api "${pkgdir}/usr/bin/lmm-api-go"
-  fi
+  lmm_cli_phase_install_compatibility_alias "$_lmm_cli_phase" "$pkgdir"
   install -Dm0644 "${bundle}/lmm-api.service" \
     "${pkgdir}/usr/lib/systemd/system/lmm-api.service"
   install -d -m0700 "${pkgdir}/etc/lmm-api-go"

--- a/packaging/aur/lmm-api-go-bin/lmm-api-cli-phase.sh
+++ b/packaging/aur/lmm-api-go-bin/lmm-api-cli-phase.sh
@@ -1,0 +1,1 @@
+../../common/lmm-api/lmm-api-cli-phase.sh

--- a/packaging/aur/lmm-api-go-git/.SRCINFO
+++ b/packaging/aur/lmm-api-go-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go-git
 	pkgdesc = LMM API Go backend, native CLI, systemd service, and web frontend (git)
-	pkgver = 0.1.1.r73.g3c9b85967
+	pkgver = 0.1.20.r1290.gcedee311d
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64
@@ -20,18 +20,18 @@ pkgbase = lmm-api-go-git
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api
+	provides = lmm-api=0.1.20.r1290.gcedee311d
+	provides = lmm-api-go=0.1.20.r1290.gcedee311d
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git
 	conflicts = lmm-api-go
 	conflicts = lmm-api-go-bin
-	conflicts = lmm-api-deploy
-	conflicts = lmm-api-deploy-bin
-	replaces = lmm-api-deploy-bin
 	options = !strip
 	backup = etc/lmm-api-go/lmm-api-go.env
 	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#branch=main
+	source = lmm-api-cli-phase.sh
 	sha256sums = SKIP
+	sha256sums = 2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935
 
 pkgname = lmm-api-go-git

--- a/packaging/aur/lmm-api-go-git/.SRCINFO
+++ b/packaging/aur/lmm-api-go-git/.SRCINFO
@@ -20,8 +20,8 @@ pkgbase = lmm-api-go-git
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api=0.1.20.r1294.gc5f84b333
-	provides = lmm-api-go=0.1.20.r1294.gc5f84b333
+	provides = lmm-api
+	provides = lmm-api-go
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git

--- a/packaging/aur/lmm-api-go-git/.SRCINFO
+++ b/packaging/aur/lmm-api-go-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go-git
 	pkgdesc = LMM API Go backend, native CLI, systemd service, and web frontend (git)
-	pkgver = 0.1.20.r1294.gc5f84b333
+	pkgver = 0.1.20.r1291.g1db462ebe
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64

--- a/packaging/aur/lmm-api-go-git/.SRCINFO
+++ b/packaging/aur/lmm-api-go-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go-git
 	pkgdesc = LMM API Go backend, native CLI, systemd service, and web frontend (git)
-	pkgver = 0.1.20.r1290.gcedee311d
+	pkgver = 0.1.20.r1294.gc5f84b333
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64
@@ -20,8 +20,8 @@ pkgbase = lmm-api-go-git
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api=0.1.20.r1290.gcedee311d
-	provides = lmm-api-go=0.1.20.r1290.gcedee311d
+	provides = lmm-api=0.1.20.r1294.gc5f84b333
+	provides = lmm-api-go=0.1.20.r1294.gc5f84b333
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git

--- a/packaging/aur/lmm-api-go-git/PKGBUILD
+++ b/packaging/aur/lmm-api-go-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction
 
 pkgname=lmm-api-go-git
-pkgver=0.1.20.r1294.gc5f84b333
+pkgver=0.1.20.r1291.g1db462ebe
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, systemd service, and web frontend (git)'
 arch=('x86_64' 'aarch64')

--- a/packaging/aur/lmm-api-go-git/PKGBUILD
+++ b/packaging/aur/lmm-api-go-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction
 
 pkgname=lmm-api-go-git
-pkgver=0.1.1.r73.g3c9b85967
+pkgver=0.1.20.r1290.gcedee311d
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, systemd service, and web frontend (git)'
 arch=('x86_64' 'aarch64')
@@ -13,19 +13,21 @@ optdepends=(
   'postgresql: production database'
   'valkey: cache, rate limiting, and login sessions'
 )
-provides=('lmm-api')
-conflicts=('lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-bin' 'lmm-api-deploy' 'lmm-api-deploy-bin')
-replaces=('lmm-api-deploy-bin')
+source "${startdir:?}/lmm-api-cli-phase.sh"
+_lmm_cli_phase=$LMM_CLI_SOURCE_PHASE
+lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
+  'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-bin'
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
-source=('lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#branch=main')
-sha256sums=('SKIP')
+source=('lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#branch=main' 'lmm-api-cli-phase.sh')
+sha256sums=('SKIP' '2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935')
+
+_source_pkgver_epoch=0.1.20
 
 pkgver() {
   cd lmm-api-go || return
-  git describe --long --tags --abbrev=9 2>/dev/null | \
-    sed -E 's/^v//; s/([^-]*-g)/r\1/; s/-/./g' || \
-    printf '0.0.0.r%s.g%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short=9 HEAD)"
+  printf '%s.r%s.g%s' "$_source_pkgver_epoch" \
+    "$(git rev-list --count HEAD)" "$(git rev-parse --short=9 HEAD)"
 }
 
 build() {
@@ -46,6 +48,7 @@ package() {
   local file
 
   install -Dm0755 "${srcdir}/lmm-api-cli" "${pkgdir}/usr/bin/lmm-api"
+  lmm_cli_phase_install_compatibility_alias "$_lmm_cli_phase" "$pkgdir"
   install -Dm0644 "${shared}/lmm-api.service" \
     "${pkgdir}/usr/lib/systemd/system/lmm-api.service"
   if [[ -f ${shared}/lmm-api-operator.sysusers ]]; then

--- a/packaging/aur/lmm-api-go-git/PKGBUILD
+++ b/packaging/aur/lmm-api-go-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction
 
 pkgname=lmm-api-go-git
-pkgver=0.1.20.r1290.gcedee311d
+pkgver=0.1.20.r1294.gc5f84b333
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, systemd service, and web frontend (git)'
 arch=('x86_64' 'aarch64')

--- a/packaging/aur/lmm-api-go-git/PKGBUILD
+++ b/packaging/aur/lmm-api-go-git/PKGBUILD
@@ -17,6 +17,9 @@ source "${startdir:?}/lmm-api-cli-phase.sh"
 _lmm_cli_phase=$LMM_CLI_SOURCE_PHASE
 lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
   'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-bin'
+# pkgver() runs after PKGBUILD evaluation; keep VCS provides unversioned so they
+# cannot retain the checked-in bootstrap version after the fetched commit moves.
+provides=('lmm-api' 'lmm-api-go')
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
 source=('lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#branch=main' 'lmm-api-cli-phase.sh')

--- a/packaging/aur/lmm-api-go-git/lmm-api-cli-phase.sh
+++ b/packaging/aur/lmm-api-go-git/lmm-api-cli-phase.sh
@@ -1,0 +1,1 @@
+../../common/lmm-api/lmm-api-cli-phase.sh

--- a/packaging/aur/lmm-api-go/.SRCINFO
+++ b/packaging/aur/lmm-api-go/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go
 	pkgdesc = LMM API Go backend, native CLI, systemd service, and web frontend
-	pkgver = 0.1.20.r1288.g241aff9d7
+	pkgver = 0.1.20.r1294.gc5f84b333
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64
@@ -20,8 +20,8 @@ pkgbase = lmm-api-go
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api=0.1.20.r1288.g241aff9d7
-	provides = lmm-api-go=0.1.20.r1288.g241aff9d7
+	provides = lmm-api=0.1.20.r1294.gc5f84b333
+	provides = lmm-api-go=0.1.20.r1294.gc5f84b333
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git
@@ -29,7 +29,7 @@ pkgbase = lmm-api-go
 	conflicts = lmm-api-go-git
 	options = !strip
 	backup = etc/lmm-api-go/lmm-api-go.env
-	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#commit=241aff9d75884fb20a070a6d513e5830a6295b3b
+	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#commit=c5f84b3337cb6d4840c754fa1d40066962f8fd97
 	source = lmm-api-cli-phase.sh
 	sha256sums = SKIP
 	sha256sums = 2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935

--- a/packaging/aur/lmm-api-go/.SRCINFO
+++ b/packaging/aur/lmm-api-go/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go
 	pkgdesc = LMM API Go backend, native CLI, systemd service, and web frontend
-	pkgver = 0.1.20.r1294.gc5f84b333
+	pkgver = 0.1.20.r1291.g1db462ebe
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64
@@ -20,8 +20,8 @@ pkgbase = lmm-api-go
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api=0.1.20.r1294.gc5f84b333
-	provides = lmm-api-go=0.1.20.r1294.gc5f84b333
+	provides = lmm-api=0.1.20.r1291.g1db462ebe
+	provides = lmm-api-go=0.1.20.r1291.g1db462ebe
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git
@@ -29,7 +29,7 @@ pkgbase = lmm-api-go
 	conflicts = lmm-api-go-git
 	options = !strip
 	backup = etc/lmm-api-go/lmm-api-go.env
-	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#commit=c5f84b3337cb6d4840c754fa1d40066962f8fd97
+	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#commit=1db462ebe08cc99e32014d478eb866e85af3badd
 	source = lmm-api-cli-phase.sh
 	sha256sums = SKIP
 	sha256sums = 2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935

--- a/packaging/aur/lmm-api-go/.SRCINFO
+++ b/packaging/aur/lmm-api-go/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lmm-api-go
 	pkgdesc = LMM API Go backend, native CLI, systemd service, and web frontend
-	pkgver = 0.1.1.r1119.g241aff9d7
+	pkgver = 0.1.20.r1288.g241aff9d7
 	pkgrel = 1
 	url = https://github.com/LIghtJUNction/api.lmm.best
 	arch = x86_64
@@ -20,18 +20,18 @@ pkgbase = lmm-api-go
 	depends = util-linux
 	optdepends = postgresql: production database
 	optdepends = valkey: cache, rate limiting, and login sessions
-	provides = lmm-api=0.1.1.r1119.g241aff9d7
+	provides = lmm-api=0.1.20.r1288.g241aff9d7
+	provides = lmm-api-go=0.1.20.r1288.g241aff9d7
 	conflicts = lmm-api
 	conflicts = lmm-api-bin
 	conflicts = lmm-api-git
 	conflicts = lmm-api-go-bin
 	conflicts = lmm-api-go-git
-	conflicts = lmm-api-deploy
-	conflicts = lmm-api-deploy-bin
-	replaces = lmm-api-deploy-bin
 	options = !strip
 	backup = etc/lmm-api-go/lmm-api-go.env
 	source = lmm-api-go::git+https://github.com/LIghtJUNction/api.lmm.best.git#commit=241aff9d75884fb20a070a6d513e5830a6295b3b
+	source = lmm-api-cli-phase.sh
 	sha256sums = SKIP
+	sha256sums = 2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935
 
 pkgname = lmm-api-go

--- a/packaging/aur/lmm-api-go/PKGBUILD
+++ b/packaging/aur/lmm-api-go/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction
 
 pkgname=lmm-api-go
-pkgver=0.1.20.r1294.gc5f84b333
+pkgver=0.1.20.r1291.g1db462ebe
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, systemd service, and web frontend'
 arch=('x86_64' 'aarch64')
@@ -20,7 +20,9 @@ lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
 
-_commit=c5f84b3337cb6d4840c754fa1d40066962f8fd97
+# This pin must already be reachable from main. A separate post-merge pin PR
+# advances it to the reviewed release merge instead of relying on branch-only objects.
+_commit=1db462ebe08cc99e32014d478eb866e85af3badd
 source=("lmm-api-go::git+${url}.git#commit=${_commit}" 'lmm-api-cli-phase.sh')
 sha256sums=('SKIP' '2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935')
 

--- a/packaging/aur/lmm-api-go/PKGBUILD
+++ b/packaging/aur/lmm-api-go/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction
 
 pkgname=lmm-api-go
-pkgver=0.1.1.r1119.g241aff9d7
+pkgver=0.1.20.r1288.g241aff9d7
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, systemd service, and web frontend'
 arch=('x86_64' 'aarch64')
@@ -13,15 +13,16 @@ optdepends=(
   'postgresql: production database'
   'valkey: cache, rate limiting, and login sessions'
 )
-provides=("lmm-api=${pkgver}")
-conflicts=('lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go-bin' 'lmm-api-go-git' 'lmm-api-deploy' 'lmm-api-deploy-bin')
-replaces=('lmm-api-deploy-bin')
+source "${startdir:?}/lmm-api-cli-phase.sh"
+_lmm_cli_phase=$LMM_CLI_SOURCE_PHASE
+lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
+  'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go-bin' 'lmm-api-go-git'
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
 
 _commit=241aff9d75884fb20a070a6d513e5830a6295b3b
-source=("lmm-api-go::git+${url}.git#commit=${_commit}")
-sha256sums=('SKIP')
+source=("lmm-api-go::git+${url}.git#commit=${_commit}" 'lmm-api-cli-phase.sh')
+sha256sums=('SKIP' '2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935')
 
 build() {
   cd lmm-api-go || return
@@ -41,6 +42,7 @@ package() {
   local file
 
   install -Dm0755 "${srcdir}/lmm-api-cli" "${pkgdir}/usr/bin/lmm-api"
+  lmm_cli_phase_install_compatibility_alias "$_lmm_cli_phase" "$pkgdir"
   install -Dm0644 "${shared}/lmm-api.service" \
     "${pkgdir}/usr/lib/systemd/system/lmm-api.service"
   if [[ -f ${shared}/lmm-api-operator.sysusers ]]; then

--- a/packaging/aur/lmm-api-go/PKGBUILD
+++ b/packaging/aur/lmm-api-go/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: LIghtJUNction
 
 pkgname=lmm-api-go
-pkgver=0.1.20.r1288.g241aff9d7
+pkgver=0.1.20.r1294.gc5f84b333
 pkgrel=1
 pkgdesc='LMM API Go backend, native CLI, systemd service, and web frontend'
 arch=('x86_64' 'aarch64')
@@ -20,7 +20,7 @@ lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
 
-_commit=241aff9d75884fb20a070a6d513e5830a6295b3b
+_commit=c5f84b3337cb6d4840c754fa1d40066962f8fd97
 source=("lmm-api-go::git+${url}.git#commit=${_commit}" 'lmm-api-cli-phase.sh')
 sha256sums=('SKIP' '2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935')
 

--- a/packaging/aur/lmm-api-go/lmm-api-cli-phase.sh
+++ b/packaging/aur/lmm-api-go/lmm-api-cli-phase.sh
@@ -1,0 +1,1 @@
+../../common/lmm-api/lmm-api-cli-phase.sh

--- a/packaging/aur/test-bin-makepkg.sh
+++ b/packaging/aur/test-bin-makepkg.sh
@@ -66,6 +66,7 @@ go_artifact="lmm-api-go-${go_pkgver}-linux-amd64"
 go_bundle="$go_work/stage/$go_artifact"
 mkdir -p "$go_bundle/frontend-dist" "$go_bundle/edge-policy/nginx"
 cp "$HERE/lmm-api-go-bin/PKGBUILD" "$go_work/"
+cp -L "$HERE/lmm-api-go-bin/lmm-api-cli-phase.sh" "$go_work/"
 # Exercise the retained bundled-frontend branch independently of the immutable
 # release pinned by the canonical package.
 # shellcheck disable=SC2016 # Deliberately write a PKGBUILD variable reference.
@@ -101,6 +102,7 @@ go_next_work="$tmp/lmm-api-go-bin-next"
 go_next_bundle="$go_next_work/stage/$go_artifact"
 mkdir -p "$go_next_bundle/edge-policy/nginx"
 cp "$HERE/lmm-api-go-bin/PKGBUILD" "$go_next_work/"
+cp -L "$HERE/lmm-api-go-bin/lmm-api-cli-phase.sh" "$go_next_work/"
 printf '#!/bin/sh\nexit 0\n' >"$go_next_bundle/lmm-api"
 chmod 0755 "$go_next_bundle/lmm-api"
 cp "$SHARED/lmm-api.service" "$SHARED/lmm-api-go.env" \
@@ -121,7 +123,12 @@ pin_fixture_hashes "$go_next_work/PKGBUILD" sha256sums_x86_64 \
   "$go_next_work/${go_artifact}.tar.gz" \
   "$go_next_work/${go_artifact}.tar.gz.sha256" \
   "$go_next_work/${go_artifact}.tar.gz.sigstore.json"
-printf '\npkgver=999.0.0\n_set_cli_transition_metadata\n' >>"$go_next_work/PKGBUILD"
+cat >>"$go_next_work/PKGBUILD" <<'PKGBUILD'
+pkgver=999.0.0
+_lmm_cli_phase=$LMM_CLI_PHASE_T1
+lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
+  'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-git'
+PKGBUILD
 build_package lmm-api-go-bin-next \
   usr/bin/lmm-api \
   usr/lib/systemd/system/lmm-api.service \

--- a/packaging/aur/test-export-go-package-base.sh
+++ b/packaging/aur/test-export-go-package-base.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+readonly HERE
+readonly EXPORTER="$HERE/export-go-package-base.sh"
+readonly PACKAGES=(lmm-api-go lmm-api-go-bin lmm-api-go-git)
+: "${TMPDIR:?set TMPDIR to a marker-owned test workspace}"
+
+fail() {
+  printf 'test-export-go-package-base: %s\n' "$*" >&2
+  exit 1
+}
+
+for command in cmp find makepkg sha256sum; do
+  command -v "$command" >/dev/null 2>&1 || fail "required command is unavailable: $command"
+done
+[[ -x $EXPORTER ]] || fail 'Go AUR package-base exporter is missing or not executable'
+work=$(mktemp -d "$TMPDIR/lmm-aur-export.XXXXXXXX")
+cleanup() { rm -rf -- "$work"; }
+trap cleanup EXIT
+
+mkdir -p "$work/exported"
+for package in "${PACKAGES[@]}"; do
+  destination="$work/exported/$package"
+  "$EXPORTER" "$package" "$destination" >/dev/null
+  [[ -f $destination/lmm-api-cli-phase.sh && ! -L $destination/lmm-api-cli-phase.sh ]] ||
+    fail "$package export did not materialize the shared helper"
+  [[ -z $(find "$destination" -type l -print -quit) ]] || fail "$package export contains a symlink"
+  generated=$(cd -- "$destination" && makepkg --printsrcinfo)
+  cmp -s <(printf '%s\n' "$generated") "$destination/.SRCINFO" ||
+    fail "$package isolated export has stale .SRCINFO"
+done
+
+fixture="$work/fixture"
+mkdir -p "$fixture/aur" "$fixture/common/lmm-api" "$fixture/output"
+cp "$EXPORTER" "$fixture/aur/export-go-package-base.sh"
+cp "$HERE/../common/lmm-api/lmm-api-cli-phase.sh" "$fixture/common/lmm-api/"
+for package in "${PACKAGES[@]}"; do
+  cp -a "$HERE/$package" "$fixture/aur/"
+done
+chmod 0755 "$fixture/aur/export-go-package-base.sh"
+
+ln -s /etc/passwd "$fixture/aur/lmm-api-go/external-link"
+if "$fixture/aur/export-go-package-base.sh" lmm-api-go "$fixture/output/unexpected-link" \
+  >"$work/unexpected-link.out" 2>&1; then
+  fail 'exporter accepted an unexpected external symlink'
+fi
+grep -Fq 'unexpected package-base entry: external-link' "$work/unexpected-link.out" ||
+  fail 'unexpected external symlink rejection was not explicit'
+rm -- "$fixture/aur/lmm-api-go/external-link"
+
+rm -- "$fixture/aur/lmm-api-go/lmm-api-cli-phase.sh"
+ln -s /etc/passwd "$fixture/aur/lmm-api-go/lmm-api-cli-phase.sh"
+if "$fixture/aur/export-go-package-base.sh" lmm-api-go "$fixture/output/escaped-helper" \
+  >"$work/escaped-helper.out" 2>&1; then
+  fail 'exporter accepted a helper symlink outside the canonical source'
+fi
+grep -Fq 'escapes the canonical helper' "$work/escaped-helper.out" ||
+  fail 'escaped helper rejection was not explicit'
+
+printf 'isolated Go AUR package-base exports verified\n'

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -157,7 +157,7 @@ contains_srcinfo lmm-api-go-git $'\tmakedepends = go>=1.25.1'
 contains_srcinfo lmm-api-go $'\tmakedepends = bun'
 contains_srcinfo lmm-api-go $'\tmakedepends = git'
 contains_srcinfo lmm-api-go $'\tmakedepends = go>=1.25.1'
-go_release_commit=241aff9d75884fb20a070a6d513e5830a6295b3b
+go_release_commit=c5f84b3337cb6d4840c754fa1d40066962f8fd97
 readonly go_release_commit
 grep -Fqx "_commit=$go_release_commit" "$HERE/lmm-api-go/PKGBUILD" ||
   die 'canonical Go package is not pinned to the reviewed direct-package revision'

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -162,10 +162,12 @@ contains_srcinfo lmm-api-go-git $'\tmakedepends = go>=1.25.1'
 contains_srcinfo lmm-api-go $'\tmakedepends = bun'
 contains_srcinfo lmm-api-go $'\tmakedepends = git'
 contains_srcinfo lmm-api-go $'\tmakedepends = go>=1.25.1'
-go_release_commit=c5f84b3337cb6d4840c754fa1d40066962f8fd97
+go_release_commit=1db462ebe08cc99e32014d478eb866e85af3badd
 readonly go_release_commit
 grep -Fqx "_commit=$go_release_commit" "$HERE/lmm-api-go/PKGBUILD" ||
   die 'canonical Go package is not pinned to the reviewed direct-package revision'
+git -C "$ROOT" merge-base --is-ancestor "$go_release_commit" origin/main ||
+  die 'canonical Go source pin is not reachable from main'
 readonly go_source_pkgver_epoch=0.1.20
 readonly last_published_go_source_pkgver=0.1.19.r1279.g0c463f094
 go_release_pkgver="$go_source_pkgver_epoch.r$(git -C "$ROOT" rev-list --count "$go_release_commit").g$(git -C "$ROOT" rev-parse --short=9 "$go_release_commit")"

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -40,12 +40,27 @@ for removed in backend.conf lmm-api.install lmm-api-go.service lmm-api.env lmm-a
   [[ ! -e $SHARED/$removed ]] || die "removed launcher/provider asset remains: $removed"
 done
 
+CLI_PHASE_HELPER=$(realpath -e "$SHARED/lmm-api-cli-phase.sh")
+readonly CLI_PHASE_HELPER
+readonly CLI_PHASE_HELPER_SHA256=2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935
+[[ -f $CLI_PHASE_HELPER && ! -L $CLI_PHASE_HELPER ]] || die 'canonical CLI phase helper is missing'
+[[ $(sha256sum "$CLI_PHASE_HELPER") == "$CLI_PHASE_HELPER_SHA256  $CLI_PHASE_HELPER" ]] ||
+  die 'canonical CLI phase helper digest changed without updating package pins'
+for package in lmm-api-go lmm-api-go-bin lmm-api-go-git; do
+  helper="$HERE/$package/lmm-api-cli-phase.sh"
+  [[ -L $helper && $(realpath -e "$helper") == "$CLI_PHASE_HELPER" ]] ||
+    die "$package does not use the canonical CLI phase helper"
+done
+local_helper="$HERE/../local/lmm-api-go/lmm-api-cli-phase.sh"
+[[ -L $local_helper && $(realpath -e "$local_helper") == "$CLI_PHASE_HELPER" ]] ||
+  die 'local Go package does not use the canonical CLI phase helper'
+
 for package in "${PACKAGES[@]}"; do
   pkgbuild="$HERE/$package/PKGBUILD"
   [[ -f $pkgbuild ]] || die "missing $pkgbuild"
   bash -n "$pkgbuild"
   if command -v shellcheck >/dev/null 2>&1; then
-    shellcheck -s bash -e SC2034,SC2154 "$pkgbuild"
+    shellcheck -s bash -e SC1091,SC2034,SC2154 "$pkgbuild"
   fi
   srcinfo=$(cd -- "$HERE/$package" && makepkg --printsrcinfo)
   cmp -s <(printf '%s\n' "$srcinfo") "$HERE/$package/.SRCINFO" ||
@@ -56,33 +71,26 @@ for package in "${PACKAGES[@]}"; do
   fi
 done
 
-contains_srcinfo_prefix lmm-api-go-bin $'\tprovides = lmm-api-go'
-for package in lmm-api-go-bin lmm-api-go-git; do
+for package in lmm-api-go lmm-api-go-bin lmm-api-go-git; do
   contains_srcinfo_prefix "$package" $'\tprovides = lmm-api'
+  contains_srcinfo_prefix "$package" $'\tprovides = lmm-api-go'
   contains_srcinfo "$package" $'\tbackup = etc/lmm-api-go/lmm-api-go.env'
+  if grep -Fq $'\tconflicts = lmm-api-deploy-bin' "$HERE/$package/.SRCINFO" ||
+    grep -Fq $'\treplaces = lmm-api-deploy-bin' "$HERE/$package/.SRCINFO"; then
+    die "$package applies the T1 deploy-package transition during T0"
+  fi
 done
-if grep -Fq $'\tprovides = lmm-api-go' "$HERE/lmm-api-go-git/.SRCINFO"; then
-  die 'Git Go package still advertises the removed CLI compatibility provider'
-fi
 contains_srcinfo lmm-api-go-bin $'\tconflicts = lmm-api-go-git'
 contains_srcinfo lmm-api-go-git $'\tconflicts = lmm-api-go-bin'
 for variant in lmm-api-go-bin lmm-api-go-git; do
   contains_srcinfo lmm-api-go $'\tconflicts = '"$variant"
 done
-contains_srcinfo_prefix lmm-api-go $'\tprovides = lmm-api'
-contains_srcinfo lmm-api-go $'\tbackup = etc/lmm-api-go/lmm-api-go.env'
-for package in lmm-api-go lmm-api-go-git; do
-  contains_srcinfo "$package" $'\tconflicts = lmm-api-deploy-bin'
-  contains_srcinfo "$package" $'\treplaces = lmm-api-deploy-bin'
-done
-declare _t1_cli_version
 declare -a conflicts replaces provides
 (
-  CARCH=x86_64
-  # shellcheck disable=SC1091
-  source "$HERE/lmm-api-go-bin/PKGBUILD"
-  pkgver=$_t1_cli_version
-  _set_cli_transition_metadata
+  # shellcheck disable=SC1090
+  source "$CLI_PHASE_HELPER"
+  lmm_cli_phase_apply_metadata "$LMM_CLI_PHASE_T1" "$LMM_CLI_T1_RELEASE" \
+    'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-git'
   [[ " ${conflicts[*]} " == *' lmm-api-deploy-bin '* ]] || die 'T1 Go package does not conflict with the legacy deploy package'
   [[ " ${replaces[*]} " == *' lmm-api-deploy-bin '* ]] || die 'T1 Go package does not replace the legacy deploy package'
   [[ " ${provides[*]} " != *' lmm-api-go='* ]] || die 'T1 Go package still provides the legacy CLI capability'
@@ -153,15 +161,15 @@ go_release_commit=241aff9d75884fb20a070a6d513e5830a6295b3b
 readonly go_release_commit
 grep -Fqx "_commit=$go_release_commit" "$HERE/lmm-api-go/PKGBUILD" ||
   die 'canonical Go package is not pinned to the reviewed direct-package revision'
-readonly reviewed_go_release_pkgver=0.1.1.r1119.g241aff9d7
-if go_release_description=$(git -C "$ROOT" describe --long --tags --match='v[0-9]*' --abbrev=9 "$go_release_commit" 2>/dev/null); then
-  go_release_pkgver=$(printf '%s\n' "$go_release_description" |
-    sed -E 's/^v//; s/([^-]*-g)/r\1/; s/-/./g')
-else
-  go_release_pkgver=$reviewed_go_release_pkgver
-fi
+readonly go_source_pkgver_epoch=0.1.20
+readonly last_published_go_source_pkgver=0.1.19.r1279.g0c463f094
+go_release_pkgver="$go_source_pkgver_epoch.r$(git -C "$ROOT" rev-list --count "$go_release_commit").g$(git -C "$ROOT" rev-parse --short=9 "$go_release_commit")"
 grep -Fqx "pkgver=$go_release_pkgver" "$HERE/lmm-api-go/PKGBUILD" ||
   die "canonical Go package version does not match pinned revision: $go_release_pkgver"
+(( $(vercmp "$last_published_go_source_pkgver" "$go_release_pkgver") < 0 )) ||
+  die "canonical Go package version is not newer than the published floor: $last_published_go_source_pkgver"
+grep -Fqx '_source_pkgver_epoch=0.1.20' "$HERE/lmm-api-go-git/PKGBUILD" ||
+  die 'Git Go package lost the monotonic source-version epoch'
 contains_srcinfo lmm-api-rs-git $'\tmakedepends = cargo'
 
 grep -Fqx 'ExecStart=/usr/bin/lmm-api serve' "$SHARED/lmm-api.service" ||
@@ -223,6 +231,7 @@ printf 'fixture archive\n' >"$stage/go-next/lmm-api-go-${go_bin_pkgver}-linux-am
 
 (
   CARCH=x86_64
+  startdir="$HERE/lmm-api-go-bin"
   srcdir="$stage/go"
   pkgdir="$tmp/pkg-go-legacy"
   # shellcheck disable=SC1091
@@ -234,6 +243,7 @@ printf 'fixture archive\n' >"$stage/go-next/lmm-api-go-${go_bin_pkgver}-linux-am
 )
 (
   CARCH=x86_64
+  startdir="$HERE/lmm-api-go-bin"
   srcdir="$stage/go-next"
   pkgdir="$tmp/pkg-go-t0"
   # shellcheck disable=SC1091
@@ -243,11 +253,13 @@ printf 'fixture archive\n' >"$stage/go-next/lmm-api-go-${go_bin_pkgver}-linux-am
 )
 (
   CARCH=x86_64
+  startdir="$HERE/lmm-api-go-bin"
   srcdir="$stage/go-next"
   pkgdir="$tmp/pkg-go-t1"
   # shellcheck disable=SC1091
   source "$HERE/lmm-api-go-bin/PKGBUILD"
-  pkgver=$_t1_cli_version
+  pkgver=$LMM_CLI_T1_RELEASE
+  _lmm_cli_phase=$LMM_CLI_PHASE_T1
   package
 )
 (
@@ -338,8 +350,8 @@ done
   die 'T1 Go package owns a bundled frontend'
 for pkgbuild in "$HERE/lmm-api-go/PKGBUILD" "$HERE/lmm-api-go-git/PKGBUILD" "$HERE/../local/lmm-api-go/PKGBUILD"; do
   # shellcheck disable=SC2016 # Deliberately inspect PKGBUILD source literals.
-  ! grep -Fq 'ln -s lmm-api "${pkgdir}/usr/bin/lmm-api-go"' "$pkgbuild" ||
-    die "final Go package still creates the legacy CLI: $pkgbuild"
+  grep -Fq 'lmm_cli_phase_install_compatibility_alias "$_lmm_cli_phase" "$pkgdir"' "$pkgbuild" ||
+    die "Go package does not apply the shared CLI phase install contract: $pkgbuild"
 done
 [[ ! -e $tmp/pkg-rs/usr/bin/lmm-api && ! -L $tmp/pkg-rs/usr/bin/lmm-api ]] ||
   die 'Rust package exposes the Go provider command'

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -80,6 +80,11 @@ for package in lmm-api-go lmm-api-go-bin lmm-api-go-git; do
     die "$package applies the T1 deploy-package transition during T0"
   fi
 done
+contains_srcinfo lmm-api-go-git $'\tprovides = lmm-api'
+contains_srcinfo lmm-api-go-git $'\tprovides = lmm-api-go'
+if grep -Eq $'^\tprovides = lmm-api(-go)?=' "$HERE/lmm-api-go-git/.SRCINFO"; then
+  die 'Git Go package embeds a stale bootstrap version in provides'
+fi
 contains_srcinfo lmm-api-go-bin $'\tconflicts = lmm-api-go-git'
 contains_srcinfo lmm-api-go-git $'\tconflicts = lmm-api-go-bin'
 for variant in lmm-api-go-bin lmm-api-go-git; do

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -54,6 +54,10 @@ done
 local_helper="$HERE/../local/lmm-api-go/lmm-api-cli-phase.sh"
 [[ -L $local_helper && $(realpath -e "$local_helper") == "$CLI_PHASE_HELPER" ]] ||
   die 'local Go package does not use the canonical CLI phase helper'
+for script in check-candidate-version.sh export-go-package-base.sh test-export-go-package-base.sh; do
+  bash -n "$HERE/$script"
+done
+"$HERE/test-export-go-package-base.sh"
 
 for package in "${PACKAGES[@]}"; do
   pkgbuild="$HERE/$package/PKGBUILD"
@@ -169,12 +173,21 @@ grep -Fqx "_commit=$go_release_commit" "$HERE/lmm-api-go/PKGBUILD" ||
 git -C "$ROOT" merge-base --is-ancestor "$go_release_commit" origin/main ||
   die 'canonical Go source pin is not reachable from main'
 readonly go_source_pkgver_epoch=0.1.20
-readonly last_published_go_source_pkgver=0.1.19.r1279.g0c463f094
+readonly last_published_go_source_version=0.1.19.r1279.g0c463f094-1
 go_release_pkgver="$go_source_pkgver_epoch.r$(git -C "$ROOT" rev-list --count "$go_release_commit").g$(git -C "$ROOT" rev-parse --short=9 "$go_release_commit")"
+go_release_pkgrel=$(sed -n 's/^pkgrel=//p' "$HERE/lmm-api-go/PKGBUILD")
+[[ $go_release_pkgrel =~ ^[1-9][0-9]*$ ]] || die 'canonical Go package has an invalid pkgrel'
+go_release_version="$go_release_pkgver-$go_release_pkgrel"
 grep -Fqx "pkgver=$go_release_pkgver" "$HERE/lmm-api-go/PKGBUILD" ||
   die "canonical Go package version does not match pinned revision: $go_release_pkgver"
-(( $(vercmp "$last_published_go_source_pkgver" "$go_release_pkgver") < 0 )) ||
-  die "canonical Go package version is not newer than the published floor: $last_published_go_source_pkgver"
+(( $(vercmp "$last_published_go_source_version" "$go_release_version") < 0 )) ||
+  die "canonical Go package version is not newer than the published floor: $last_published_go_source_version"
+"$HERE/check-candidate-version.sh" lmm-api-go "$go_release_version" "$go_release_version" >/dev/null ||
+  die 'AUR exact source candidate was rejected'
+if "$HERE/check-candidate-version.sh" lmm-api-go "$go_release_version" \
+  "$go_release_pkgver-$((go_release_pkgrel + 1))" >/dev/null 2>&1; then
+  die 'AUR source candidate accepted a strictly newer published pkgrel'
+fi
 grep -Fqx '_source_pkgver_epoch=0.1.20' "$HERE/lmm-api-go-git/PKGBUILD" ||
   die 'Git Go package lost the monotonic source-version epoch'
 contains_srcinfo lmm-api-rs-git $'\tmakedepends = cargo'

--- a/packaging/aur/verify-go-release-pins.sh
+++ b/packaging/aur/verify-go-release-pins.sh
@@ -9,7 +9,8 @@ readonly API_ROOT=${GITHUB_API_URL:-https://api.github.com}
 readonly PKGBUILD="$HERE/lmm-api-go-bin/PKGBUILD"
 readonly SRCINFO="$HERE/lmm-api-go-bin/.SRCINFO"
 readonly SOURCE_PKGBUILD="$HERE/lmm-api-go/PKGBUILD"
-readonly PUBLISHED_SOURCE_FLOOR=0.1.19.r1279.g0c463f094
+readonly VERSION_CHECK="$HERE/check-candidate-version.sh"
+readonly PUBLISHED_SOURCE_FLOOR=0.1.19.r1279.g0c463f094-1
 readonly CURL_RETRY_ARGS=(--retry 4 --retry-all-errors --retry-delay 2 --connect-timeout 15)
 
 fail() {
@@ -44,6 +45,7 @@ download_asset() {
 for command in cosign curl git jq makepkg sha256sum sort vercmp; do
   command -v "$command" >/dev/null 2>&1 || fail "required command is unavailable: $command"
 done
+[[ -x $VERSION_CHECK ]] || fail 'AUR candidate version checker is missing or not executable'
 : "${TMPDIR:?set TMPDIR to a marker-owned verification workspace}"
 work=$(mktemp -d "$TMPDIR/lmm-go-release-pins.XXXXXXXX")
 cleanup() { rm -rf -- "$work"; }
@@ -113,17 +115,21 @@ for arch in amd64 arm64; do
 done
 
 source_pkgver=$(sed -n 's/^pkgver=//p' "$SOURCE_PKGBUILD")
-(( $(vercmp "$PUBLISHED_SOURCE_FLOOR" "$source_pkgver") < 0 )) ||
-  fail "source pkgver is not newer than the published floor: $PUBLISHED_SOURCE_FLOOR"
+source_pkgrel=$(sed -n 's/^pkgrel=//p' "$SOURCE_PKGBUILD")
+[[ -n $source_pkgver && $source_pkgrel =~ ^[1-9][0-9]*$ ]] ||
+  fail 'source PKGBUILD has an invalid pkgver or pkgrel'
+source_candidate="$source_pkgver-$source_pkgrel"
+(( $(vercmp "$PUBLISHED_SOURCE_FLOOR" "$source_candidate") < 0 )) ||
+  fail "source package version is not newer than the published floor: $PUBLISHED_SOURCE_FLOOR"
 aur_json=$(curl --fail --location --silent --show-error "${CURL_RETRY_ARGS[@]}" --max-time 60 \
   'https://aur.archlinux.org/rpc/v5/info?arg[]=lmm-api-go&arg[]=lmm-api-go-bin')
 for package in lmm-api-go lmm-api-go-bin; do
   published=$(jq -r --arg package "$package" '.results[] | select(.Name == $package) | .Version' <<<"$aur_json")
   [[ -n $published && $published != null ]] || fail "AUR did not report $package"
-  candidate=$source_pkgver
+  candidate=$source_candidate
   [[ $package == lmm-api-go-bin ]] && candidate="$pkgver-1"
-  (( $(vercmp "$published" "$candidate") <= 0 )) ||
-    fail "$package candidate $candidate is older than published $published"
+  "$VERSION_CHECK" "$package" "$candidate" "$published" >/dev/null ||
+    fail "$package candidate failed the published-version contract"
 done
 
 printf 'latest Go release, AUR monotonicity, checksums, and Sigstore pins verified: %s\n' "$latest_tag"

--- a/packaging/aur/verify-go-release-pins.sh
+++ b/packaging/aur/verify-go-release-pins.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+umask 077
+
+HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+ROOT=$(git -C "$HERE" rev-parse --show-toplevel)
+readonly HERE ROOT
+readonly REPOSITORY=${GITHUB_REPOSITORY:-LIghtJUNction/api.lmm.best}
+readonly API_ROOT=${GITHUB_API_URL:-https://api.github.com}
+readonly PKGBUILD="$HERE/lmm-api-go-bin/PKGBUILD"
+readonly SRCINFO="$HERE/lmm-api-go-bin/.SRCINFO"
+readonly SOURCE_PKGBUILD="$HERE/lmm-api-go/PKGBUILD"
+readonly PUBLISHED_SOURCE_FLOOR=0.1.19.r1279.g0c463f094
+readonly CURL_RETRY_ARGS=(--retry 4 --retry-all-errors --retry-delay 2 --connect-timeout 15)
+
+fail() {
+  printf 'verify-go-release-pins: %s\n' "$*" >&2
+  exit 1
+}
+
+api_get() {
+  local url=$1
+  if [[ -n ${GITHUB_TOKEN:-} ]]; then
+    curl --fail --location --silent --show-error "${CURL_RETRY_ARGS[@]}" --max-time 60 \
+      --header "Authorization: Bearer $GITHUB_TOKEN" \
+      --header 'Accept: application/vnd.github+json' "$url"
+  else
+    curl --fail --location --silent --show-error "${CURL_RETRY_ARGS[@]}" --max-time 60 \
+      --header 'Accept: application/vnd.github+json' "$url"
+  fi
+}
+
+download_asset() {
+  local url=$1 output=$2
+  if [[ -n ${GITHUB_TOKEN:-} ]]; then
+    curl --fail --location --silent --show-error "${CURL_RETRY_ARGS[@]}" --max-time 300 \
+      --header "Authorization: Bearer $GITHUB_TOKEN" \
+      --output "$output" "$url"
+  else
+    curl --fail --location --silent --show-error "${CURL_RETRY_ARGS[@]}" --max-time 300 \
+      --output "$output" "$url"
+  fi
+}
+
+for command in cosign curl git jq makepkg sha256sum sort vercmp; do
+  command -v "$command" >/dev/null 2>&1 || fail "required command is unavailable: $command"
+done
+: "${TMPDIR:?set TMPDIR to a marker-owned verification workspace}"
+work=$(mktemp -d "$TMPDIR/lmm-go-release-pins.XXXXXXXX")
+cleanup() { rm -rf -- "$work"; }
+trap cleanup EXIT
+
+pkgver=$(sed -n 's/^pkgver=//p' "$PKGBUILD")
+[[ $pkgver =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
+  fail 'binary PKGBUILD has an invalid release version'
+latest_tag=$(api_get "$API_ROOT/repos/$REPOSITORY/releases?per_page=100" |
+  jq -r '.[] | select(.draft == false and (.tag_name | test("^go-v[0-9]+\\.[0-9]+\\.[0-9]+$"))) | .tag_name' |
+  sort -V | tail -n 1)
+[[ -n $latest_tag ]] || fail 'no published Go release was found'
+[[ $latest_tag == "go-v$pkgver" ]] ||
+  fail "binary package is not pinned to the latest Go release: $latest_tag"
+
+git -C "$ROOT" fetch --force --no-tags origin "refs/tags/$latest_tag:refs/tags/$latest_tag" >/dev/null 2>&1 || true
+git -C "$ROOT" tag -v "$latest_tag" >"$work/tag-verification.log" 2>&1 ||
+  fail "$latest_tag is not a valid signed tag"
+release_json="$work/release.json"
+api_get "$API_ROOT/repos/$REPOSITORY/releases/tags/$latest_tag" >"$release_json"
+[[ $(jq -r '.draft' "$release_json") == false && $(jq -r '.prerelease' "$release_json") == false ]] ||
+  fail "$latest_tag is not a final release"
+
+mapfile -t amd64_pins < <(awk '$1 == "sha256sums_x86_64" { print $3 }' "$SRCINFO")
+mapfile -t arm64_pins < <(awk '$1 == "sha256sums_aarch64" { print $3 }' "$SRCINFO")
+[[ ${#amd64_pins[@]} -eq 3 && ${#arm64_pins[@]} -eq 3 ]] ||
+  fail 'binary .SRCINFO must pin archive, checksum, and Sigstore bundle per architecture'
+
+for arch in amd64 arm64; do
+  artifact="lmm-api-go-$pkgver-linux-$arch.tar.gz"
+  names=("$artifact" "$artifact.sha256" "$artifact.sigstore.json")
+  if [[ $arch == amd64 ]]; then
+    pins=("${amd64_pins[@]}")
+  else
+    pins=("${arm64_pins[@]}")
+  fi
+  for index in 0 1 2; do
+    name=${names[$index]}
+    url=$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .browser_download_url' "$release_json")
+    digest=$(jq -r --arg name "$name" '.assets[] | select(.name == $name) | .digest' "$release_json")
+    [[ -n $url && $url != null && $digest == sha256:* ]] || fail "$latest_tag is missing $name or its digest"
+    output="$work/$name"
+    download_asset "$url" "$output"
+    actual=$(sha256sum "$output")
+    actual=${actual%% *}
+    [[ $actual == "${pins[$index]}" && $actual == "${digest#sha256:}" ]] ||
+      fail "$name does not match its PKGBUILD and GitHub release digest"
+  done
+  expected=$(awk 'NR == 1 { print $1 }' "$work/$artifact.sha256")
+  [[ $expected == "${pins[0]}" ]] || fail "$artifact checksum asset does not bind the archive"
+  cosign verify-blob \
+    --bundle "$work/$artifact.sigstore.json" \
+    --certificate-identity "https://github.com/$REPOSITORY/.github/workflows/release-go.yml@refs/tags/$latest_tag" \
+    --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+    "$work/$artifact" >"$work/cosign-$arch.log" || fail "$artifact Sigstore bundle is invalid"
+done
+
+source_pkgver=$(sed -n 's/^pkgver=//p' "$SOURCE_PKGBUILD")
+(( $(vercmp "$PUBLISHED_SOURCE_FLOOR" "$source_pkgver") < 0 )) ||
+  fail "source pkgver is not newer than the published floor: $PUBLISHED_SOURCE_FLOOR"
+aur_json=$(curl --fail --location --silent --show-error "${CURL_RETRY_ARGS[@]}" --max-time 60 \
+  'https://aur.archlinux.org/rpc/v5/info?arg[]=lmm-api-go&arg[]=lmm-api-go-bin')
+for package in lmm-api-go lmm-api-go-bin; do
+  published=$(jq -r --arg package "$package" '.results[] | select(.Name == $package) | .Version' <<<"$aur_json")
+  [[ -n $published && $published != null ]] || fail "AUR did not report $package"
+  candidate=$source_pkgver
+  [[ $package == lmm-api-go-bin ]] && candidate="$pkgver-1"
+  (( $(vercmp "$published" "$candidate") <= 0 )) ||
+    fail "$package candidate $candidate is older than published $published"
+done
+
+printf 'latest Go release, AUR monotonicity, checksums, and Sigstore pins verified: %s\n' "$latest_tag"

--- a/packaging/aur/verify-go-release-pins.sh
+++ b/packaging/aur/verify-go-release-pins.sh
@@ -3,8 +3,7 @@ set -Eeuo pipefail
 umask 077
 
 HERE=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
-ROOT=$(git -C "$HERE" rev-parse --show-toplevel)
-readonly HERE ROOT
+readonly HERE
 readonly REPOSITORY=${GITHUB_REPOSITORY:-LIghtJUNction/api.lmm.best}
 readonly API_ROOT=${GITHUB_API_URL:-https://api.github.com}
 readonly PKGBUILD="$HERE/lmm-api-go-bin/PKGBUILD"
@@ -60,9 +59,20 @@ latest_tag=$(api_get "$API_ROOT/repos/$REPOSITORY/releases?per_page=100" |
 [[ $latest_tag == "go-v$pkgver" ]] ||
   fail "binary package is not pinned to the latest Go release: $latest_tag"
 
-git -C "$ROOT" fetch --force --no-tags origin "refs/tags/$latest_tag:refs/tags/$latest_tag" >/dev/null 2>&1 || true
-git -C "$ROOT" tag -v "$latest_tag" >"$work/tag-verification.log" 2>&1 ||
-  fail "$latest_tag is not a valid signed tag"
+tag_ref=$(api_get "$API_ROOT/repos/$REPOSITORY/git/ref/tags/$latest_tag")
+tag_object_sha=$(jq -r '.object.sha' <<<"$tag_ref")
+[[ $(jq -r '.object.type' <<<"$tag_ref") == tag && $tag_object_sha =~ ^[0-9a-f]{40}$ ]] ||
+  fail "$latest_tag is not an annotated tag"
+tag_object=$(api_get "$API_ROOT/repos/$REPOSITORY/git/tags/$tag_object_sha")
+tag_revision=$(jq -r '.object.sha' <<<"$tag_object")
+[[ $(jq -r '.verification.verified' <<<"$tag_object") == true &&
+   $(jq -r '.object.type' <<<"$tag_object") == commit && $tag_revision =~ ^[0-9a-f]{40}$ ]] ||
+  fail "$latest_tag is not a GitHub-verified signed commit tag"
+comparison=$(api_get "$API_ROOT/repos/$REPOSITORY/compare/$tag_revision...main")
+case $(jq -r '.status' <<<"$comparison") in
+  ahead|identical) ;;
+  *) fail "$latest_tag does not identify an ancestor of main" ;;
+esac
 release_json="$work/release.json"
 api_get "$API_ROOT/repos/$REPOSITORY/releases/tags/$latest_tag" >"$release_json"
 [[ $(jq -r '.draft' "$release_json") == false && $(jq -r '.prerelease' "$release_json") == false ]] ||

--- a/packaging/common/lmm-api/lmm-api-cli-phase.sh
+++ b/packaging/common/lmm-api/lmm-api-cli-phase.sh
@@ -1,0 +1,46 @@
+# shellcheck shell=bash disable=SC2034
+# Canonical package metadata/install contract for the unified Go CLI transition.
+
+readonly LMM_CLI_PHASE_T0=t0
+readonly LMM_CLI_PHASE_T1=t1
+readonly LMM_CLI_T1_RELEASE=0.1.60
+# Source, -git, and local recipes follow this explicit repository phase instead
+# of comparing their independent rolling pkgver with the binary release train.
+readonly LMM_CLI_SOURCE_PHASE=t0
+
+lmm_cli_phase_validate() {
+  [[ $1 == "$LMM_CLI_PHASE_T0" || $1 == "$LMM_CLI_PHASE_T1" ]]
+}
+
+lmm_cli_phase_for_binary_release() {
+  local version=$1
+  if (( $(vercmp "$version" "$LMM_CLI_T1_RELEASE") < 0 )); then
+    printf '%s\n' "$LMM_CLI_PHASE_T0"
+  else
+    printf '%s\n' "$LMM_CLI_PHASE_T1"
+  fi
+}
+
+lmm_cli_phase_apply_metadata() {
+  local phase=$1 version=$2
+  shift 2
+  lmm_cli_phase_validate "$phase" || return 1
+  provides=("lmm-api=${version}")
+  conflicts=("$@")
+  replaces=()
+  if [[ $phase == "$LMM_CLI_PHASE_T0" ]]; then
+    provides+=("lmm-api-go=${version}")
+  else
+    conflicts+=('lmm-api-deploy' 'lmm-api-deploy-bin')
+    replaces+=('lmm-api-deploy-bin')
+  fi
+}
+
+lmm_cli_phase_install_compatibility_alias() {
+  local phase=$1 pkgdir=$2
+  lmm_cli_phase_validate "$phase" || return 1
+  if [[ $phase == "$LMM_CLI_PHASE_T0" ]]; then
+    [[ ! -e $pkgdir/usr/bin/lmm-api-go && ! -L $pkgdir/usr/bin/lmm-api-go ]] || return 1
+    ln -s lmm-api "$pkgdir/usr/bin/lmm-api-go"
+  fi
+}

--- a/packaging/local/lmm-api-go/PKGBUILD
+++ b/packaging/local/lmm-api-go/PKGBUILD
@@ -12,13 +12,15 @@ optdepends=(
   'postgresql: production database'
   'valkey: cache, rate limiting, and login sessions'
 )
-provides=('lmm-api')
-conflicts=('lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-git' 'lmm-api-deploy' 'lmm-api-deploy-bin')
-replaces=('lmm-api-deploy-bin')
+source "${startdir:?}/lmm-api-cli-phase.sh"
+_lmm_cli_phase=${LMM_API_CLI_PHASE:-$LMM_CLI_SOURCE_PHASE}
+lmm_cli_phase_apply_metadata "$_lmm_cli_phase" "$pkgver" \
+  'lmm-api' 'lmm-api-bin' 'lmm-api-git' 'lmm-api-go' 'lmm-api-go-git'
 backup=('etc/lmm-api-go/lmm-api-go.env')
 options=('!strip')
 source=(
   lmm-api
+  lmm-api-cli-phase.sh
   frontend-dist.tar
   lmm-api.service
   lmm-api-go.env
@@ -37,7 +39,7 @@ source=(
   geoip2-country-update.service
   geoip2-country-update.timer
 )
-sha256sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+sha256sums=('SKIP' '2b93864b302a7901a4688fd5b7df9b7e262f193a666a915718f434db20054935' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
 prepare() {
   install -d -m0755 "${srcdir}/frontend-dist"
@@ -48,6 +50,7 @@ package() {
   local file
 
   install -Dm0755 "${srcdir}/lmm-api" "${pkgdir}/usr/bin/lmm-api"
+  lmm_cli_phase_install_compatibility_alias "$_lmm_cli_phase" "$pkgdir"
   install -Dm0644 "${srcdir}/lmm-api.service" \
     "${pkgdir}/usr/lib/systemd/system/lmm-api.service"
   install -Dm0644 "${srcdir}/lmm-api-operator.sysusers" \

--- a/packaging/local/lmm-api-go/build-local-package.sh
+++ b/packaging/local/lmm-api-go/build-local-package.sh
@@ -58,6 +58,8 @@ trap cleanup EXIT
 mkdir -p -- "$build_dir/makepkg"
 
 install -Dm0644 "$SCRIPT_DIR/PKGBUILD" "$build_dir/PKGBUILD"
+install -Dm0644 "$REPO_ROOT/packaging/common/lmm-api/lmm-api-cli-phase.sh" \
+  "$build_dir/lmm-api-cli-phase.sh"
 install -Dm0755 "$GO_BINARY" "$build_dir/lmm-api"
 install -Dm0644 "$REPO_ROOT/packaging/common/lmm-api/lmm-api.service" "$build_dir/lmm-api.service"
 install -Dm0600 "$REPO_ROOT/packaging/common/lmm-api/lmm-api-go.env" "$build_dir/lmm-api-go.env"

--- a/packaging/local/lmm-api-go/lmm-api-cli-phase.sh
+++ b/packaging/local/lmm-api-go/lmm-api-cli-phase.sh
@@ -1,0 +1,1 @@
+../../common/lmm-api/lmm-api-cli-phase.sh

--- a/scripts/test-verify-release-commit-checks.sh
+++ b/scripts/test-verify-release-commit-checks.sh
@@ -5,56 +5,180 @@ ROOT=$(git rev-parse --show-toplevel)
 SCRIPT="$ROOT/scripts/verify-release-commit-checks.sh"
 REQUIRED="$ROOT/.github/required-release-checks.txt"
 REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+readonly ROOT SCRIPT REQUIRED REVISION
 
 tmp=$(mktemp -d)
 cleanup() { rm -rf -- "$tmp"; }
 trap cleanup EXIT
 
-write_fixture() {
-  local conclusion=$1 failed_name=${2:-}
-  {
-    printf '{"check_runs":['
-    separator=
-    id=100
-    while IFS= read -r name; do
-      [[ -n $name ]] || continue
-      current=$conclusion
-      [[ $name == "$failed_name" ]] && current=failure
-      printf '%s' "$separator"
-      jq -cn --arg name "$name" --arg conclusion "$current" --argjson id "$id" \
-        '{id:$id,name:$name,status:"completed",conclusion:$conclusion,app:{slug:"github-actions"}}'
-      separator=,
-      ((id += 1))
-    done <"$REQUIRED"
-    printf ']}\n'
-  } >"$tmp/checks.json"
+write_success_fixtures() {
+  local checks='[]' runs='[]' id=100 run_id=1000
+  local name workflow event branch extra key
+  declare -A workflow_run_ids=()
+
+  while IFS='|' read -r name workflow event branch extra; do
+    [[ -n $name ]] || continue
+    [[ -n $workflow && -n $event && -n $branch && -z $extra ]]
+    key="$workflow|$event|$branch"
+    if [[ -z ${workflow_run_ids[$key]:-} ]]; then
+      workflow_run_ids[$key]=$run_id
+      runs=$(jq -c \
+        --argjson id "$run_id" \
+        --arg path "$workflow" \
+        --arg event "$event" \
+        --arg branch "$branch" \
+        --arg revision "$REVISION" \
+        '. + [{
+          id: $id,
+          path: $path,
+          event: $event,
+          head_branch: $branch,
+          head_sha: $revision,
+          status: "completed",
+          conclusion: "success",
+          created_at: "2026-08-24T00:00:00Z",
+          updated_at: "2026-08-24T00:01:00Z",
+          completed_at: "2026-08-24T00:01:00Z"
+        }]' <<<"$runs")
+      ((run_id += 1))
+    fi
+    selected_run_id=${workflow_run_ids[$key]}
+    checks=$(jq -c \
+      --argjson id "$id" \
+      --argjson run_id "$selected_run_id" \
+      --arg name "$name" \
+      '. + [{
+        id: $id,
+        name: $name,
+        status: "completed",
+        conclusion: "success",
+        started_at: "2026-08-24T00:00:00Z",
+        completed_at: "2026-08-24T00:01:00Z",
+        details_url: ("https://github.example/actions/runs/" + ($run_id | tostring) + "/job/" + ($id | tostring)),
+        app: {slug: "github-actions"}
+      }]' <<<"$checks")
+    ((id += 1))
+  done <"$REQUIRED"
+
+  jq -cn --argjson check_runs "$checks" '{check_runs:$check_runs}' >"$tmp/checks.json"
+  jq -cn --argjson workflow_runs "$runs" '{workflow_runs:$workflow_runs}' >"$tmp/runs.json"
 }
 
-write_fixture success
-LMM_CHECK_RUNS_FILE="$tmp/checks.json" LMM_CHECK_MAX_ATTEMPTS=1 \
-  bash "$SCRIPT" "$REVISION" >/dev/null
+verify_fixture() {
+  local checks_file=${1:-$tmp/checks.json} runs_file=${2:-$tmp/runs.json}
+  LMM_CHECK_RUNS_FILE="$checks_file" \
+    LMM_WORKFLOW_RUNS_FILE="$runs_file" \
+    LMM_CHECK_MAX_ATTEMPTS=1 \
+    bash "$SCRIPT" "$REVISION"
+}
 
-jq '.check_runs += [{id:9999,name:"Release artifact contract",status:"in_progress",conclusion:null,app:{slug:"github-actions"}}]' \
-  "$tmp/checks.json" >"$tmp/tag-duplicate.json"
-LMM_CHECK_RUNS_FILE="$tmp/tag-duplicate.json" LMM_CHECK_MAX_ATTEMPTS=1 \
-  bash "$SCRIPT" "$REVISION" >/dev/null
+expect_rejected() {
+  local label=$1 expected=$2 checks_file=${3:-$tmp/checks.json} runs_file=${4:-$tmp/runs.json}
+  if verify_fixture "$checks_file" "$runs_file" >"$tmp/rejected.out" 2>&1; then
+    printf 'negative governance fixture unexpectedly accepted %s\n' "$label" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$tmp/rejected.out" || {
+    printf 'negative governance fixture for %s did not report %s\n' "$label" "$expected" >&2
+    cat "$tmp/rejected.out" >&2
+    exit 1
+  }
+}
 
-failed_name='Release artifact contract'
-write_fixture success "$failed_name"
-if LMM_CHECK_RUNS_FILE="$tmp/checks.json" LMM_CHECK_MAX_ATTEMPTS=1 \
-  bash "$SCRIPT" "$REVISION" >"$tmp/failure.out" 2>&1; then
-  printf 'negative governance fixture unexpectedly accepted a failed release check\n' >&2
-  exit 1
-fi
-grep -Fq "$failed_name (failure)" "$tmp/failure.out"
+write_success_fixtures
+verify_fixture >/dev/null
+ci_run_id=$(jq -r '.workflow_runs[] | select(.path == ".github/workflows/ci.yml" and .event == "push" and .head_branch == "main") | .id' "$tmp/runs.json")
+[[ $ci_run_id =~ ^[0-9]+$ ]]
 
-write_fixture success
-jq 'del(.check_runs[-1])' "$tmp/checks.json" >"$tmp/missing.json"
-if LMM_CHECK_RUNS_FILE="$tmp/missing.json" LMM_CHECK_MAX_ATTEMPTS=1 \
-  bash "$SCRIPT" "$REVISION" >"$tmp/missing.out" 2>&1; then
-  printf 'negative governance fixture unexpectedly accepted a missing check\n' >&2
-  exit 1
-fi
-grep -Fq '(missing)' "$tmp/missing.out"
+for conclusion in failure cancelled timed_out; do
+  write_success_fixtures
+  jq \
+    --argjson run_id "$ci_run_id" \
+    --arg conclusion "$conclusion" \
+    '.check_runs += [{
+      id: 9999,
+      name: "Release artifact contract",
+      status: "completed",
+      conclusion: $conclusion,
+      started_at: "2026-08-24T00:02:00Z",
+      completed_at: "2026-08-24T00:03:00Z",
+      details_url: ("https://github.example/actions/runs/" + ($run_id | tostring) + "/job/9999"),
+      app: {slug: "github-actions"}
+    }]' "$tmp/checks.json" >"$tmp/new-$conclusion-check.json"
+  expect_rejected "newer completed $conclusion check" "Release artifact contract ($conclusion)" \
+    "$tmp/new-$conclusion-check.json" "$tmp/runs.json"
+done
 
-printf 'release governance negative fixtures verified\n'
+for conclusion in failure cancelled timed_out; do
+  write_success_fixtures
+  jq \
+    --arg conclusion "$conclusion" \
+    --arg revision "$REVISION" \
+    '.workflow_runs += [{
+      id: 9000,
+      path: ".github/workflows/ci.yml",
+      event: "push",
+      head_branch: "main",
+      head_sha: $revision,
+      status: "completed",
+      conclusion: $conclusion,
+      created_at: "2026-08-24T00:04:00Z",
+      updated_at: "2026-08-24T00:05:00Z",
+      completed_at: "2026-08-24T00:05:00Z"
+    }]' "$tmp/runs.json" >"$tmp/new-$conclusion-run.json"
+  expect_rejected "newer completed $conclusion workflow" ".github/workflows/ci.yml $conclusion" \
+    "$tmp/checks.json" "$tmp/new-$conclusion-run.json"
+done
+
+write_success_fixtures
+jq --arg revision "$REVISION" '.workflow_runs += [
+  {
+    id: 9100,
+    path: ".github/workflows/ci.yml",
+    event: "pull_request",
+    head_branch: "feature/review",
+    head_sha: $revision,
+    status: "completed",
+    conclusion: "failure",
+    completed_at: "2026-08-24T00:10:00Z"
+  },
+  {
+    id: 9200,
+    path: ".github/workflows/ci.yml",
+    event: "push",
+    head_branch: "go-v0.1.59",
+    head_sha: $revision,
+    status: "completed",
+    conclusion: "failure",
+    completed_at: "2026-08-24T00:11:00Z"
+  },
+  {
+    id: 9300,
+    path: ".github/workflows/ci.yml",
+    event: "workflow_dispatch",
+    head_branch: "main",
+    head_sha: $revision,
+    status: "completed",
+    conclusion: "failure",
+    completed_at: "2026-08-24T00:12:00Z"
+  },
+  {
+    id: 9400,
+    path: ".github/workflows/ci.yml",
+    event: "push",
+    head_branch: "main",
+    head_sha: $revision,
+    status: "in_progress",
+    conclusion: null,
+    updated_at: "2026-08-24T00:13:00Z"
+  }
+]' "$tmp/runs.json" >"$tmp/unrelated-runs.json"
+verify_fixture "$tmp/checks.json" "$tmp/unrelated-runs.json" >/dev/null
+
+write_success_fixtures
+jq 'del(.check_runs[] | select(.name == "Release artifact contract"))' \
+  "$tmp/checks.json" >"$tmp/missing.json"
+expect_rejected 'missing selected-run check' 'Release artifact contract (selected workflow run' \
+  "$tmp/missing.json" "$tmp/runs.json"
+
+printf 'release governance workflow/event and latest-completed fixtures verified\n'

--- a/scripts/test-verify-release-commit-checks.sh
+++ b/scripts/test-verify-release-commit-checks.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+SCRIPT="$ROOT/scripts/verify-release-commit-checks.sh"
+REQUIRED="$ROOT/.github/required-release-checks.txt"
+REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+tmp=$(mktemp -d)
+cleanup() { rm -rf -- "$tmp"; }
+trap cleanup EXIT
+
+write_fixture() {
+  local conclusion=$1 failed_name=${2:-}
+  {
+    printf '{"check_runs":['
+    separator=
+    id=100
+    while IFS= read -r name; do
+      [[ -n $name ]] || continue
+      current=$conclusion
+      [[ $name == "$failed_name" ]] && current=failure
+      printf '%s' "$separator"
+      jq -cn --arg name "$name" --arg conclusion "$current" --argjson id "$id" \
+        '{id:$id,name:$name,status:"completed",conclusion:$conclusion,app:{slug:"github-actions"}}'
+      separator=,
+      ((id += 1))
+    done <"$REQUIRED"
+    printf ']}\n'
+  } >"$tmp/checks.json"
+}
+
+write_fixture success
+LMM_CHECK_RUNS_FILE="$tmp/checks.json" LMM_CHECK_MAX_ATTEMPTS=1 \
+  bash "$SCRIPT" "$REVISION" >/dev/null
+
+failed_name='Release artifact contract'
+write_fixture success "$failed_name"
+if LMM_CHECK_RUNS_FILE="$tmp/checks.json" LMM_CHECK_MAX_ATTEMPTS=1 \
+  bash "$SCRIPT" "$REVISION" >"$tmp/failure.out" 2>&1; then
+  printf 'negative governance fixture unexpectedly accepted a failed release check\n' >&2
+  exit 1
+fi
+grep -Fq "$failed_name (failure)" "$tmp/failure.out"
+
+write_fixture success
+jq 'del(.check_runs[-1])' "$tmp/checks.json" >"$tmp/missing.json"
+if LMM_CHECK_RUNS_FILE="$tmp/missing.json" LMM_CHECK_MAX_ATTEMPTS=1 \
+  bash "$SCRIPT" "$REVISION" >"$tmp/missing.out" 2>&1; then
+  printf 'negative governance fixture unexpectedly accepted a missing check\n' >&2
+  exit 1
+fi
+grep -Fq '(missing)' "$tmp/missing.out"
+
+printf 'release governance negative fixtures verified\n'

--- a/scripts/test-verify-release-commit-checks.sh
+++ b/scripts/test-verify-release-commit-checks.sh
@@ -34,6 +34,11 @@ write_fixture success
 LMM_CHECK_RUNS_FILE="$tmp/checks.json" LMM_CHECK_MAX_ATTEMPTS=1 \
   bash "$SCRIPT" "$REVISION" >/dev/null
 
+jq '.check_runs += [{id:9999,name:"Release artifact contract",status:"in_progress",conclusion:null,app:{slug:"github-actions"}}]' \
+  "$tmp/checks.json" >"$tmp/tag-duplicate.json"
+LMM_CHECK_RUNS_FILE="$tmp/tag-duplicate.json" LMM_CHECK_MAX_ATTEMPTS=1 \
+  bash "$SCRIPT" "$REVISION" >/dev/null
+
 failed_name='Release artifact contract'
 write_fixture success "$failed_name"
 if LMM_CHECK_RUNS_FILE="$tmp/checks.json" LMM_CHECK_MAX_ATTEMPTS=1 \

--- a/scripts/verify-release-commit-checks.sh
+++ b/scripts/verify-release-commit-checks.sh
@@ -41,7 +41,11 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   for name in "${required[@]}"; do
     record=$(jq -c --arg name "$name" '
       [.check_runs[] | select(.name == $name and .app.slug == "github-actions")]
-      | if length == 0 then null else max_by(.id) end
+      | if length == 0 then null
+        elif any(.conclusion == "success") then
+          [.[] | select(.conclusion == "success")] | max_by(.id)
+        else max_by(.id)
+        end
     ' <<<"$checks")
     if [[ $record == null ]]; then
       pending+=("$name (missing)")

--- a/scripts/verify-release-commit-checks.sh
+++ b/scripts/verify-release-commit-checks.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+readonly ROOT
+readonly REPOSITORY=${GITHUB_REPOSITORY:-LIghtJUNction/api.lmm.best}
+readonly API_ROOT=${GITHUB_API_URL:-https://api.github.com}
+readonly REQUIRED_FILE="$ROOT/.github/required-release-checks.txt"
+readonly MAX_ATTEMPTS=${LMM_CHECK_MAX_ATTEMPTS:-30}
+readonly WAIT_SECONDS=${LMM_CHECK_WAIT_SECONDS:-20}
+
+fail() {
+  printf 'verify-release-commit-checks: %s\n' "$*" >&2
+  exit 1
+}
+
+[[ $# -eq 1 && $1 =~ ^[0-9a-f]{40}$ ]] || fail 'usage: verify-release-commit-checks.sh COMMIT_SHA'
+readonly REVISION=$1
+[[ -f $REQUIRED_FILE ]] || fail 'required check inventory is missing'
+mapfile -t required < <(grep -v '^[[:space:]]*$' "$REQUIRED_FILE")
+[[ ${#required[@]} -gt 0 ]] || fail 'required check inventory is empty'
+for command in curl jq; do command -v "$command" >/dev/null 2>&1 || fail "required command is unavailable: $command"; done
+
+fetch_checks() {
+  if [[ -n ${LMM_CHECK_RUNS_FILE:-} ]]; then
+    cat -- "$LMM_CHECK_RUNS_FILE"
+    return
+  fi
+  [[ -n ${GITHUB_TOKEN:-} ]] || fail 'GITHUB_TOKEN is required for live check verification'
+  curl --fail --location --silent --show-error \
+    --retry 4 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 60 \
+    --header "Authorization: Bearer $GITHUB_TOKEN" \
+    --header 'Accept: application/vnd.github+json' \
+    "$API_ROOT/repos/$REPOSITORY/commits/$REVISION/check-runs?per_page=100"
+}
+
+for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
+  checks=$(fetch_checks) || fail 'could not read commit check runs'
+  invalid=()
+  pending=()
+  for name in "${required[@]}"; do
+    record=$(jq -c --arg name "$name" '
+      [.check_runs[] | select(.name == $name and .app.slug == "github-actions")]
+      | if length == 0 then null else max_by(.id) end
+    ' <<<"$checks")
+    if [[ $record == null ]]; then
+      pending+=("$name (missing)")
+      continue
+    fi
+    status=$(jq -r '.status' <<<"$record")
+    conclusion=$(jq -r '.conclusion // ""' <<<"$record")
+    if [[ $status != completed ]]; then
+      pending+=("$name ($status)")
+    elif [[ $conclusion != success ]]; then
+      invalid+=("$name ($conclusion)")
+    fi
+  done
+  if [[ ${#invalid[@]} -gt 0 ]]; then
+    printf 'verify-release-commit-checks: failed required checks for %s:\n' "$REVISION" >&2
+    printf '  - %s\n' "${invalid[@]}" >&2
+    exit 1
+  fi
+  if [[ ${#pending[@]} -eq 0 ]]; then
+    printf 'all required CI, CodeQL, and release artifact checks passed for %s\n' "$REVISION"
+    exit 0
+  fi
+  if (( attempt == MAX_ATTEMPTS )); then
+    printf 'verify-release-commit-checks: required checks did not complete for %s:\n' "$REVISION" >&2
+    printf '  - %s\n' "${pending[@]}" >&2
+    exit 1
+  fi
+  sleep "$WAIT_SECONDS"
+done

--- a/scripts/verify-release-commit-checks.sh
+++ b/scripts/verify-release-commit-checks.sh
@@ -17,40 +17,121 @@ fail() {
 [[ $# -eq 1 && $1 =~ ^[0-9a-f]{40}$ ]] || fail 'usage: verify-release-commit-checks.sh COMMIT_SHA'
 readonly REVISION=$1
 [[ -f $REQUIRED_FILE ]] || fail 'required check inventory is missing'
-mapfile -t required < <(grep -v '^[[:space:]]*$' "$REQUIRED_FILE")
-[[ ${#required[@]} -gt 0 ]] || fail 'required check inventory is empty'
+
+required_names=()
+required_workflows=()
+required_events=()
+required_branches=()
+while IFS='|' read -r name workflow event branch extra; do
+  [[ -n $name ]] || continue
+  [[ -n $workflow && -n $event && -n $branch && -z $extra ]] ||
+    fail "invalid required check inventory entry: $name"
+  required_names+=("$name")
+  required_workflows+=("$workflow")
+  required_events+=("$event")
+  required_branches+=("$branch")
+done <"$REQUIRED_FILE"
+[[ ${#required_names[@]} -gt 0 ]] || fail 'required check inventory is empty'
 for command in curl jq; do command -v "$command" >/dev/null 2>&1 || fail "required command is unavailable: $command"; done
+
+api_get() {
+  local url=$1
+  curl --fail --location --silent --show-error \
+    --retry 4 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 60 \
+    --header "Authorization: Bearer $GITHUB_TOKEN" \
+    --header 'Accept: application/vnd.github+json' \
+    "$url"
+}
 
 fetch_checks() {
   if [[ -n ${LMM_CHECK_RUNS_FILE:-} ]]; then
     cat -- "$LMM_CHECK_RUNS_FILE"
     return
   fi
-  [[ -n ${GITHUB_TOKEN:-} ]] || fail 'GITHUB_TOKEN is required for live check verification'
-  curl --fail --location --silent --show-error \
-    --retry 4 --retry-all-errors --retry-delay 2 --connect-timeout 15 --max-time 60 \
-    --header "Authorization: Bearer $GITHUB_TOKEN" \
-    --header 'Accept: application/vnd.github+json' \
-    "$API_ROOT/repos/$REPOSITORY/commits/$REVISION/check-runs?per_page=100"
+  api_get "$API_ROOT/repos/$REPOSITORY/commits/$REVISION/check-runs?per_page=100"
 }
+
+fetch_workflow_runs() {
+  if [[ -n ${LMM_WORKFLOW_RUNS_FILE:-} ]]; then
+    cat -- "$LMM_WORKFLOW_RUNS_FILE"
+    return
+  fi
+  api_get "$API_ROOT/repos/$REPOSITORY/actions/runs?head_sha=$REVISION&per_page=100"
+}
+
+if [[ -z ${LMM_CHECK_RUNS_FILE:-} || -z ${LMM_WORKFLOW_RUNS_FILE:-} ]]; then
+  [[ -n ${GITHUB_TOKEN:-} ]] || fail 'GITHUB_TOKEN is required for live check verification'
+fi
 
 for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
   checks=$(fetch_checks) || fail 'could not read commit check runs'
+  workflow_runs=$(fetch_workflow_runs) || fail 'could not read workflow runs'
   invalid=()
   pending=()
-  for name in "${required[@]}"; do
-    record=$(jq -c --arg name "$name" '
-      [.check_runs[] | select(.name == $name and .app.slug == "github-actions")]
-      | if length == 0 then null
-        elif any(.conclusion == "success") then
-          [.[] | select(.conclusion == "success")] | max_by(.id)
-        else max_by(.id)
+
+  for index in "${!required_names[@]}"; do
+    name=${required_names[$index]}
+    workflow=${required_workflows[$index]}
+    event=${required_events[$index]}
+    branch=${required_branches[$index]}
+
+    workflow_run=$(jq -c \
+      --arg workflow "$workflow" \
+      --arg event "$event" \
+      --arg branch "$branch" \
+      --arg revision "$REVISION" '
+        [.workflow_runs[] |
+          select(
+            .path == $workflow and
+            .event == $event and
+            .head_branch == $branch and
+            .head_sha == $revision
+          )] |
+        if length == 0 then null
+        elif any(.status == "completed") then
+          [.[] | select(.status == "completed")] |
+          max_by([(.completed_at // .updated_at // .created_at // ""), .id])
+        else
+          max_by([(.updated_at // .created_at // ""), .id])
         end
-    ' <<<"$checks")
-    if [[ $record == null ]]; then
-      pending+=("$name (missing)")
+      ' <<<"$workflow_runs")
+    if [[ $workflow_run == null ]]; then
+      pending+=("$name ($workflow $event/$branch missing)")
       continue
     fi
+
+    workflow_status=$(jq -r '.status' <<<"$workflow_run")
+    workflow_conclusion=$(jq -r '.conclusion // ""' <<<"$workflow_run")
+    if [[ $workflow_status != completed ]]; then
+      pending+=("$name ($workflow $workflow_status)")
+      continue
+    fi
+    if [[ $workflow_conclusion != success ]]; then
+      invalid+=("$name ($workflow $workflow_conclusion)")
+      continue
+    fi
+
+    workflow_run_id=$(jq -r '.id' <<<"$workflow_run")
+    record=$(jq -c --arg name "$name" --argjson run_id "$workflow_run_id" '
+      [.check_runs[] |
+        select(
+          .name == $name and
+          .app.slug == "github-actions" and
+          ((.details_url // "") | contains("/actions/runs/" + ($run_id | tostring) + "/"))
+        )] |
+      if length == 0 then null
+      elif any(.status == "completed") then
+        [.[] | select(.status == "completed")] |
+        max_by([(.completed_at // .started_at // ""), .id])
+      else
+        max_by([(.started_at // ""), .id])
+      end
+    ' <<<"$checks")
+    if [[ $record == null ]]; then
+      pending+=("$name (selected workflow run $workflow_run_id missing)")
+      continue
+    fi
+
     status=$(jq -r '.status' <<<"$record")
     conclusion=$(jq -r '.conclusion // ""' <<<"$record")
     if [[ $status != completed ]]; then
@@ -59,16 +140,17 @@ for ((attempt = 1; attempt <= MAX_ATTEMPTS; attempt++)); do
       invalid+=("$name ($conclusion)")
     fi
   done
+
   if [[ ${#invalid[@]} -gt 0 ]]; then
     printf 'verify-release-commit-checks: failed required checks for %s:\n' "$REVISION" >&2
     printf '  - %s\n' "${invalid[@]}" >&2
     exit 1
   fi
   if [[ ${#pending[@]} -eq 0 ]]; then
-    printf 'all required CI, CodeQL, and release artifact checks passed for %s\n' "$REVISION"
+    printf 'all required main-push CI, CodeQL, and release artifact checks passed for %s\n' "$REVISION"
     exit 0
   fi
-  if (( attempt == MAX_ATTEMPTS )); then
+  if ((attempt == MAX_ATTEMPTS)); then
     printf 'verify-release-commit-checks: required checks did not complete for %s:\n' "$REVISION" >&2
     printf '  - %s\n' "${pending[@]}" >&2
     exit 1


### PR DESCRIPTION
## Summary
- pin `lmm-api-go-bin` to verified `go-v0.1.59` assets/checksums/Sigstore bundles
- move rolling source packages onto monotonic `0.1.20.rN.gSHA` versions with a published-floor `vercmp` gate
- apply one canonical T0/T1 phase contract to bin/source/-git/local recipes
- preserve the T0 compatibility alias and legacy deploy package until T1 0.1.60
- reconcile transport-ambiguous activation dispatches and allow at most one evidence-free redispatch
- require exact CI, CodeQL, and release-artifact checks before tag/release promotion
- add a dedicated release artifact check plus live latest-release/AUR/Sigstore pin verification

## Verification
- full Go tests and `go vet`
- appcli LSP diagnostics
- real `makepkg` bin smoke
- real pacman split/T0/T1/rollback roundtrip
- latest GitHub Go release checksums and Sigstore verification for amd64/arm64
- AUR matrix and release artifact contracts
- governance negative fixtures
- activation dispatch fault injection before SSH, after unit creation, and after result transport

## Release gate
Do not publish AUR or deploy production until PR #143 is merged and CodeQL alert #51 is confirmed closed.

## Sourcery 摘要

通过经过验证的发布固定版本、共享阶段规则和基于证据的部署调度，提升发布推广、软件包过渡和生产环境激活的安全性。

新功能：
- 增加对 Go 发布资产、校验和、Sigstore bundle、AUR 版本和发布构件契约的实时验证。
- 增加调度证据检查，以及生产部署的有界激活重新调度处理。

错误修复：
- 对于传输结果不明确的 SSH 结果，在允许进行一次重新调度前协调远程证据，防止生产环境重复激活。
- 针对缺失或未成功的 CI、CodeQL 和构件检查，强化发布和标签推广流程。
- 修正软件包过渡行为，使 T0 保留兼容性别名和旧版部署软件包，直到 T1。

增强功能：
- 统一二进制、源代码、git 和本地软件包配方中的 T0/T1 元数据及兼容性别名行为。
- 将滚动源软件包版本迁移为单调递增版本，并设置已发布版本下限。
- 将 amd64 和 arm64 架构的固定 Go 二进制版本更新至 0.1.59。

CI：
- 在 CI 和推广工作流中要求执行发布治理和构件契约检查。
- 扩展 AUR CI 验证，增加 Go 发布固定版本和 Sigstore 的实时验证。

部署：
- 持久化激活单元标识和调度尝试记录，并在调度结果不明确后观察现有的激活任务。

文档：
- 记录规范的 CLI 阶段契约、T0/T1 软件包过渡行为以及发布验证工作流。

测试：
- 增加发布治理负面测试夹具和生产环境调度故障注入覆盖。
- 扩展软件包往返测试和 AUR 矩阵测试，覆盖兼容性别名、过渡元数据、单调递增版本和构件完整性。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

加强发布推广、软件包过渡和生产环境激活流程，防止使用未经验证的制品、前后不一致的阶段元数据以及含义不明确的调度结果。

新功能：
- 为 Go 发布资产、校验和、Sigstore bundle、AUR 版本以及发布制品契约添加实时验证。
- 添加基于证据的生产环境激活调度协调机制：当不存在远程证据时，最多执行一次有界重调度。

错误修复：
- 当 SSH 结果存在传输歧义时，通过在发现任何调度证据后观察现有任务，防止重复激活生产环境。
- 除非所需的 CI、CodeQL 和发布制品检查成功，否则阻止标签和发布推广。
- 在 T1 过渡期间保留 T0 兼容性别名和旧版部署软件包。

增强功能：
- 统一二进制、源代码、git 和本地软件包配方中的 T0/T1 元数据及兼容性行为。
- 使用带有已发布版本下限的单调递增滚动源软件包版本。
- 将固定版本的 amd64 和 arm64 Go 二进制软件包更新至经过验证的 0.1.59 版本。

CI：
- 在 CI 和推广工作流中添加发布制品契约及发布治理检查。
- 扩展 AUR CI，添加实时 Go 发布版本固定值和 Sigstore 验证。

部署：
- 持久化激活单元标识和调度尝试记录，并在重试或观察现有任务之前协调存在歧义的激活结果。

文档：
- 记录共享 CLI 阶段契约、T0/T1 软件包过渡行为以及发布验证工作流。

测试：
- 扩展软件包往返、AUR 矩阵、发布治理、制品契约和激活故障注入测试覆盖范围。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

增强发布推广、软件包过渡和生产环境激活流程，防止使用未经验证的构件、 不一致的阶段元数据以及含义不明确的调度结果。

新功能：
- 为固定版本的 Go 发布资产、校验和、Sigstore bundle、AUR 版本和发布构件契约添加实时验证。
- 添加基于证据的生产环境激活调度结果协调，并支持有界的重新调度行为。

错误修复：
- 在 SSH 结果存在传输歧义时，通过在任何重试前检查现有证据，防止重复进行生产环境激活。
- 当必需的 CI、CodeQL 或发布构件检查缺失或未成功时，阻止标签和发布推广。
- 在 T1 过渡期间保留 T0 兼容性别名和旧版部署软件包。

增强功能：
- 统一二进制、源代码、git 和本地软件包配方中的 T0/T1 元数据及兼容性行为。
- 使用带有已发布版本下限的单调递增滚动源软件包版本。
- 将 amd64 和 arm64 二进制软件包固定版本更新为经过验证的 Go 0.1.59 发布版本。

CI：
- 在 CI 和推广工作流中要求执行发布治理和构件契约检查。
- 扩展 AUR CI，添加实时 Go 发布版本固定检查和 Sigstore 验证。

部署：
- 持久化激活单元标识和调度尝试记录，并在重试或观察现有任务之前协调含义不明确的激活结果。

文档：
- 记录共享 CLI 阶段契约、T0/T1 软件包过渡行为以及发布验证工作流。

测试：
- 扩展软件包往返测试和 AUR 矩阵覆盖范围，涵盖兼容性别名、过渡元数据、单调递增版本和构件完整性。
- 添加发布治理负向测试固件，以及生产环境激活调度故障注入测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过强制执行已验证的制品、共享阶段规则和基于证据的调度处理，强化发布推广、软件包过渡和生产环境激活流程。

新功能：
- 为固定版本的 Go 发布资产、校验和、Sigstore bundle、AUR 版本以及发布制品契约添加实时验证。
- 添加基于证据的生产环境激活调度协调机制：当不存在远程证据时，允许有界的一次重新调度。

错误修复：
- 在 SSH 返回传输状态不明确的结果后，通过在重试前检查现有证据，防止重复激活生产环境。
- 当必需的 CI、CodeQL 或发布制品检查缺失或未成功时，阻止标签和发布推广。
- 在过渡到 T1 期间，保留 T0 兼容性别名和旧版部署软件包。

增强功能：
- 统一二进制、源码、git 和本地软件包配方中的 T0/T1 元数据及兼容性行为。
- 采用带有已发布版本下限的单调递增滚动源码软件包版本，并将二进制软件包更新为已验证的 Go 发布版本 0.1.59 固定版本。

CI：
- 在 CI 和发布推广工作流中要求执行发布治理和制品契约检查。
- 扩展 AUR CI，添加实时 Go 发布版本固定值和 Sigstore 验证。

部署：
- 持久化激活单元标识和调度尝试记录，并在观察或重新调度任务前，协调处理不明确的激活结果。

文档：
- 记录共享 CLI 阶段契约、T0/T1 软件包过渡行为以及发布验证工作流。

测试：
- 扩展软件包往返、AUR 矩阵、发布治理、制品契约和激活故障注入测试覆盖范围。

杂项：
- 将 HeroSMS 设置标签重命名为更准确地描述临时激活，并覆盖所有受支持的语言环境。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过强制执行已验证的构件、统一的阶段规则以及基于证据的调度处理，增强发布推广、软件包过渡和生产环境激活的可靠性。

新功能：
- 为 Go 发布资产、校验和、Sigstore 捆绑包、AUR 版本和发布构件契约添加实时验证。
- 添加基于证据的生产环境激活调度协调机制：当不存在远程证据时，最多执行一次有界重新调度。

错误修复：
- 在 SSH 结果存在传输歧义时，通过在重试前检查现有证据，防止重复激活生产环境。
- 除非必需的 CI、CodeQL 和发布构件检查成功，否则阻止标签和发布推广。
- 在 T1 过渡期间保留 T0 兼容性别名和旧版部署软件包。

增强功能：
- 统一二进制、源代码、git 和本地软件包配方中的 T0/T1 元数据及兼容性行为。
- 采用单调递增的滚动源代码软件包版本，并设置已发布版本下限；同时将固定版本的 Go 二进制文件更新至经过验证的发布版本 0.1.59。

CI：
- 在 CI 和推广工作流中要求执行发布治理和构件契约检查。
- 通过实时 Go 发布固定版本和 Sigstore 验证，扩展 AUR 验证。

部署：
- 持久化激活单元标识和调度尝试记录，并在观察或重新调度任务前协调存在歧义的激活结果。

文档：
- 记录共享 CLI 阶段契约、T0/T1 软件包过渡行为以及发布验证工作流。

测试：
- 扩展软件包往返、AUR 矩阵、发布治理、构件契约和激活故障注入测试覆盖范围。

杂务：
- 重命名 HeroSMS 设置标签，以便在支持的语言环境中准确描述临时激活。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过强制执行已验证制品、共享阶段契约和基于证据的调度处理，增强发布推广、软件包过渡和生产环境激活的可靠性。

新功能：
- 增加对固定版本 Go 发布资产、校验和、Sigstore bundle、AUR 版本以及发布制品契约的实时验证。
- 增加基于证据的生产环境激活调度协调机制：当不存在远程证据时，允许有界的一次重新调度。

错误修复：
- 对于传输结果不明确的 SSH 结果，在重试前先检查现有证据，防止重复进行生产环境激活。
- 除非必需的 CI、CodeQL 和发布制品检查成功，否则阻止标签和发布推广。
- 在 T1 过渡期间保留 T0 兼容性别名和旧版部署软件包。

改进：
- 在二进制、源代码、git 和本地软件包配方之间统一 T0/T1 元数据和兼容性行为。
- 使用带有已发布版本下限的单调递增滚动源软件包版本，并将二进制软件包更新为已验证的 Go release 0.1.59 固定版本。
- 在生产部署状态转换过程中持久化激活单元标识和调度尝试记录。

CI：
- 在 CI 和推广工作流中要求执行发布治理和制品契约检查。
- 通过实时 Go 发布固定版本和 Sigstore 验证，扩展 AUR 软件包验证。

部署：
- 使用单元、清单和状态证据协调结果不明确的激活调度，然后再观察或重新调度部署工作。

文档：
- 记录共享 CLI 阶段契约、T0/T1 软件包过渡行为以及发布验证工作流。

测试：
- 扩展软件包往返测试、AUR 矩阵测试、发布治理、制品契约和激活故障注入测试的覆盖范围。

日常维护：
- 将 HeroSMS 设置标签重命名，以便在支持的语言环境中准确描述临时激活。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过强制执行已验证的制品、共享阶段契约和基于证据的调度处理，强化版本发布推广、软件包过渡和生产环境激活流程。

新功能：
- 增加对固定版本 Go 发布资产、校验和、Sigstore 捆绑包、AUR 版本及发布制品契约的实时验证。
- 增加基于证据的生产环境激活调度协调，持久化单元标识，并最多执行一次安全重新调度。

错误修复：
- 在 SSH 结果存在传输歧义时，通过在重试前检查现有远程证据，防止重复激活生产环境。
- 当必需的 CI、CodeQL 或发布制品检查缺失或未成功时，阻止标签和版本发布推广。
- 在 T1 过渡期间保留 T0 兼容性别名和旧版部署软件包。

增强功能：
- 统一二进制、源代码、git 和本地软件包配方中的 T0/T1 元数据及兼容性行为。
- 使用带有已发布版本下限的单调递增源软件包版本，并将经过验证的 amd64 和 arm64 Go 二进制版本更新至 0.1.59。
- 改进生产版本状态持久化及激活监控的终止阶段处理。

CI：
- 在 CI 和版本发布推广工作流中要求执行版本治理和制品契约检查。
- 通过实时 Go 发布固定版本和 Sigstore 验证，扩展 AUR 验证。

部署：
- 持久化激活单元和调度尝试状态，并在观察或重新调度部署任务前协调存在歧义的激活结果。

文档：
- 记录共享 CLI 阶段契约、T0/T1 软件包过渡行为以及版本验证工作流。

测试：
- 扩展软件包往返、AUR 矩阵、版本治理、制品契约和激活故障注入测试的覆盖范围。

杂项：
- 重命名 HeroSMS 设置标签，以便在所有支持的语言环境中准确描述临时激活。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden release promotion, package transitions, and production activation by enforcing verified artifacts, shared phase contracts, and evidence-based dispatch handling.

New Features:
- Add live verification for pinned Go release assets, checksums, Sigstore bundles, AUR versions, and release artifact contracts.
- Add evidence-based production activation dispatch reconciliation with persisted unit identity and at most one safe redispatch.

Bug Fixes:
- Prevent duplicate production activations after transport-ambiguous SSH results by observing existing remote evidence before retrying.
- Block tag and release promotion when required CI, CodeQL, or release artifact checks are missing or unsuccessful.
- Preserve the T0 compatibility alias and legacy deploy package through the T1 transition.

Enhancements:
- Unify T0/T1 metadata and compatibility behavior across binary, source, git, and local package recipes.
- Use monotonic rolling source package versions with a published-version floor and update verified amd64 and arm64 Go binaries to 0.1.59.
- Improve production release state persistence and terminal-phase handling for activation monitoring.

CI:
- Require release governance and artifact contract checks in CI and release promotion workflows.
- Extend AUR validation with live Go release pin and Sigstore verification.

Deployment:
- Persist activation unit and dispatch-attempt state and reconcile ambiguous activation results before observing or redispatching deployment work.

Documentation:
- Document the shared CLI phase contract, T0/T1 package transition behavior, and release verification workflow.

Tests:
- Expand package roundtrip, AUR matrix, release governance, artifact contract, and activation fault-injection test coverage.

Chores:
- Rename HeroSMS settings labels to accurately describe temporary activations across supported locales.

</details>

</details>

</details>

</details>

</details>

</details>

</details>