### PR TITLE
fix(web): rename HeroSMS activation settings

### DIFF
--- a/apps/web/src/features/email-activations/i18n.ts
+++ b/apps/web/src/features/email-activations/i18n.ts
@@ -45,7 +45,7 @@ export const heroSmsTranslations = {
       'For security, the browser never reads back the saved secret. Enter a new key only when rotating it.',
     'HeroSMS API key cleared': 'HeroSMS API key cleared',
     'HeroSMS connection test passed': 'HeroSMS connection test passed',
-    'HeroSMS Email': 'HeroSMS Email',
+    'HeroSMS temporary activations': 'HeroSMS temporary activations',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -210,7 +210,7 @@ export const heroSmsTranslations = {
       '出于安全考虑，浏览器不会读回已保存的密钥。只有在轮换时才输入新密钥。',
     'HeroSMS API key cleared': '已清除 HeroSMS API 密钥',
     'HeroSMS connection test passed': 'HeroSMS 连接测试通过',
-    'HeroSMS Email': 'HeroSMS 邮箱接码',
+    'HeroSMS temporary activations': 'HeroSMS 临时接码',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS 暂时不可用，请保持页面打开并稍后重试。',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -370,7 +370,7 @@ export const heroSmsTranslations = {
       '基於安全考量，瀏覽器不會讀回已儲存的密鑰。只有在輪換時才輸入新金鑰。',
     'HeroSMS API key cleared': '已清除 HeroSMS API 金鑰',
     'HeroSMS connection test passed': 'HeroSMS 連線測試通過',
-    'HeroSMS Email': 'HeroSMS 郵箱接碼',
+    'HeroSMS temporary activations': 'HeroSMS 臨時接碼',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS 暫時不可用，請保持頁面開啟並稍後重試。',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -532,7 +532,7 @@ export const heroSmsTranslations = {
       'Pour des raisons de sécurité, le navigateur ne relit jamais le secret enregistré. Saisissez une nouvelle clé uniquement lors de sa rotation.',
     'HeroSMS API key cleared': 'Clé API HeroSMS effacée',
     'HeroSMS connection test passed': 'Test de connexion HeroSMS réussi',
-    'HeroSMS Email': 'E-mail HeroSMS',
+    'HeroSMS temporary activations': 'Activations temporaires HeroSMS',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS est temporairement indisponible. Laissez cette page ouverte et réessayez sous peu.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -701,7 +701,7 @@ export const heroSmsTranslations = {
       'セキュリティのため、ブラウザーは保存済みシークレットを読み戻しません。新しいキーはローテーション時のみ入力してください。',
     'HeroSMS API key cleared': 'HeroSMS API キーを消去しました',
     'HeroSMS connection test passed': 'HeroSMS 接続テストに成功しました',
-    'HeroSMS Email': 'HeroSMS メール認証受信',
+    'HeroSMS temporary activations': 'HeroSMS 一時認証',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS は一時的に利用できません。このページを開いたまま、しばらくしてから再試行してください。',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -867,7 +867,7 @@ export const heroSmsTranslations = {
     'HeroSMS API key cleared': 'API-ключ HeroSMS очищен',
     'HeroSMS connection test passed':
       'Проверка подключения HeroSMS прошла успешно',
-    'HeroSMS Email': 'Почта HeroSMS',
+    'HeroSMS temporary activations': 'Временные активации HeroSMS',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS временно недоступен. Оставьте эту страницу открытой и попробуйте снова чуть позже.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':
@@ -1034,7 +1034,7 @@ export const heroSmsTranslations = {
       'Vì lý do bảo mật, trình duyệt không bao giờ đọc lại bí mật đã lưu. Chỉ nhập khóa mới khi bạn xoay vòng khóa.',
     'HeroSMS API key cleared': 'Đã xóa API key HeroSMS',
     'HeroSMS connection test passed': 'Kiểm tra kết nối HeroSMS thành công',
-    'HeroSMS Email': 'Email HeroSMS',
+    'HeroSMS temporary activations': 'Kích hoạt tạm thời HeroSMS',
     'HeroSMS is temporarily unavailable. Keep this page open and try again shortly.':
       'HeroSMS tạm thời không khả dụng. Hãy giữ trang này mở và thử lại sau ít phút.',
     'HeroSMS only returns purchasable email domains after you provide a non-empty target site.':

--- a/apps/web/src/features/system-settings/operations/section-registry.test.tsx
+++ b/apps/web/src/features/system-settings/operations/section-registry.test.tsx
@@ -1,0 +1,31 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import { getOperationsSectionMeta } from './section-registry.js'
+
+describe('operations section registry', () => {
+  test('names the shared HeroSMS email and SMS settings accurately', () => {
+    assert.equal(
+      getOperationsSectionMeta('hero-sms').titleKey,
+      'HeroSMS temporary activations'
+    )
+  })
+})

--- a/apps/web/src/features/system-settings/operations/section-registry.tsx
+++ b/apps/web/src/features/system-settings/operations/section-registry.tsx
@@ -111,7 +111,7 @@ const OPERATIONS_SECTIONS = [
   },
   {
     id: 'hero-sms',
-    titleKey: 'HeroSMS Email',
+    titleKey: 'HeroSMS temporary activations',
     build: () => <LazyHeroSmsSettingsSection />,
   },
   {

--- a/apps/web/src/i18n/static-keys.ts
+++ b/apps/web/src/i18n/static-keys.ts
@@ -693,5 +693,5 @@ export const STATIC_I18N_KEYS = [
   'Telegram binding failed. Please try again.',
   'Verification scope is missing',
   'Email Activations',
-  'HeroSMS Email',
+  'HeroSMS temporary activations',
 ] as const


### PR DESCRIPTION
## Summary
- rename the shared HeroSMS settings section from the email-only title to `HeroSMS temporary activations`
- update all seven feature translations and the static i18n inventory
- add a registry test proving the title covers both email and SMS settings

## Verification
- targeted HeroSMS API and section-registry tests
- TypeScript project build
- `bun run i18n:sync`

## Deployment
No production change. Before any Web deployment, run GET → reset, save → refetch, and full reload E2E against the candidate build, then follow the explicit production authorization flow.

## Sourcery 摘要

重命名共享的 HeroSMS 设置标题，以反映电子邮件和 SMS 临时激活。

错误修复：
- 重命名共享的 HeroSMS 设置部分，使其准确涵盖电子邮件和 SMS 临时激活。

增强功能：
- 更新所有受支持翻译中的 HeroSMS 激活术语以及静态 i18n 键清单。

测试：
- 添加注册表测试，验证共享的 HeroSMS 部分使用临时激活标题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the shared HeroSMS settings title to reflect both email and SMS temporary activations.

Bug Fixes:
- Rename the shared HeroSMS settings section to accurately cover both email and SMS temporary activations.

Enhancements:
- Update HeroSMS activation terminology across all supported translations and the static i18n key inventory.

Tests:
- Add a registry test verifying the shared HeroSMS section uses the temporary activations title.

</details>