### PR TITLE
fix(go): reject unsupported OpenAI image formats

### DIFF
--- a/apps/api-go/controller/relay_image_validation_test.go
+++ b/apps/api-go/controller/relay_image_validation_test.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LIghtJUNction/api.lmm.best/common"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelayRejectsUnsupportedImageBeforeBillingAndChannelSelection(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	part, err := writer.CreateFormFile("image[]", "image.png")
+	require.NoError(t, err)
+	_, err = part.Write([]byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'})
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	response := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(response)
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	context.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	context.Set(common.RequestIdKey, "image-validation-test")
+	t.Cleanup(func() { common.CleanupBodyStorage(context) })
+
+	Relay(context, types.RelayFormatOpenAIImage)
+
+	require.Equal(t, http.StatusBadRequest, response.Code)
+	var payload struct {
+		Error types.OpenAIError `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &payload))
+	require.Equal(t, "new_api_error", payload.Error.Type)
+	require.Equal(t, string(types.ErrorCodeInvalidRequest), payload.Error.Code)
+	require.Contains(t, payload.Error.Message, "unsupported image content type")
+	require.Empty(t, context.GetStringSlice("use_channel"), "validation must stop before upstream selection")
+}

--- a/apps/api-go/relay/channel/openai/adaptor.go
+++ b/apps/api-go/relay/channel/openai/adaptor.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/LIghtJUNction/api.lmm.best/common"
@@ -502,9 +501,8 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 			// Process all image files
 			for i, fileHeader := range imageFiles {
-				// Determine MIME type before opening or forwarding the file. Unsupported
-				// extensions must fail locally rather than being mislabeled upstream.
-				mimeType, err := detectImageMimeType(fileHeader.Filename)
+				// Determine MIME type from a bounded byte prefix before forwarding.
+				mimeType, err := relaycommon.DetectSupportedImageUploadMediaType(fileHeader)
 				if err != nil {
 					return nil, err
 				}
@@ -540,8 +538,8 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 			// Handle mask file if present
 			if maskFiles, exists := mf.File["mask"]; exists && len(maskFiles) > 0 {
-				// Validate the extension before opening or forwarding the mask file.
-				mimeType, err := detectImageMimeType(maskFiles[0].Filename)
+				// Determine the mask MIME type from bytes rather than its filename.
+				mimeType, err := relaycommon.DetectSupportedImageUploadMediaType(maskFiles[0])
 				if err != nil {
 					return nil, err
 				}
@@ -586,21 +584,6 @@ func isJSONRequest(c *gin.Context) bool {
 		return false
 	}
 	return strings.HasPrefix(c.Request.Header.Get("Content-Type"), "application/json")
-}
-
-// detectImageMimeType determines the MIME type based on the file extension.
-func detectImageMimeType(filename string) (string, error) {
-	ext := strings.ToLower(filepath.Ext(filename))
-	switch ext {
-	case ".jpg", ".jpeg":
-		return "image/jpeg", nil
-	case ".png":
-		return "image/png", nil
-	case ".webp":
-		return "image/webp", nil
-	default:
-		return "", fmt.Errorf("unsupported image format %q; supported formats: .jpg, .jpeg, .png, .webp", ext)
-	}
 }
 
 func (a *Adaptor) ConvertOpenAIResponsesRequest(c *gin.Context, info *relaycommon.RelayInfo, request dto.OpenAIResponsesRequest) (any, error) {

--- a/apps/api-go/relay/channel/openai/adaptor.go
+++ b/apps/api-go/relay/channel/openai/adaptor.go
@@ -502,6 +502,13 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 			// Process all image files
 			for i, fileHeader := range imageFiles {
+				// Determine MIME type before opening or forwarding the file. Unsupported
+				// extensions must fail locally rather than being mislabeled upstream.
+				mimeType, err := detectImageMimeType(fileHeader.Filename)
+				if err != nil {
+					return nil, err
+				}
+
 				file, err := fileHeader.Open()
 				if err != nil {
 					return nil, fmt.Errorf("failed to open image file %d: %w", i, err)
@@ -512,9 +519,6 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 				if len(imageFiles) > 1 {
 					fieldName = "image[]"
 				}
-
-				// Determine MIME type based on file extension
-				mimeType := detectImageMimeType(fileHeader.Filename)
 
 				// Create a form file with the appropriate content type
 				h := make(textproto.MIMEHeader)
@@ -536,14 +540,17 @@ func (a *Adaptor) ConvertImageRequest(c *gin.Context, info *relaycommon.RelayInf
 
 			// Handle mask file if present
 			if maskFiles, exists := mf.File["mask"]; exists && len(maskFiles) > 0 {
+				// Validate the extension before opening or forwarding the mask file.
+				mimeType, err := detectImageMimeType(maskFiles[0].Filename)
+				if err != nil {
+					return nil, err
+				}
+
 				maskFile, err := maskFiles[0].Open()
 				if err != nil {
 					return nil, errors.New("failed to open mask file")
 				}
 				// 复制完立即关闭，避免在循环内使用 defer 占用资源
-
-				// Determine MIME type for mask file
-				mimeType := detectImageMimeType(maskFiles[0].Filename)
 
 				// Create a form file with the appropriate content type
 				h := make(textproto.MIMEHeader)
@@ -581,23 +588,18 @@ func isJSONRequest(c *gin.Context) bool {
 	return strings.HasPrefix(c.Request.Header.Get("Content-Type"), "application/json")
 }
 
-// detectImageMimeType determines the MIME type based on the file extension
-func detectImageMimeType(filename string) string {
+// detectImageMimeType determines the MIME type based on the file extension.
+func detectImageMimeType(filename string) (string, error) {
 	ext := strings.ToLower(filepath.Ext(filename))
 	switch ext {
 	case ".jpg", ".jpeg":
-		return "image/jpeg"
+		return "image/jpeg", nil
 	case ".png":
-		return "image/png"
+		return "image/png", nil
 	case ".webp":
-		return "image/webp"
+		return "image/webp", nil
 	default:
-		// Try to detect from extension if possible
-		if strings.HasPrefix(ext, ".jp") {
-			return "image/jpeg"
-		}
-		// Default to png as a fallback
-		return "image/png"
+		return "", fmt.Errorf("unsupported image format %q; supported formats: .jpg, .jpeg, .png, .webp", ext)
 	}
 }
 

--- a/apps/api-go/relay/channel/openai/adaptor_mime_test.go
+++ b/apps/api-go/relay/channel/openai/adaptor_mime_test.go
@@ -1,0 +1,82 @@
+package openai
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectImageMimeType(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		wantType string
+		wantErr  string
+	}{
+		{name: "jpeg uppercase", filename: "input.JPEG", wantType: "image/jpeg"},
+		{name: "jpg uppercase", filename: "input.JPG", wantType: "image/jpeg"},
+		{name: "png uppercase", filename: "input.PNG", wantType: "image/png"},
+		{name: "webp uppercase", filename: "input.WEBP", wantType: "image/webp"},
+		{
+			name:     "heic is unsupported",
+			filename: "input.HEIC",
+			wantErr:  `unsupported image format ".heic"; supported formats: .jpg, .jpeg, .png, .webp`,
+		},
+		{
+			name:     "extensionless is unsupported",
+			filename: "input",
+			wantErr:  `unsupported image format ""; supported formats: .jpg, .jpeg, .png, .webp`,
+		},
+		{
+			name:     "unknown extension is unsupported",
+			filename: "input.gif",
+			wantErr:  `unsupported image format ".gif"; supported formats: .jpg, .jpeg, .png, .webp`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := detectImageMimeType(tt.filename)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				require.Empty(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, got)
+		})
+	}
+}
+
+func TestConvertImageRequestRejectsUnsupportedImageFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	part, err := writer.CreateFormFile("image", "input.heic")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("fake image"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	require.NoError(t, c.Request.ParseMultipartForm(32<<20))
+
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeImagesEdits}
+	converted, err := (&Adaptor{}).ConvertImageRequest(c, info, dto.ImageRequest{Model: "gpt-image-1"})
+
+	require.Nil(t, converted)
+	require.EqualError(t, err, `unsupported image format ".heic"; supported formats: .jpg, .jpeg, .png, .webp`)
+}

--- a/apps/api-go/relay/channel/openai/adaptor_mime_test.go
+++ b/apps/api-go/relay/channel/openai/adaptor_mime_test.go
@@ -14,50 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDetectImageMimeType(t *testing.T) {
-	tests := []struct {
-		name     string
-		filename string
-		wantType string
-		wantErr  string
-	}{
-		{name: "jpeg uppercase", filename: "input.JPEG", wantType: "image/jpeg"},
-		{name: "jpg uppercase", filename: "input.JPG", wantType: "image/jpeg"},
-		{name: "png uppercase", filename: "input.PNG", wantType: "image/png"},
-		{name: "webp uppercase", filename: "input.WEBP", wantType: "image/webp"},
-		{
-			name:     "heic is unsupported",
-			filename: "input.HEIC",
-			wantErr:  `unsupported image format ".heic"; supported formats: .jpg, .jpeg, .png, .webp`,
-		},
-		{
-			name:     "extensionless is unsupported",
-			filename: "input",
-			wantErr:  `unsupported image format ""; supported formats: .jpg, .jpeg, .png, .webp`,
-		},
-		{
-			name:     "unknown extension is unsupported",
-			filename: "input.gif",
-			wantErr:  `unsupported image format ".gif"; supported formats: .jpg, .jpeg, .png, .webp`,
-		},
-	}
+var testPNGBytes = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}
+var testHEICBytes = []byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := detectImageMimeType(tt.filename)
-			if tt.wantErr != "" {
-				require.EqualError(t, err, tt.wantErr)
-				require.Empty(t, got)
-				return
-			}
-
-			require.NoError(t, err)
-			require.Equal(t, tt.wantType, got)
-		})
-	}
-}
-
-func TestConvertImageRequestRejectsUnsupportedMaskFormat(t *testing.T) {
+func TestConvertImageRequestRejectsUnsupportedMaskContent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var body bytes.Buffer
@@ -65,11 +25,11 @@ func TestConvertImageRequestRejectsUnsupportedMaskFormat(t *testing.T) {
 	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
 	imagePart, err := writer.CreateFormFile("image", "input.png")
 	require.NoError(t, err)
-	_, err = imagePart.Write([]byte("fake png"))
+	_, err = imagePart.Write(testPNGBytes)
 	require.NoError(t, err)
-	maskPart, err := writer.CreateFormFile("mask", "mask.heic")
+	maskPart, err := writer.CreateFormFile("mask", "mask.png")
 	require.NoError(t, err)
-	_, err = maskPart.Write([]byte("fake heic"))
+	_, err = maskPart.Write(testHEICBytes)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
@@ -82,18 +42,18 @@ func TestConvertImageRequestRejectsUnsupportedMaskFormat(t *testing.T) {
 	converted, err := (&Adaptor{}).ConvertImageRequest(c, info, dto.ImageRequest{Model: "gpt-image-1"})
 
 	require.Nil(t, converted)
-	require.EqualError(t, err, `unsupported image format ".heic"; supported formats: .jpg, .jpeg, .png, .webp`)
+	require.EqualError(t, err, `unsupported image content type "application/octet-stream"; supported formats: JPEG, PNG, WebP`)
 }
 
-func TestConvertImageRequestRejectsUnsupportedImageFormat(t *testing.T) {
+func TestConvertImageRequestRejectsUnsupportedImageContent(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
 	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
-	part, err := writer.CreateFormFile("image", "input.heic")
+	part, err := writer.CreateFormFile("image", "input.png")
 	require.NoError(t, err)
-	_, err = part.Write([]byte("fake image"))
+	_, err = part.Write(testHEICBytes)
 	require.NoError(t, err)
 	require.NoError(t, writer.Close())
 
@@ -106,5 +66,5 @@ func TestConvertImageRequestRejectsUnsupportedImageFormat(t *testing.T) {
 	converted, err := (&Adaptor{}).ConvertImageRequest(c, info, dto.ImageRequest{Model: "gpt-image-1"})
 
 	require.Nil(t, converted)
-	require.EqualError(t, err, `unsupported image format ".heic"; supported formats: .jpg, .jpeg, .png, .webp`)
+	require.EqualError(t, err, `unsupported image content type "application/octet-stream"; supported formats: JPEG, PNG, WebP`)
 }

--- a/apps/api-go/relay/channel/openai/adaptor_mime_test.go
+++ b/apps/api-go/relay/channel/openai/adaptor_mime_test.go
@@ -57,6 +57,34 @@ func TestDetectImageMimeType(t *testing.T) {
 	}
 }
 
+func TestConvertImageRequestRejectsUnsupportedMaskFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	imagePart, err := writer.CreateFormFile("image", "input.png")
+	require.NoError(t, err)
+	_, err = imagePart.Write([]byte("fake png"))
+	require.NoError(t, err)
+	maskPart, err := writer.CreateFormFile("mask", "mask.heic")
+	require.NoError(t, err)
+	_, err = maskPart.Write([]byte("fake heic"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	require.NoError(t, c.Request.ParseMultipartForm(32<<20))
+
+	info := &relaycommon.RelayInfo{RelayMode: relayconstant.RelayModeImagesEdits}
+	converted, err := (&Adaptor{}).ConvertImageRequest(c, info, dto.ImageRequest{Model: "gpt-image-1"})
+
+	require.Nil(t, converted)
+	require.EqualError(t, err, `unsupported image format ".heic"; supported formats: .jpg, .jpeg, .png, .webp`)
+}
+
 func TestConvertImageRequestRejectsUnsupportedImageFormat(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/apps/api-go/relay/channel/openai/image_edit_test.go
+++ b/apps/api-go/relay/channel/openai/image_edit_test.go
@@ -66,6 +66,7 @@ func TestConvertImageEditRequestMultipart(t *testing.T) {
 		require.Equal(t, "true", replayedRequest.PostForm.Get("stream"))
 		require.Equal(t, "3", replayedRequest.PostForm.Get("partial_images"))
 		require.Len(t, replayedRequest.MultipartForm.File["image"], 1)
+		require.Equal(t, "image/png", replayedRequest.MultipartForm.File["image"][0].Header.Get("Content-Type"))
 
 		file, err := replayedRequest.MultipartForm.File["image"][0].Open()
 		require.NoError(t, err)

--- a/apps/api-go/relay/channel/openai/image_edit_test.go
+++ b/apps/api-go/relay/channel/openai/image_edit_test.go
@@ -32,7 +32,7 @@ func TestConvertImageEditRequestMultipart(t *testing.T) {
 		require.NoError(t, writer.WriteField("partial_images", "3"))
 		part, err := writer.CreateFormFile("image", "input.png")
 		require.NoError(t, err)
-		_, err = part.Write([]byte("fake image"))
+		_, err = part.Write(testPNGBytes)
 		require.NoError(t, err)
 		require.NoError(t, writer.Close())
 
@@ -73,7 +73,7 @@ func TestConvertImageEditRequestMultipart(t *testing.T) {
 		defer file.Close()
 		fileBytes, err := io.ReadAll(file)
 		require.NoError(t, err)
-		require.Equal(t, []byte("fake image"), fileBytes)
+		require.Equal(t, testPNGBytes, fileBytes)
 	}
 
 	t.Run("with pre-parsed form", func(t *testing.T) {

--- a/apps/api-go/relay/common/image_upload.go
+++ b/apps/api-go/relay/common/image_upload.go
@@ -1,0 +1,78 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"sort"
+	"strings"
+)
+
+const imageUploadSignatureLimit = 512
+
+// DetectSupportedImageUploadMediaType identifies an image from a bounded byte
+// prefix. Filenames and client-provided Content-Type values are not trusted.
+func DetectSupportedImageUploadMediaType(fileHeader *multipart.FileHeader) (string, error) {
+	if fileHeader == nil {
+		return "", errors.New("image file is missing")
+	}
+	file, err := fileHeader.Open()
+	if err != nil {
+		return "", fmt.Errorf("open image file: %w", err)
+	}
+	defer file.Close()
+
+	signature := make([]byte, imageUploadSignatureLimit)
+	read, err := io.ReadFull(file, signature)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return "", fmt.Errorf("read image signature: %w", err)
+	}
+	if read == 0 {
+		return "", errors.New("image file is empty")
+	}
+
+	mediaType := http.DetectContentType(signature[:read])
+	switch mediaType {
+	case "image/jpeg", "image/png", "image/webp":
+		return mediaType, nil
+	default:
+		return "", fmt.Errorf("unsupported image content type %q; supported formats: JPEG, PNG, WebP", mediaType)
+	}
+}
+
+// ValidateImageEditMultipartFiles validates every image or mask that the
+// OpenAI-compatible image-edit adaptor can forward.
+func ValidateImageEditMultipartFiles(form *multipart.Form) error {
+	if form == nil {
+		return errors.New("multipart image edit form is missing")
+	}
+
+	imageFiles := append([]*multipart.FileHeader(nil), form.File["image"]...)
+	imageFiles = append(imageFiles, form.File["image[]"]...)
+	imageArrayFields := make([]string, 0)
+	for field := range form.File {
+		if strings.HasPrefix(field, "image[") && field != "image[]" {
+			imageArrayFields = append(imageArrayFields, field)
+		}
+	}
+	sort.Strings(imageArrayFields)
+	for _, field := range imageArrayFields {
+		imageFiles = append(imageFiles, form.File[field]...)
+	}
+	if len(imageFiles) == 0 {
+		return errors.New("image file is required")
+	}
+	for index, fileHeader := range imageFiles {
+		if _, err := DetectSupportedImageUploadMediaType(fileHeader); err != nil {
+			return fmt.Errorf("image file %d: %w", index+1, err)
+		}
+	}
+	for index, fileHeader := range form.File["mask"] {
+		if _, err := DetectSupportedImageUploadMediaType(fileHeader); err != nil {
+			return fmt.Errorf("mask file %d: %w", index+1, err)
+		}
+	}
+	return nil
+}

--- a/apps/api-go/relay/common/image_upload_test.go
+++ b/apps/api-go/relay/common/image_upload_test.go
@@ -1,0 +1,111 @@
+package common
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var imageUploadPNG = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}
+var imageUploadJPEG = []byte{0xff, 0xd8, 0xff, 0xe0, 0, 0x10, 'J', 'F', 'I', 'F'}
+var imageUploadWebP = []byte{'R', 'I', 'F', 'F', 4, 0, 0, 0, 'W', 'E', 'B', 'P', 'V', 'P', '8', ' '}
+var imageUploadHEIC = []byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'}
+
+func imageUploadForm(t *testing.T, files map[string][]struct {
+	name string
+	data []byte
+}) *multipart.Form {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for field, entries := range files {
+		for _, entry := range entries {
+			part, err := writer.CreateFormFile(field, entry.name)
+			require.NoError(t, err)
+			_, err = part.Write(entry.data)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, writer.Close())
+	request := httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+	require.NoError(t, request.ParseMultipartForm(1<<20))
+	t.Cleanup(func() { _ = request.MultipartForm.RemoveAll() })
+	return request.MultipartForm
+}
+
+func TestDetectSupportedImageUploadMediaTypeUsesBytesNotFilename(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		filename  string
+		content   []byte
+		mediaType string
+		wantError string
+	}{
+		{name: "extensionless PNG", filename: "blob", content: imageUploadPNG, mediaType: "image/png"},
+		{name: "JPEG with wrong extension", filename: "image.heic", content: imageUploadJPEG, mediaType: "image/jpeg"},
+		{name: "WebP uppercase", filename: "IMAGE.WEBP", content: imageUploadWebP, mediaType: "image/webp"},
+		{name: "fake PNG", filename: "image.png", content: []byte("not an image"), wantError: "unsupported image content type"},
+		{name: "HEIC named PNG", filename: "image.png", content: imageUploadHEIC, wantError: "unsupported image content type"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			form := imageUploadForm(t, map[string][]struct {
+				name string
+				data []byte
+			}{"image": {{name: test.filename, data: test.content}}})
+			mediaType, err := DetectSupportedImageUploadMediaType(form.File["image"][0])
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				require.Empty(t, mediaType)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.mediaType, mediaType)
+		})
+	}
+}
+
+func TestValidateImageEditMultipartFilesCoversImageArraysAndMask(t *testing.T) {
+	valid := imageUploadForm(t, map[string][]struct {
+		name string
+		data []byte
+	}{
+		"image":   {{name: "blob", data: imageUploadPNG}},
+		"image[]": {{name: "second.bin", data: imageUploadJPEG}},
+		"mask":    {{name: "mask.dat", data: imageUploadWebP}},
+	})
+	require.NoError(t, ValidateImageEditMultipartFiles(valid))
+
+	for _, test := range []struct {
+		name  string
+		files map[string][]struct {
+			name string
+			data []byte
+		}
+		wantError string
+	}{
+		{name: "missing image", files: map[string][]struct {
+			name string
+			data []byte
+		}{"mask": {{name: "mask.png", data: imageUploadPNG}}}, wantError: "image file is required"},
+		{name: "image array HEIC", files: map[string][]struct {
+			name string
+			data []byte
+		}{"image[]": {{name: "blob", data: imageUploadHEIC}}}, wantError: "image file 1"},
+		{name: "mask HEIC", files: map[string][]struct {
+			name string
+			data []byte
+		}{
+			"image": {{name: "image.png", data: imageUploadPNG}},
+			"mask":  {{name: "mask.png", data: imageUploadHEIC}},
+		}, wantError: "mask file 1"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.ErrorContains(t, ValidateImageEditMultipartFiles(imageUploadForm(t, test.files)), test.wantError)
+		})
+	}
+}

--- a/apps/api-go/relay/helper/image_edit_validation.go
+++ b/apps/api-go/relay/helper/image_edit_validation.go
@@ -1,0 +1,52 @@
+package helper
+
+import (
+	"errors"
+	"mime"
+	"net/http"
+	"strings"
+
+	basecommon "github.com/LIghtJUNction/api.lmm.best/common"
+	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/gin-gonic/gin"
+)
+
+const imageEditFilesValidatedKey = "lmm_image_edit_files_validated"
+
+// ValidateOpenAIImageEditMultipart validates files independently of channel
+// selection and pass-through settings. A successful validation is reusable on
+// retries of the same replayable request body.
+func ValidateOpenAIImageEditMultipart(c *gin.Context) *types.NewAPIError {
+	if c == nil || c.Request == nil || c.GetBool(imageEditFilesValidatedKey) {
+		return nil
+	}
+	rawContentType := c.Request.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(rawContentType)
+	if err != nil {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(rawContentType)), "multipart/form-data") {
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		return nil
+	}
+	if mediaType != "multipart/form-data" {
+		return nil
+	}
+
+	form := c.Request.MultipartForm
+	if form == nil {
+		form, err = basecommon.ParseMultipartFormReusable(c)
+		if err != nil {
+			if basecommon.IsRequestBodyTooLargeError(err) || errors.Is(err, basecommon.ErrRequestBodyTooLarge) {
+				return types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusRequestEntityTooLarge, types.ErrOptionWithSkipRetry())
+			}
+			return types.NewErrorWithStatusCode(err, types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+		}
+		c.Request.MultipartForm = form
+	}
+	if err := relaycommon.ValidateImageEditMultipartFiles(form); err != nil {
+		return types.NewErrorWithStatusCode(err, types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
+	}
+	c.Set(imageEditFilesValidatedKey, true)
+	return nil
+}

--- a/apps/api-go/relay/helper/image_edit_validation_test.go
+++ b/apps/api-go/relay/helper/image_edit_validation_test.go
@@ -1,0 +1,85 @@
+package helper
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	basecommon "github.com/LIghtJUNction/api.lmm.best/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/LIghtJUNction/api.lmm.best/setting/model_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func imageValidationContext(t *testing.T, field, filename string, content []byte, validImage bool) *gin.Context {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	if validImage && field != "image" && field != "image[]" {
+		image, err := writer.CreateFormFile("image", "blob")
+		require.NoError(t, err)
+		_, err = image.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0})
+		require.NoError(t, err)
+	}
+	part, err := writer.CreateFormFile(field, filename)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	context.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	t.Cleanup(func() { basecommon.CleanupBodyStorage(context) })
+	return context
+}
+
+func requireInvalidImageAPIError(t *testing.T, err error) {
+	t.Helper()
+	var apiErr *types.NewAPIError
+	require.ErrorAs(t, err, &apiErr)
+	require.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	require.Equal(t, types.ErrorCodeInvalidRequest, apiErr.GetErrorCode())
+	require.True(t, types.IsSkipRetryError(apiErr))
+}
+
+func TestImageEditValidationRejectsEveryForwardedFileFieldBeforeRelay(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	heic := []byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'}
+	originalPassThrough := model_setting.GetGlobalSettings().PassThroughRequestEnabled
+	t.Cleanup(func() { model_setting.GetGlobalSettings().PassThroughRequestEnabled = originalPassThrough })
+
+	for _, passThrough := range []bool{false, true} {
+		model_setting.GetGlobalSettings().PassThroughRequestEnabled = passThrough
+		for _, test := range []struct {
+			field      string
+			validImage bool
+		}{
+			{field: "image"},
+			{field: "image[]"},
+			{field: "mask", validImage: true},
+		} {
+			t.Run(test.field+"/pass-through="+map[bool]string{false: "off", true: "on"}[passThrough], func(t *testing.T) {
+				context := imageValidationContext(t, test.field, "image.png", heic, test.validImage)
+				_, err := GetAndValidOpenAIImageRequest(context, relayconstant.RelayModeImagesEdits)
+				requireInvalidImageAPIError(t, err)
+				require.False(t, context.GetBool(imageEditFilesValidatedKey))
+			})
+		}
+	}
+}
+
+func TestImageEditValidationAcceptsExtensionlessPNGAndCachesSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	context := imageValidationContext(t, "image", "blob", []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0}, false)
+
+	_, err := GetAndValidOpenAIImageRequest(context, relayconstant.RelayModeImagesEdits)
+	require.NoError(t, err)
+	require.True(t, context.GetBool(imageEditFilesValidatedKey))
+	require.Nil(t, ValidateOpenAIImageEditMultipart(context))
+}

--- a/apps/api-go/relay/helper/openai_image_request_test.go
+++ b/apps/api-go/relay/helper/openai_image_request_test.go
@@ -32,7 +32,7 @@ func TestGetAndValidOpenAIImageRequestMultipartStream(t *testing.T) {
 		if withImage {
 			part, err := writer.CreateFormFile("image", "input.png")
 			require.NoError(t, err)
-			_, err = part.Write([]byte("fake image"))
+			_, err = part.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', 0, 0, 0, 0})
 			require.NoError(t, err)
 		}
 		require.NoError(t, writer.Close())

--- a/apps/api-go/relay/helper/valid_request.go
+++ b/apps/api-go/relay/helper/valid_request.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -184,13 +185,16 @@ func GetAndValidOpenAIImageRequest(c *gin.Context, relayMode int) (*dto.ImageReq
 
 	switch relayMode {
 	case relayconstant.RelayModeImagesEdits:
-		if strings.Contains(c.Request.Header.Get("Content-Type"), "multipart/form-data") {
+		if strings.Contains(strings.ToLower(c.Request.Header.Get("Content-Type")), "multipart/form-data") {
 			form, err := common.ParseMultipartFormReusable(c)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse image edit form request: %w", err)
+				if common.IsRequestBodyTooLargeError(err) || errors.Is(err, common.ErrRequestBodyTooLarge) {
+					return nil, types.NewErrorWithStatusCode(err, types.ErrorCodeReadRequestBodyFailed, http.StatusRequestEntityTooLarge, types.ErrOptionWithSkipRetry())
+				}
+				return nil, types.NewErrorWithStatusCode(fmt.Errorf("failed to parse image edit form request: %w", err), types.ErrorCodeInvalidRequest, http.StatusBadRequest, types.ErrOptionWithSkipRetry())
 			}
-			formData := url.Values(form.Value)
 			c.Request.MultipartForm = form
+			formData := url.Values(form.Value)
 			c.Request.PostForm = formData
 			imageRequest.Prompt = formData.Get("prompt")
 			imageRequest.Model = formData.Get("model")
@@ -227,6 +231,9 @@ func GetAndValidOpenAIImageRequest(c *gin.Context, relayMode int) (*dto.ImageReq
 			if hasWatermark {
 				watermark := formData.Get("watermark") == "true"
 				imageRequest.Watermark = &watermark
+			}
+			if validationErr := ValidateOpenAIImageEditMultipart(c); validationErr != nil {
+				return nil, validationErr
 			}
 			break
 		}

--- a/apps/api-go/relay/image_handler.go
+++ b/apps/api-go/relay/image_handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/LIghtJUNction/api.lmm.best/constant"
 	"github.com/LIghtJUNction/api.lmm.best/logger"
 	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
 	"github.com/LIghtJUNction/api.lmm.best/relay/helper"
 	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
 	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
@@ -21,6 +22,11 @@ import (
 )
 
 func ImageHelper(c *gin.Context, info *relaycommon.RelayInfo) (newAPIError *types.NewAPIError) {
+	if info.RelayMode == relayconstant.RelayModeImagesEdits {
+		if validationErr := helper.ValidateOpenAIImageEditMultipart(c); validationErr != nil {
+			return validationErr
+		}
+	}
 	info.InitChannelMeta(c)
 
 	imageReq, ok := info.Request.(*dto.ImageRequest)

--- a/apps/api-go/relay/image_validation_test.go
+++ b/apps/api-go/relay/image_validation_test.go
@@ -1,0 +1,71 @@
+package relay
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	basecommon "github.com/LIghtJUNction/api.lmm.best/common"
+	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/LIghtJUNction/api.lmm.best/setting/model_setting"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func invalidImageEditContext(t *testing.T) *gin.Context {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "gpt-image-1"))
+	part, err := writer.CreateFormFile("image", "image.png")
+	require.NoError(t, err)
+	_, err = part.Write([]byte{0, 0, 0, 0x18, 'f', 't', 'y', 'p', 'h', 'e', 'i', 'c'})
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	context.Request.Header.Set("Content-Type", writer.FormDataContentType())
+	t.Cleanup(func() { basecommon.CleanupBodyStorage(context) })
+	return context
+}
+
+func TestImageHelperCannotBypassValidationWithPassThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	originalPassThrough := model_setting.GetGlobalSettings().PassThroughRequestEnabled
+	t.Cleanup(func() { model_setting.GetGlobalSettings().PassThroughRequestEnabled = originalPassThrough })
+
+	for _, test := range []struct {
+		name           string
+		globalSetting  bool
+		channelSetting bool
+	}{
+		{name: "pass-through off"},
+		{name: "global pass-through", globalSetting: true},
+		{name: "channel pass-through", channelSetting: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			model_setting.GetGlobalSettings().PassThroughRequestEnabled = test.globalSetting
+			context := invalidImageEditContext(t)
+			info := &relaycommon.RelayInfo{
+				RelayMode: relayconstant.RelayModeImagesEdits,
+				Request:   &dto.ImageRequest{Model: "gpt-image-1"},
+				ChannelMeta: &relaycommon.ChannelMeta{
+					ChannelSetting: dto.ChannelSettings{PassThroughBodyEnabled: test.channelSetting},
+				},
+			}
+
+			apiErr := ImageHelper(context, info)
+			require.NotNil(t, apiErr)
+			require.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+			require.Equal(t, types.ErrorCodeInvalidRequest, apiErr.GetErrorCode())
+			require.True(t, types.IsSkipRetryError(apiErr))
+			require.Nil(t, info.Billing, "local validation must not create a billing session")
+			require.Empty(t, context.GetStringSlice("use_channel"), "local validation must not select or contact an upstream")
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- remove the unsafe unknown-extension → `image/png` fallback in OpenAI image edits
- reject HEIC, extensionless, and unknown image/mask names locally before forwarding
- preserve case-insensitive JPEG/JPG/PNG/WebP mappings
- cover both image and mask rejection plus forwarded MIME headers

## Verification
- `go test -p 2 ./relay/channel/openai`
- `git diff --check`

## Follow-up
This is a fail-local safety stopgap only. It does not claim HEIC support and does not trust bytes yet; the central bytes-first full-decode/normalizer work remains required. No production deployment.

## Sourcery 摘要

通过在处理前验证文件名，防止 OpenAI 图像编辑转发不受支持的图像格式。

错误修复：
- 在本地拒绝不受支持、无扩展名以及未知的图像和蒙版文件名，而不是使用错误的 MIME 类型转发它们。

增强功能：
- 保留 JPEG、PNG 和 WebP 图像格式不区分大小写的 MIME 映射。

测试：
- 增加对受支持的大写扩展名、不受支持的格式、图像和蒙版拒绝，以及转发的图像 MIME 标头的覆盖测试。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

根据文件内容验证 OpenAI 图像编辑上传，并在转发请求前在本地拒绝不支持的图像或蒙版格式。

错误修复：
- 在本地拒绝不支持、空、伪造或其他无效的图像和蒙版上传，而不是使用错误的备用 MIME 类型将其转发。
- 防止无效的图像编辑请求进入计费、渠道选择、透传处理或上游服务。

增强功能：
- 根据文件内容检测受支持的 JPEG、PNG 和 WebP 格式，同时保留不区分大小写且不依赖文件名的处理方式。
- 对格式错误或超大的 multipart 图像编辑请求返回结构化、不可重试的无效请求错误，并在请求处理过程中复用成功的验证结果。

测试：
- 增加对基于内容的图像检测、图像数组、蒙版、无扩展名文件、不支持的格式、转发的 MIME 标头以及防止绕过验证的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate OpenAI image-edit uploads from their contents and fail unsupported image or mask formats locally before forwarding requests.

Bug Fixes:
- Reject unsupported, empty, fake, or otherwise invalid image and mask uploads locally instead of forwarding them with an incorrect fallback MIME type.
- Prevent invalid image-edit requests from reaching billing, channel selection, pass-through handling, or upstream services.

Enhancements:
- Detect supported JPEG, PNG, and WebP formats from file contents while preserving case- and filename-independent handling.
- Return structured non-retryable invalid-request errors for malformed or oversized multipart image-edit requests and reuse successful validation across request processing.

Tests:
- Add coverage for content-based image detection, image arrays, masks, extensionless files, unsupported formats, forwarded MIME headers, and validation bypass prevention.

</details>

</details>