### PR TITLE
fix(edge): return structured 451 errors to API clients

### DIFF
--- a/apps/api-go/controller/access_policy_error.go
+++ b/apps/api-go/controller/access_policy_error.go
@@ -3,8 +3,10 @@ package controller
 import (
 	"fmt"
 	"html/template"
+	"mime"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,9 +15,14 @@ import (
 )
 
 const (
-	accessPolicyErrorHeader  = "access-policy"
-	accessPolicyResultHeader = "X-LMM-Access-Policy"
-	accessPolicyDenied       = "denied"
+	accessPolicyErrorHeader          = "access-policy"
+	accessPolicyResultHeader         = "X-LMM-Access-Policy"
+	accessPolicyOriginalURIHeader    = "X-LMM-Original-URI"
+	accessPolicyOriginalAcceptHeader = "X-LMM-Original-Accept"
+	accessPolicyDenied               = "denied"
+	accessPolicyRejectedErrorCode    = "IP_ACCESS_ROUTE_REJECTED"
+	accessPolicyRejectedErrorType    = "access_policy_error"
+	accessPolicyRejectedMessage      = "Request rejected by IP access policy."
 )
 
 // GetAccessPolicyErrorPage renders the edge-policy response through the Go
@@ -30,17 +37,57 @@ func GetAccessPolicyErrorPage(c *gin.Context) {
 		return
 	}
 
+	requestID := accessPolicyRequestID(c)
+	c.Header(common.RequestIdKey, requestID)
+	c.Header("Cache-Control", "private, no-store, max-age=0")
+	c.Header("Pragma", "no-cache")
+	c.Header("Vary", "Accept")
+	c.Header("X-Content-Type-Options", "nosniff")
+	if accessPolicyWantsJSON(c) {
+		c.JSON(http.StatusUnavailableForLegalReasons, gin.H{
+			"error": gin.H{
+				"code":       accessPolicyRejectedErrorCode,
+				"message":    accessPolicyRejectedMessage,
+				"request_id": requestID,
+				"type":       accessPolicyRejectedErrorType,
+			},
+		})
+		return
+	}
+
 	language := "zh"
 	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(c.GetHeader("Accept-Language"))), "en") {
 		language = "en"
 	}
-	requestID := accessPolicyRequestID(c)
-	c.Header(common.RequestIdKey, requestID)
 	page := accessPolicyErrorPage(language, accessPolicyErrorDiagnostics(c, requestID))
-	c.Header("Cache-Control", "private, no-store, max-age=0")
-	c.Header("Pragma", "no-cache")
-	c.Header("X-Content-Type-Options", "nosniff")
 	c.Data(http.StatusUnavailableForLegalReasons, "text/html; charset=utf-8", []byte(page))
+}
+
+func accessPolicyWantsJSON(c *gin.Context) bool {
+	originalURI := strings.TrimSpace(c.GetHeader(accessPolicyOriginalURIHeader))
+	if queryStart := strings.IndexByte(originalURI, '?'); queryStart >= 0 {
+		originalURI = originalURI[:queryStart]
+	}
+	if originalURI == "/v1" || strings.HasPrefix(originalURI, "/v1/") {
+		return true
+	}
+
+	for mediaRange := range strings.SplitSeq(strings.ToLower(c.GetHeader(accessPolicyOriginalAcceptHeader)), ",") {
+		mediaType, parameters, err := mime.ParseMediaType(strings.TrimSpace(mediaRange))
+		if err != nil {
+			continue
+		}
+		if quality, ok := parameters["q"]; ok {
+			parsedQuality, err := strconv.ParseFloat(quality, 64)
+			if err != nil || parsedQuality <= 0 {
+				continue
+			}
+		}
+		if mediaType == "application/json" || mediaType == "text/json" || strings.HasSuffix(mediaType, "+json") {
+			return true
+		}
+	}
+	return false
 }
 
 type accessPolicyErrorDetails struct {

--- a/apps/api-go/controller/access_policy_error.go
+++ b/apps/api-go/controller/access_policy_error.go
@@ -77,7 +77,7 @@ func accessPolicyWantsJSON(c *gin.Context) bool {
 	if queryStart := strings.IndexByte(originalURI, '?'); queryStart >= 0 {
 		originalURI = originalURI[:queryStart]
 	}
-	if originalURI == "/v1" || strings.HasPrefix(originalURI, "/v1/") {
+	if accessPolicyAPIPath(originalURI) {
 		return true
 	}
 
@@ -97,6 +97,30 @@ func accessPolicyWantsJSON(c *gin.Context) bool {
 		}
 	}
 	return false
+}
+
+func accessPolicyAPIPath(path string) bool {
+	for _, prefix := range []string{
+		"/api",
+		"/mcp",
+		"/v1",
+		"/v1beta",
+		"/pg",
+		"/mj",
+		"/suno",
+		"/kling/v1",
+		"/jimeng",
+	} {
+		if path == prefix || strings.HasPrefix(path, prefix+"/") {
+			return true
+		}
+	}
+	if path == "/dashboard/billing/subscription" || path == "/dashboard/billing/usage" {
+		return true
+	}
+
+	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	return len(segments) >= 2 && segments[0] != "" && segments[1] == "mj"
 }
 
 type accessPolicyErrorDetails struct {

--- a/apps/api-go/controller/access_policy_error.go
+++ b/apps/api-go/controller/access_policy_error.go
@@ -41,9 +41,10 @@ func GetAccessPolicyErrorPage(c *gin.Context) {
 	c.Header(common.RequestIdKey, requestID)
 	c.Header("Cache-Control", "private, no-store, max-age=0")
 	c.Header("Pragma", "no-cache")
-	c.Header("Vary", "Accept")
+	c.Header("Vary", "Accept, Origin")
 	c.Header("X-Content-Type-Options", "nosniff")
 	if accessPolicyWantsJSON(c) {
+		applyAccessPolicyJSONCORS(c)
 		c.JSON(http.StatusUnavailableForLegalReasons, gin.H{
 			"error": gin.H{
 				"code":       accessPolicyRejectedErrorCode,
@@ -61,6 +62,14 @@ func GetAccessPolicyErrorPage(c *gin.Context) {
 	}
 	page := accessPolicyErrorPage(language, accessPolicyErrorDiagnostics(c, requestID))
 	c.Data(http.StatusUnavailableForLegalReasons, "text/html; charset=utf-8", []byte(page))
+}
+
+func applyAccessPolicyJSONCORS(c *gin.Context) {
+	if strings.TrimSpace(c.GetHeader("Origin")) == "" {
+		return
+	}
+	c.Header("Access-Control-Allow-Origin", "*")
+	c.Header("Access-Control-Expose-Headers", common.RequestIdKey)
 }
 
 func accessPolicyWantsJSON(c *gin.Context) bool {

--- a/apps/api-go/controller/personal_access_ip_test.go
+++ b/apps/api-go/controller/personal_access_ip_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -151,6 +152,47 @@ func TestAccessPolicyErrorPageRequiresCapturedDenial(t *testing.T) {
 	assert.Contains(t, body, "IPv4")
 	assert.Contains(t, body, "route_reject")
 	assert.NotContains(t, body, "符合条件的账号")
+
+	jsonHeaders := make(map[string]string, len(validHeaders)+4)
+	for name, value := range validHeaders {
+		jsonHeaders[name] = value
+	}
+	jsonHeaders[accessPolicyOriginalURIHeader] = "/v1/models?debug=1"
+	jsonHeaders[accessPolicyOriginalAcceptHeader] = "*/*"
+	jsonHeaders["Authorization"] = "Bearer must-not-leak"
+	jsonHeaders["Cookie"] = "session=must-not-leak"
+	status, response = request("127.0.0.1:42000", jsonHeaders)
+	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
+	assert.Contains(t, response.Header().Get("Content-Type"), "application/json")
+	assert.Less(t, response.Body.Len(), 512)
+	assert.NotContains(t, response.Body.String(), "must-not-leak")
+	assert.NotContains(t, response.Body.String(), "203.0.113.42")
+	var payload struct {
+		Error struct {
+			Code      string `json:"code"`
+			Message   string `json:"message"`
+			RequestID string `json:"request_id"`
+			Type      string `json:"type"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body.Bytes(), &payload))
+	assert.Equal(t, accessPolicyRejectedErrorCode, payload.Error.Code)
+	assert.Equal(t, accessPolicyRejectedMessage, payload.Error.Message)
+	assert.Equal(t, accessPolicyRejectedErrorType, payload.Error.Type)
+	assert.NotEmpty(t, payload.Error.RequestID)
+
+	jsonHeaders[accessPolicyOriginalURIHeader] = "/api/status"
+	jsonHeaders[accessPolicyOriginalAcceptHeader] = "text/plain, application/problem+json; q=0.9"
+	status, response = request("127.0.0.1:42000", jsonHeaders)
+	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
+	assert.Contains(t, response.Header().Get("Content-Type"), "application/json")
+
+	jsonHeaders[accessPolicyOriginalURIHeader] = "/"
+	jsonHeaders[accessPolicyOriginalAcceptHeader] = "application/json; q=0, text/html"
+	status, response = request("127.0.0.1:42000", jsonHeaders)
+	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
+	assert.Contains(t, response.Header().Get("Content-Type"), "text/html")
+	assert.NotContains(t, response.Body.String(), "must-not-leak")
 
 	status, _ = request("127.0.0.1:42000", map[string]string{
 		"X-LMM-Internal-Error": accessPolicyErrorHeader,

--- a/apps/api-go/controller/personal_access_ip_test.go
+++ b/apps/api-go/controller/personal_access_ip_test.go
@@ -21,6 +21,32 @@ func TestLoopbackPeerAcceptsOnlyLoopbackAddresses(t *testing.T) {
 	assert.False(t, loopbackPeer("not-an-address"))
 }
 
+func TestAccessPolicyAPIPathMatchesNginxBackendFamilies(t *testing.T) {
+	for _, path := range []string{
+		"/api/status",
+		"/mcp",
+		"/v1/models",
+		"/v1beta/models/gemini:generateContent",
+		"/pg/chat/completions",
+		"/mj/submit",
+		"/suno/generate",
+		"/kling/v1/videos",
+		"/jimeng/generations",
+		"/dashboard/billing/subscription",
+		"/dashboard/billing/usage",
+		"/openai/mj/image/task",
+	} {
+		t.Run(path, func(t *testing.T) {
+			assert.True(t, accessPolicyAPIPath(path))
+		})
+	}
+	for _, path := range []string{"/", "/pricing", "/v1beta-docs", "/apiary", "/foo/mjpeg"} {
+		t.Run("browser "+path, func(t *testing.T) {
+			assert.False(t, accessPolicyAPIPath(path))
+		})
+	}
+}
+
 func TestPersonalAccessIPCompatibilityEndpointIsRetired(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	context, _ := gin.CreateTestContext(recorder)

--- a/apps/api-go/controller/personal_access_ip_test.go
+++ b/apps/api-go/controller/personal_access_ip_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/LIghtJUNction/api.lmm.best/common"
 	"github.com/LIghtJUNction/api.lmm.best/setting"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -159,11 +160,16 @@ func TestAccessPolicyErrorPageRequiresCapturedDenial(t *testing.T) {
 	}
 	jsonHeaders[accessPolicyOriginalURIHeader] = "/v1/models?debug=1"
 	jsonHeaders[accessPolicyOriginalAcceptHeader] = "*/*"
+	jsonHeaders["Origin"] = "https://sdk.example"
 	jsonHeaders["Authorization"] = "Bearer must-not-leak"
 	jsonHeaders["Cookie"] = "session=must-not-leak"
 	status, response = request("127.0.0.1:42000", jsonHeaders)
 	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
 	assert.Contains(t, response.Header().Get("Content-Type"), "application/json")
+	assert.Equal(t, "*", response.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, response.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, common.RequestIdKey, response.Header().Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "Accept, Origin", response.Header().Get("Vary"))
 	assert.Less(t, response.Body.Len(), 512)
 	assert.NotContains(t, response.Body.String(), "must-not-leak")
 	assert.NotContains(t, response.Body.String(), "203.0.113.42")
@@ -192,6 +198,9 @@ func TestAccessPolicyErrorPageRequiresCapturedDenial(t *testing.T) {
 	status, response = request("127.0.0.1:42000", jsonHeaders)
 	require.Equal(t, http.StatusUnavailableForLegalReasons, status)
 	assert.Contains(t, response.Header().Get("Content-Type"), "text/html")
+	assert.Empty(t, response.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, response.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "Accept, Origin", response.Header().Get("Vary"))
 	assert.NotContains(t, response.Body.String(), "must-not-leak")
 
 	status, _ = request("127.0.0.1:42000", map[string]string{

--- a/apps/api-go/internal/appcli/deploy_edge_policy.go
+++ b/apps/api-go/internal/appcli/deploy_edge_policy.go
@@ -166,6 +166,8 @@ func (runtime *productionRuntime) validateEdgePolicyAssets(assetRoot string) err
 		{name: "nginx/http-map.conf", need: "geoip2 /var/lib/geoip2/DBIP-Country-Lite.mmdb {"},
 		{name: "nginx/new-api.conf", need: "include /etc/nginx/lmm-api-region-policy.conf;"},
 		{name: "nginx/lmm-api-region-policy.conf", need: "auth_request /internal/access-ip-policy;"},
+		{name: "nginx/lmm-api-region-policy.conf", need: "proxy_set_header X-LMM-Original-URI $request_uri;"},
+		{name: "nginx/lmm-api-region-policy.conf", need: "proxy_set_header X-LMM-Original-Accept $http_accept;"},
 	} {
 		content, err := os.ReadFile(filepath.Join(assetRoot, check.name))
 		if err != nil || !strings.Contains(string(content), check.need) {

--- a/apps/api-go/internal/appcli/deploy_edge_policy_test.go
+++ b/apps/api-go/internal/appcli/deploy_edge_policy_test.go
@@ -76,6 +76,8 @@ func TestEdgePolicyInstallBacksUpRemovesLegacyAndRestores(t *testing.T) {
 			candidate += "include /etc/nginx/lmm-api-region-policy.conf;\n"
 		case "region-policy":
 			candidate += "auth_request /internal/access-ip-policy;\n"
+			candidate += "proxy_set_header X-LMM-Original-URI $request_uri;\n"
+			candidate += "proxy_set_header X-LMM-Original-Accept $http_accept;\n"
 		}
 		if err := os.WriteFile(assetPath, []byte(candidate), 0o644); err != nil {
 			t.Fatal(err)

--- a/deploy/check-frontend-split.sh
+++ b/deploy/check-frontend-split.sh
@@ -99,6 +99,10 @@ assert_literal 'auth_request_set $lmm_access_policy_result $upstream_http_x_lmm_
 assert_literal 'X-LMM-CN-Source $lmm_cn_source;' "$region_policy"
 assert_literal 'X-LMM-Access-Policy $lmm_access_policy_result;' "$region_policy"
 assert_literal 'X-LMM-Internal-Error access-policy;' "$region_policy"
+assert_literal 'X-LMM-Original-URI $request_uri;' "$region_policy"
+assert_literal 'X-LMM-Original-Accept $http_accept;' "$region_policy"
+assert_literal 'proxy_set_header Authorization "";' "$region_policy"
+assert_literal 'proxy_set_header Cookie "";' "$region_policy"
 assert_literal 'deploy production edge-policy install|verify' "$repo/apps/api-go/internal/appcli/deploy.go"
 if grep -Fq 'location ^~ /dashboard/' "$config"; then
   fail 'broad /dashboard/ proxy would swallow frontend dashboard routes'

--- a/deploy/nginx/lmm-api-region-policy.conf
+++ b/deploy/nginx/lmm-api-region-policy.conf
@@ -48,5 +48,7 @@ location = /internal/errors/access-policy {
     proxy_set_header X-LMM-CN-Source $lmm_cn_source;
     proxy_set_header X-LMM-Access-Policy $lmm_access_policy_result;
     proxy_set_header X-LMM-Internal-Error access-policy;
+    proxy_set_header X-LMM-Original-URI $request_uri;
+    proxy_set_header X-LMM-Original-Accept $http_accept;
     proxy_intercept_errors off;
 }


### PR DESCRIPTION
## Root cause
Production read-only evidence showed `/v1/models` was rejected by the configured CN IP-routing rule in Nginx `auth_request`, before token/model/channel handlers. API clients consequently received the 4.4 KiB browser HTML page. This change does **not** alter the allowlist or CN policy.

## Changes
- return a small structured JSON 451 for `/v1` paths regardless of `Accept`
- also return JSON for positive JSON media ranges, including `+json`; preserve HTML for browser navigation
- emit stable `IP_ACCESS_ROUTE_REJECTED`, type, message, and request ID
- pass only original URI/Accept classification metadata through the trusted internal Nginx redirect
- keep Authorization and Cookie stripped and prove secrets/diagnostics are not reflected
- make edge asset validation require the new Nginx contract

## Verification
- `go test -p 2 ./controller -count=1`
- `go test -p 2 ./internal/appcli -count=1`
- `bash deploy/check-frontend-split.sh`
- Go LSP clean; `git diff --check` clean

No production mutation or deployment.

## Sourcery 总结

在不更改底层 IP 访问策略的情况下，为被边缘拒绝的 API 请求返回安全、基于内容协商的 451 响应。

新功能：
- 对被边缘 IP 访问策略拒绝的 API 请求返回结构化 JSON 451 响应，其中包含稳定的错误元数据和请求 ID。

错误修复：
- 防止请求在到达应用处理程序之前被阻止时，API 客户端收到面向浏览器的 HTML。
- 在识别正向 JSON 媒体范围（包括 +json 类型）的同时，为浏览器导航保留 HTML 响应。

增强功能：
- 通过受信任的内部边缘策略重定向，仅转发原始 URI 和 Accept 分类元数据。
- 强化边缘策略资源验证，要求满足元数据转发和凭据剥离契约。

测试：
- 增加对 JSON 协商、API 路径处理、HTML 回退、稳定错误字段，以及防止凭据或诊断信息泄露的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在不更改底层访问规则的情况下，为被边缘 IP 访问策略拒绝的请求返回安全且经过内容协商的 451 响应。

新功能：
- 对被边缘 IP 访问策略拒绝的 API 请求返回结构化 JSON 451 响应，并提供稳定的错误元数据。

错误修复：
- 防止请求在到达应用处理程序之前被拒绝时，API 客户端收到面向浏览器的 HTML。
- 在识别包括 +json 类型在内的正向 JSON 媒体范围的同时，为浏览器导航保留 HTML 响应。

增强：
- 通过受信任的边缘错误路径仅转发原始 URI 和 Accept 分类元数据，同时移除凭据和 Cookie。

测试：
- 增加对内容协商、稳定错误字段、CORS 行为、HTML 回退，以及防止凭据或诊断信息泄露的覆盖测试。

维护：
- 强化边缘策略资源验证，要求遵循元数据转发约定并移除凭据。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

对于因边缘 IP 访问策略而被拒绝的请求，返回根据内容协商确定的安全 451 响应，同时不更改底层访问规则。

新功能：
- 为被边缘拒绝的 API 请求返回结构化 JSON 451 响应，其中包含稳定的错误元数据和请求 ID。

错误修复：
- 防止 API 客户端在请求被边缘 IP 访问策略拒绝时收到面向浏览器的 HTML。
- 在识别正向 JSON 媒体范围（包括 +json 类型）的同时，为浏览器导航保留 HTML 响应。

增强：
- 通过受信任的边缘错误路径安全地传递原始 URI 和 Accept 元数据，同时移除凭据和 Cookie。

测试：
- 增加对 API 路径分类、内容协商、稳定错误字段、CORS 行为、HTML 回退，以及防止凭据或诊断信息泄漏的覆盖测试。

杂务：
- 强化边缘策略资源验证，要求遵守元数据转发和凭据移除契约。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Return content-negotiated, secure 451 responses for requests rejected by edge IP access policy without changing the underlying access rules.

New Features:
- Return structured JSON 451 responses with stable error metadata and request IDs for edge-rejected API requests.

Bug Fixes:
- Prevent API clients from receiving browser-oriented HTML when requests are rejected by edge IP access policy.
- Preserve HTML responses for browser navigation while recognizing positive JSON media ranges, including +json types.

Enhancements:
- Safely propagate original URI and Accept metadata through the trusted edge error path while stripping credentials and cookies.

Tests:
- Add coverage for API path classification, content negotiation, stable error fields, CORS behavior, HTML fallback, and protection against credential or diagnostic leakage.

Chores:
- Strengthen edge policy asset validation to require the metadata forwarding and credential removal contract.

</details>

</details>

</details>