### PR TITLE
fix(web): isolate subscription dialog requests

### DIFF
--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
@@ -1,0 +1,384 @@
+/*
+Copyright (C) 2026 LIghtJUNction
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+import type { ReactNode } from 'react'
+
+import type {
+  ApiResponse,
+  PlanRecord,
+  UserSubscriptionRecord,
+} from '../../types'
+
+const domWindow = new Window({
+  url: 'https://console.example.test/admin/users',
+})
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'SVGElement',
+  'Node',
+  'Element',
+  'Event',
+  'MouseEvent',
+  'PointerEvent',
+  'FocusEvent',
+  'CustomEvent',
+  'MutationObserver',
+  'ResizeObserver',
+  'requestAnimationFrame',
+  'cancelAnimationFrame',
+  'getComputedStyle',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { createInstance } = await import('i18next')
+const { I18nextProvider, initReactI18next } = await import('react-i18next')
+const { toast } = await import('sonner')
+const { api } = await import('@/lib/api')
+const { UserSubscriptionsDialog } = await import('./user-subscriptions-dialog')
+
+const originalGet = api.get
+const originalToastError = toast.error
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+const i18n = createInstance()
+await i18n.use(initReactI18next).init({
+  lng: 'en',
+  resources: { en: { translation: {} } },
+})
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T | PromiseLike<T>) => void
+  reject: (reason?: unknown) => void
+}
+
+type PendingRequest = {
+  url: string
+  response: Deferred<unknown>
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve']
+  let reject!: Deferred<T>['reject']
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function installDeferredTransport(requests: PendingRequest[]) {
+  let requestIndex = 0
+  api.get = (async (url: string) => {
+    const request = requests[requestIndex++]
+    assert.ok(request, `Unexpected GET request: ${url}`)
+    assert.equal(url, request.url)
+    return { data: await request.response.promise }
+  }) as typeof api.get
+}
+
+function plansResponse(
+  id: number,
+  title: string
+): ApiResponse<PlanRecord[]> {
+  return {
+    success: true,
+    data: [
+      {
+        plan: { id, title } as PlanRecord['plan'],
+      },
+    ],
+  }
+}
+
+function subscriptionsResponse(
+  id: number,
+  userId: number,
+  planId: number
+): ApiResponse<UserSubscriptionRecord[]> {
+  return {
+    success: true,
+    data: [
+      {
+        subscription: {
+          id,
+          user_id: userId,
+          plan_id: planId,
+          status: 'active',
+          source: 'test',
+          start_time: 1,
+          end_time: 4_000_000_000,
+          amount_total: 100,
+          amount_used: 0,
+        },
+      },
+    ],
+  }
+}
+
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function dialogElement(
+  open: boolean,
+  user: { id: number; username?: string } | null
+) {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <UserSubscriptionsDialog
+        open={open}
+        user={user}
+        onOpenChange={() => undefined}
+      />
+    </I18nextProvider>
+  )
+}
+
+async function renderDialog(
+  open: boolean,
+  user: { id: number; username?: string } | null
+) {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(dialogElement(open, user))
+    await flush()
+  })
+  return { container, root }
+}
+
+async function rerenderDialog(
+  root: ReturnType<typeof createRoot>,
+  open: boolean,
+  user: { id: number; username?: string } | null
+) {
+  await act(async () => {
+    root.render(dialogElement(open, user))
+    await flush()
+  })
+}
+
+async function unmountDialog(
+  rendered: Awaited<ReturnType<typeof renderDialog>>
+) {
+  await act(async () => rendered.root.unmount())
+  rendered.container.remove()
+}
+
+function dialogText() {
+  return document.body.textContent ?? ''
+}
+
+afterEach(() => {
+  api.get = originalGet
+  toast.error = originalToastError
+  document.body.replaceChildren()
+})
+
+after(() => domWindow.close())
+
+describe('UserSubscriptionsDialog request isolation', () => {
+  test('keeps the latest user when the earlier load resolves last', async () => {
+    const plansA = deferred<ApiResponse<PlanRecord[]>>()
+    const subsA = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const plansB = deferred<ApiResponse<PlanRecord[]>>()
+    const subsB = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansA,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: subsA,
+      },
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansB,
+      },
+      {
+        url: '/api/subscription/admin/users/2/subscriptions',
+        response: subsB,
+      },
+    ])
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await rerenderDialog(rendered.root, true, { id: 2, username: 'B' })
+
+      await act(async () => {
+        plansB.resolve(plansResponse(20, 'B plan'))
+        subsB.resolve(subscriptionsResponse(202, 2, 20))
+        await flush()
+      })
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /A plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+      assert.doesNotMatch(dialogText(), /Loading\.\.\./)
+
+      await act(async () => {
+        plansA.resolve(plansResponse(10, 'A plan'))
+        subsA.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /A plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('ignores a stale partial failure, error, and finally state', async () => {
+    const plansA = deferred<ApiResponse<PlanRecord[]>>()
+    const subsA = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const plansB = deferred<ApiResponse<PlanRecord[]>>()
+    const subsB = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansA,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: subsA,
+      },
+      {
+        url: '/api/subscription/admin/plans',
+        response: plansB,
+      },
+      {
+        url: '/api/subscription/admin/users/2/subscriptions',
+        response: subsB,
+      },
+    ])
+    const errors: string[] = []
+    toast.error = ((message: unknown) => {
+      errors.push(String(message))
+      return 1
+    }) as typeof toast.error
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await rerenderDialog(rendered.root, true, { id: 2, username: 'B' })
+
+      await act(async () => {
+        plansA.reject(new Error('A plans failed'))
+        await flush()
+      })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.deepEqual(errors, [])
+
+      await act(async () => {
+        subsA.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.deepEqual(errors, [])
+
+      await act(async () => {
+        plansB.resolve(plansResponse(20, 'B plan'))
+        subsB.resolve(subscriptionsResponse(202, 2, 20))
+        await flush()
+      })
+      assert.doesNotMatch(dialogText(), /Loading\.\.\./)
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
+      assert.deepEqual(errors, [])
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('invalidates responses from a closed dialog before reopening it', async () => {
+    const oldPlans = deferred<ApiResponse<PlanRecord[]>>()
+    const oldSubs = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const reopenedPlans = deferred<ApiResponse<PlanRecord[]>>()
+    const reopenedSubs = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      {
+        url: '/api/subscription/admin/plans',
+        response: oldPlans,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: oldSubs,
+      },
+      {
+        url: '/api/subscription/admin/plans',
+        response: reopenedPlans,
+      },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: reopenedSubs,
+      },
+    ])
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await rerenderDialog(rendered.root, false, { id: 1, username: 'A' })
+      await rerenderDialog(rendered.root, true, {
+        id: 1,
+        username: 'A reopened',
+      })
+
+      await act(async () => {
+        reopenedPlans.resolve(plansResponse(20, 'Reopened plan'))
+        reopenedSubs.resolve(subscriptionsResponse(202, 1, 20))
+        await flush()
+      })
+      assert.match(dialogText(), /Reopened plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /Old plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+
+      await act(async () => {
+        oldPlans.resolve(plansResponse(10, 'Old plan'))
+        oldSubs.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /Reopened plan/)
+      assert.match(dialogText(), /202/)
+      assert.doesNotMatch(dialogText(), /Old plan/)
+      assert.doesNotMatch(dialogText(), /101/)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+})

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
@@ -20,7 +20,6 @@ import assert from 'node:assert/strict'
 import { after, afterEach, describe, test } from 'node:test'
 
 import { Window } from 'happy-dom'
-import type { ReactNode } from 'react'
 
 import type {
   ApiResponse,
@@ -239,6 +238,8 @@ describe('UserSubscriptionsDialog request isolation', () => {
     const rendered = await renderDialog(true, { id: 1, username: 'A' })
     try {
       await rerenderDialog(rendered.root, true, { id: 2, username: 'B' })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.doesNotMatch(dialogText(), /101/)
 
       await act(async () => {
         plansB.resolve(plansResponse(20, 'B plan'))

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
@@ -65,7 +65,10 @@ const { api } = await import('@/lib/api')
 const { UserSubscriptionsDialog } = await import('./user-subscriptions-dialog')
 
 const originalGet = api.get
+const originalPost = api.post
+const originalDelete = api.delete
 const originalToastError = toast.error
+const originalToastSuccess = toast.success
 const reactTestGlobals = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean
 }
@@ -150,7 +153,8 @@ async function flush() {
 
 function dialogElement(
   open: boolean,
-  user: { id: number; username?: string } | null
+  user: { id: number; username?: string } | null,
+  onSuccess?: () => void
 ) {
   return (
     <I18nextProvider i18n={i18n}>
@@ -158,6 +162,7 @@ function dialogElement(
         open={open}
         user={user}
         onOpenChange={() => undefined}
+        onSuccess={onSuccess}
       />
     </I18nextProvider>
   )
@@ -165,13 +170,14 @@ function dialogElement(
 
 async function renderDialog(
   open: boolean,
-  user: { id: number; username?: string } | null
+  user: { id: number; username?: string } | null,
+  onSuccess?: () => void
 ) {
   const container = document.createElement('div')
   document.body.append(container)
   const root = createRoot(container)
   await act(async () => {
-    root.render(dialogElement(open, user))
+    root.render(dialogElement(open, user, onSuccess))
     await flush()
   })
   return { container, root }
@@ -180,10 +186,11 @@ async function renderDialog(
 async function rerenderDialog(
   root: ReturnType<typeof createRoot>,
   open: boolean,
-  user: { id: number; username?: string } | null
+  user: { id: number; username?: string } | null,
+  onSuccess?: () => void
 ) {
   await act(async () => {
-    root.render(dialogElement(open, user))
+    root.render(dialogElement(open, user, onSuccess))
     await flush()
   })
 }
@@ -199,9 +206,81 @@ function dialogText() {
   return document.body.textContent ?? ''
 }
 
+function installImmediateReads() {
+  const requests: string[] = []
+  api.get = (async (url: string) => {
+    requests.push(url)
+    if (url === '/api/subscription/admin/plans') {
+      return { data: plansResponse(11, 'Plan') }
+    }
+    const userMatch = url.match(
+      /^\/api\/subscription\/admin\/users\/(\d+)\/subscriptions$/
+    )
+    assert.ok(userMatch, `Unexpected GET request: ${url}`)
+    const userId = Number(userMatch[1])
+    return {
+      data: subscriptionsResponse(userId * 111, userId, 11),
+    }
+  }) as typeof api.get
+  return requests
+}
+
+async function clickElement(element: Element | undefined | null) {
+  assert.ok(element instanceof HTMLElement, 'interactive element was not found')
+  await act(async () => {
+    element.click()
+    await flush()
+  })
+}
+
+function elementWithText(selector: string, text: string) {
+  return [...document.querySelectorAll(selector)].find(
+    (element) => element.textContent?.trim() === text
+  )
+}
+
+async function selectFirstPlan() {
+  await clickElement(document.querySelector('[role="combobox"]'))
+  await clickElement(document.querySelector('[role="option"]'))
+}
+
+async function chooseRowAction(label: string) {
+  await clickElement(document.querySelector('button[aria-label="Actions"]'))
+  await clickElement(elementWithText('[role="menuitem"]', label))
+}
+
+async function confirmDialogAction(label: string) {
+  await clickElement(elementWithText('button', label))
+}
+
+function captureMutationEffects() {
+  const successes: unknown[] = []
+  const errors: unknown[] = []
+  let onSuccessCalls = 0
+  toast.success = ((message: unknown) => {
+    successes.push(message)
+    return 'success-toast'
+  }) as typeof toast.success
+  toast.error = ((message: unknown) => {
+    errors.push(message)
+    return 'error-toast'
+  }) as typeof toast.error
+  return {
+    successes,
+    errors,
+    onSuccess: () => {
+      onSuccessCalls += 1
+    },
+    onSuccessCalls: () => onSuccessCalls,
+  }
+}
+
 afterEach(() => {
   api.get = originalGet
+  api.post = originalPost
+  api.delete = originalDelete
   toast.error = originalToastError
+  toast.success = originalToastSuccess
   document.body.replaceChildren()
 })
 
@@ -258,6 +337,50 @@ describe('UserSubscriptionsDialog request isolation', () => {
       assert.match(dialogText(), /202/)
       assert.doesNotMatch(dialogText(), /A plan/)
       assert.doesNotMatch(dialogText(), /101/)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('clears a rendered previous-user row immediately on switch', async () => {
+    const plansA = deferred<ApiResponse<PlanRecord[]>>()
+    const subsA = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    const plansB = deferred<ApiResponse<PlanRecord[]>>()
+    const subsB = deferred<ApiResponse<UserSubscriptionRecord[]>>()
+    installDeferredTransport([
+      { url: '/api/subscription/admin/plans', response: plansA },
+      {
+        url: '/api/subscription/admin/users/1/subscriptions',
+        response: subsA,
+      },
+      { url: '/api/subscription/admin/plans', response: plansB },
+      {
+        url: '/api/subscription/admin/users/2/subscriptions',
+        response: subsB,
+      },
+    ])
+
+    const rendered = await renderDialog(true, { id: 1, username: 'A' })
+    try {
+      await act(async () => {
+        plansA.resolve(plansResponse(10, 'A plan'))
+        subsA.resolve(subscriptionsResponse(101, 1, 10))
+        await flush()
+      })
+      assert.match(dialogText(), /A plan/)
+      assert.match(dialogText(), /101/)
+
+      await rerenderDialog(rendered.root, true, { id: 2, username: 'B' })
+      assert.match(dialogText(), /Loading\.\.\./)
+      assert.doesNotMatch(dialogText(), /101/)
+
+      await act(async () => {
+        plansB.resolve(plansResponse(20, 'B plan'))
+        subsB.resolve(subscriptionsResponse(202, 2, 20))
+        await flush()
+      })
+      assert.match(dialogText(), /B plan/)
+      assert.match(dialogText(), /202/)
     } finally {
       await unmountDialog(rendered)
     }
@@ -322,6 +445,178 @@ describe('UserSubscriptionsDialog request isolation', () => {
     } finally {
       await unmountDialog(rendered)
     }
+  })
+
+  test('does not revive the previous user after a deferred create completes', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let postCalls = 0
+    api.post = (async (url: string) => {
+      postCalls += 1
+      assert.equal(url, '/api/subscription/admin/users/1/subscriptions')
+      return mutation.promise
+    }) as typeof api.post
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+    try {
+      assert.match(dialogText(), /111/)
+      await selectFirstPlan()
+      await clickElement(elementWithText('button', 'Add subscription'))
+      assert.equal(postCalls, 1)
+
+      await rerenderDialog(
+        rendered.root,
+        true,
+        { id: 2, username: 'B' },
+        effects.onSuccess
+      )
+      assert.match(dialogText(), /222/)
+      assert.doesNotMatch(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+
+      await act(async () => {
+        mutation.resolve({
+          data: { success: true, data: { message: 'created A' } },
+        })
+        await flush()
+      })
+      assert.match(dialogText(), /222/)
+      assert.doesNotMatch(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+      assert.deepEqual(effects.successes, [])
+      assert.deepEqual(effects.errors, [])
+      assert.equal(effects.onSuccessCalls(), 0)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('suppresses a deferred invalidate completion after close', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let postCalls = 0
+    api.post = (async (url: string) => {
+      postCalls += 1
+      assert.equal(
+        url,
+        '/api/subscription/admin/user_subscriptions/111/invalidate'
+      )
+      return mutation.promise
+    }) as typeof api.post
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+    try {
+      await chooseRowAction('Invalidate')
+      await confirmDialogAction('Continue')
+      assert.equal(postCalls, 1)
+
+      await rerenderDialog(
+        rendered.root,
+        false,
+        { id: 1, username: 'A' },
+        effects.onSuccess
+      )
+      await act(async () => {
+        mutation.reject(new Error('stale invalidate failed'))
+        await flush()
+      })
+      assert.equal(requests.length, 2)
+      assert.deepEqual(effects.successes, [])
+      assert.deepEqual(effects.errors, [])
+      assert.equal(effects.onSuccessCalls(), 0)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('does not let a deferred delete affect the same user after reopen', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let deleteCalls = 0
+    api.delete = (async (url: string) => {
+      deleteCalls += 1
+      assert.equal(url, '/api/subscription/admin/user_subscriptions/111')
+      return mutation.promise
+    }) as typeof api.delete
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+    try {
+      await chooseRowAction('Delete')
+      await confirmDialogAction('Continue')
+      assert.equal(deleteCalls, 1)
+
+      await rerenderDialog(
+        rendered.root,
+        false,
+        { id: 1, username: 'A' },
+        effects.onSuccess
+      )
+      await rerenderDialog(
+        rendered.root,
+        true,
+        { id: 1, username: 'A reopened' },
+        effects.onSuccess
+      )
+      assert.match(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+
+      await act(async () => {
+        mutation.resolve({ data: { success: true } })
+        await flush()
+      })
+      assert.match(dialogText(), /111/)
+      assert.equal(requests.length, 4)
+      assert.deepEqual(effects.successes, [])
+      assert.deepEqual(effects.errors, [])
+      assert.equal(effects.onSuccessCalls(), 0)
+    } finally {
+      await unmountDialog(rendered)
+    }
+  })
+
+  test('suppresses a deferred reset completion after unmount', async () => {
+    const requests = installImmediateReads()
+    const mutation = deferred<unknown>()
+    let postCalls = 0
+    api.post = (async (url: string) => {
+      postCalls += 1
+      assert.equal(url, '/api/subscription/admin/users/1/subscriptions/reset')
+      return mutation.promise
+    }) as typeof api.post
+    const effects = captureMutationEffects()
+    const rendered = await renderDialog(
+      true,
+      { id: 1, username: 'A' },
+      effects.onSuccess
+    )
+
+    await chooseRowAction('Reset quota')
+    await confirmDialogAction('Reset quota')
+    assert.equal(postCalls, 1)
+    await unmountDialog(rendered)
+    await act(async () => {
+      mutation.resolve({
+        data: { success: true, data: { reset_count: 1 } },
+      })
+      await flush()
+    })
+    assert.equal(requests.length, 2)
+    assert.deepEqual(effects.successes, [])
+    assert.deepEqual(effects.errors, [])
+    assert.equal(effects.onSuccessCalls(), 0)
+    assert.equal(dialogText(), '')
   })
 
   test('invalidates responses from a closed dialog before reopening it', async () => {

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.test.tsx
@@ -85,7 +85,7 @@ type Deferred<T> = {
 
 type PendingRequest = {
   url: string
-  response: Deferred<unknown>
+  response: { promise: Promise<unknown> }
 }
 
 function deferred<T>(): Deferred<T> {
@@ -108,10 +108,7 @@ function installDeferredTransport(requests: PendingRequest[]) {
   }) as typeof api.get
 }
 
-function plansResponse(
-  id: number,
-  title: string
-): ApiResponse<PlanRecord[]> {
+function plansResponse(id: number, title: string): ApiResponse<PlanRecord[]> {
   return {
     success: true,
     data: [

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
@@ -17,7 +17,14 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Ban, Plus, RotateCcw, Trash2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -75,6 +82,20 @@ interface Props {
   onSuccess?: () => void
 }
 
+type DialogRequestScope = Readonly<{
+  open: boolean
+  userId: number | null
+  epoch: number
+  mounted: boolean
+}>
+
+type ActiveDialogRequestScope = DialogRequestScope &
+  Readonly<{
+    open: true
+    userId: number
+    mounted: true
+  }>
+
 function SubscriptionStatusBadge(props: {
   sub: UserSubscriptionRecord['subscription']
   t: (key: string) => string
@@ -112,7 +133,8 @@ function SubscriptionStatusBadge(props: {
 
 export function UserSubscriptionsDialog(props: Props) {
   const { t } = useTranslation()
-  const [loading, setLoading] = useState(false)
+  const userId = props.user?.id ?? null
+  const [loading, setLoading] = useState(props.open && userId !== null)
   const [creating, setCreating] = useState(false)
   const [plans, setPlans] = useState<PlanRecord[]>([])
   const [subs, setSubs] = useState<UserSubscriptionRecord[]>([])
@@ -128,6 +150,68 @@ export function UserSubscriptionsDialog(props: Props) {
     subId: number
   } | null>(null)
   const requestGenerationRef = useRef(0)
+  const currentScopeRef = useRef<DialogRequestScope>({
+    open: props.open,
+    userId,
+    epoch: 0,
+    mounted: true,
+  })
+
+  useLayoutEffect(() => {
+    const currentScope = currentScopeRef.current
+    if (!currentScope.mounted) {
+      currentScopeRef.current = {
+        ...currentScope,
+        epoch: currentScope.epoch + 1,
+        mounted: true,
+      }
+    }
+
+    return () => {
+      const scopeAtUnmount = currentScopeRef.current
+      currentScopeRef.current = {
+        ...scopeAtUnmount,
+        epoch: scopeAtUnmount.epoch + 1,
+        mounted: false,
+      }
+    }
+  }, [])
+
+  useLayoutEffect(() => {
+    const currentScope = currentScopeRef.current
+    if (currentScope.open !== props.open || currentScope.userId !== userId) {
+      currentScopeRef.current = {
+        open: props.open,
+        userId,
+        epoch: currentScope.epoch + 1,
+        mounted: currentScope.mounted,
+      }
+      requestGenerationRef.current += 1
+      setSubs([])
+      setSelectedPlanId('')
+      setCreating(false)
+      setResetting(false)
+      setConfirmAction(null)
+      setResetAction(null)
+      setLoading(props.open && userId !== null)
+    }
+  }, [props.open, userId])
+
+  const isCurrentOpenScope = useCallback(
+    (scope: DialogRequestScope): scope is ActiveDialogRequestScope => {
+      const currentScope = currentScopeRef.current
+      return (
+        scope.mounted &&
+        scope.open &&
+        scope.userId !== null &&
+        currentScope.mounted &&
+        currentScope.open &&
+        currentScope.userId === scope.userId &&
+        currentScope.epoch === scope.epoch
+      )
+    },
+    []
+  )
 
   const planTitleMap = useMemo(() => {
     const map = new Map<number, string>()
@@ -137,117 +221,131 @@ export function UserSubscriptionsDialog(props: Props) {
     return map
   }, [plans])
 
-  const loadData = useCallback(async () => {
-    const userId = props.user?.id
-    if (!props.open || !userId) return
+  const loadData = useCallback(
+    async (scope: DialogRequestScope) => {
+      if (!isCurrentOpenScope(scope) || scope.userId === null) return
 
-    const requestGeneration = ++requestGenerationRef.current
-    const isLatestRequest = () =>
-      requestGenerationRef.current === requestGeneration
+      const requestGeneration = ++requestGenerationRef.current
+      const isCurrentRequest = () =>
+        requestGenerationRef.current === requestGeneration &&
+        isCurrentOpenScope(scope)
 
-    setLoading(true)
-    try {
-      const [plansRes, subsRes] = await Promise.all([
-        getAdminPlans(),
-        getUserSubscriptions(userId),
-      ])
-      if (!isLatestRequest()) return
-      if (plansRes.success) setPlans(plansRes.data || [])
-      if (subsRes.success) setSubs(subsRes.data || [])
-    } catch {
-      if (isLatestRequest()) toast.error(t('Loading failed'))
-    } finally {
-      if (isLatestRequest()) setLoading(false)
-    }
-  }, [props.open, props.user?.id, t])
+      setLoading(true)
+      try {
+        const [plansRes, subsRes] = await Promise.all([
+          getAdminPlans(),
+          getUserSubscriptions(scope.userId),
+        ])
+        if (!isCurrentRequest()) return
+        if (plansRes.success) setPlans(plansRes.data || [])
+        if (subsRes.success) setSubs(subsRes.data || [])
+      } catch {
+        if (isCurrentRequest()) toast.error(t('Loading failed'))
+      } finally {
+        if (isCurrentRequest()) setLoading(false)
+      }
+    },
+    [isCurrentOpenScope, t]
+  )
 
   useEffect(() => {
-    if (!props.open || !props.user?.id) {
-      requestGenerationRef.current += 1
-      setSubs([])
-      setLoading(false)
-      return
-    }
+    const scope = currentScopeRef.current
+    requestGenerationRef.current += 1
+    if (!isCurrentOpenScope(scope)) return
 
-    setSubs([])
-    setSelectedPlanId('')
-    void loadData()
+    void loadData(scope)
 
     return () => {
       requestGenerationRef.current += 1
     }
-  }, [props.open, props.user?.id, loadData])
+  }, [props.open, userId, isCurrentOpenScope, loadData])
 
   const handleCreate = async () => {
-    if (!props.user?.id || !selectedPlanId) {
-      toast.error(t('Please select a subscription plan'))
+    const scope = currentScopeRef.current
+    if (!isCurrentOpenScope(scope) || !selectedPlanId) {
+      if (isCurrentOpenScope(scope)) {
+        toast.error(t('Please select a subscription plan'))
+      }
       return
     }
+
     setCreating(true)
     try {
-      const res = await createUserSubscription(props.user.id, {
+      const res = await createUserSubscription(scope.userId, {
         plan_id: Number(selectedPlanId),
       })
+      if (!isCurrentOpenScope(scope)) return
       if (res.success) {
         toast.success(res.data?.message || t('Added successfully'))
         setSelectedPlanId('')
-        await loadData()
-        props.onSuccess?.()
+        await loadData(scope)
+        if (isCurrentOpenScope(scope)) props.onSuccess?.()
       }
     } catch {
-      toast.error(t('Request failed'))
+      if (isCurrentOpenScope(scope)) toast.error(t('Request failed'))
     } finally {
-      setCreating(false)
+      if (isCurrentOpenScope(scope)) setCreating(false)
     }
   }
 
   const handleConfirmAction = async () => {
-    if (!confirmAction) return
+    const scope = currentScopeRef.current
+    const action = confirmAction
+    if (!isCurrentOpenScope(scope) || !action) return
+
     try {
-      if (confirmAction.type === 'invalidate') {
-        const res = await invalidateUserSubscription(confirmAction.subId)
+      if (action.type === 'invalidate') {
+        const res = await invalidateUserSubscription(action.subId)
+        if (!isCurrentOpenScope(scope)) return
         if (res.success) {
           toast.success(res.data?.message || t('Has been invalidated'))
-          await loadData()
-          props.onSuccess?.()
+          await loadData(scope)
+          if (isCurrentOpenScope(scope)) props.onSuccess?.()
         }
       } else {
-        const res = await deleteUserSubscription(confirmAction.subId)
+        const res = await deleteUserSubscription(action.subId)
+        if (!isCurrentOpenScope(scope)) return
         if (res.success) {
           toast.success(t('Deleted'))
-          await loadData()
-          props.onSuccess?.()
+          await loadData(scope)
+          if (isCurrentOpenScope(scope)) props.onSuccess?.()
         }
       }
     } catch {
-      toast.error(t('Operation failed'))
+      if (isCurrentOpenScope(scope)) toast.error(t('Operation failed'))
     } finally {
-      setConfirmAction(null)
+      if (isCurrentOpenScope(scope)) setConfirmAction(null)
     }
   }
 
   const handleResetConfirm = async () => {
-    if (!props.user?.id || !resetAction) return
+    const scope = currentScopeRef.current
+    const action = resetAction
+    if (!isCurrentOpenScope(scope) || !action) return
+
     setResetting(true)
     try {
-      const res = await resetUserSubscriptionsByPlan(props.user.id, {
-        plan_id: resetAction.planId,
+      const res = await resetUserSubscriptionsByPlan(scope.userId, {
+        plan_id: action.planId,
         advance_reset_time: advanceResetTime,
       })
+      if (!isCurrentOpenScope(scope)) return
       if (res.success) {
         toast.success(
           t('Reset {{count}} active subscriptions', {
             count: res.data?.reset_count || 0,
           })
         )
-        await loadData()
-        props.onSuccess?.()
+        await loadData(scope)
+        if (isCurrentOpenScope(scope)) props.onSuccess?.()
       }
     } catch {
-      toast.error(t('Operation failed'))
+      if (isCurrentOpenScope(scope)) toast.error(t('Operation failed'))
     } finally {
-      setResetting(false)
-      setResetAction(null)
+      if (isCurrentOpenScope(scope)) {
+        setResetting(false)
+        setResetAction(null)
+      }
     }
   }
 

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
@@ -164,9 +164,12 @@ export function UserSubscriptionsDialog(props: Props) {
   useEffect(() => {
     if (!props.open || !props.user?.id) {
       requestGenerationRef.current += 1
+      setSubs([])
+      setLoading(false)
       return
     }
 
+    setSubs([])
     setSelectedPlanId('')
     void loadData()
 

--- a/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
+++ b/apps/web/src/features/subscriptions/components/dialogs/user-subscriptions-dialog.tsx
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Ban, Plus, RotateCcw, Trash2 } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -127,6 +127,7 @@ export function UserSubscriptionsDialog(props: Props) {
     type: 'invalidate' | 'delete'
     subId: number
   } | null>(null)
+  const requestGenerationRef = useRef(0)
 
   const planTitleMap = useMemo(() => {
     const map = new Map<number, string>()
@@ -137,26 +138,40 @@ export function UserSubscriptionsDialog(props: Props) {
   }, [plans])
 
   const loadData = useCallback(async () => {
-    if (!props.user?.id) return
+    const userId = props.user?.id
+    if (!props.open || !userId) return
+
+    const requestGeneration = ++requestGenerationRef.current
+    const isLatestRequest = () =>
+      requestGenerationRef.current === requestGeneration
+
     setLoading(true)
     try {
       const [plansRes, subsRes] = await Promise.all([
         getAdminPlans(),
-        getUserSubscriptions(props.user.id),
+        getUserSubscriptions(userId),
       ])
+      if (!isLatestRequest()) return
       if (plansRes.success) setPlans(plansRes.data || [])
       if (subsRes.success) setSubs(subsRes.data || [])
     } catch {
-      toast.error(t('Loading failed'))
+      if (isLatestRequest()) toast.error(t('Loading failed'))
     } finally {
-      setLoading(false)
+      if (isLatestRequest()) setLoading(false)
     }
-  }, [props.user?.id, t])
+  }, [props.open, props.user?.id, t])
 
   useEffect(() => {
-    if (props.open && props.user?.id) {
-      setSelectedPlanId('')
-      loadData()
+    if (!props.open || !props.user?.id) {
+      requestGenerationRef.current += 1
+      return
+    }
+
+    setSelectedPlanId('')
+    void loadData()
+
+    return () => {
+      requestGenerationRef.current += 1
     }
   }, [props.open, props.user?.id, loadData])
 


### PR DESCRIPTION
## Summary
- invalidate in-flight subscription/plan requests when the dialog closes or switches users
- apply data, errors, and loading completion only for the current open user
- clear the prior user’s rows immediately during close/switch
- cover late A/active B, stale partial failure/finally, and close→reopen races

## Independent verification
- focused race tests: 3/3 pass
- full serial Web suite: 168 files pass
- `bun run typecheck`: pass
- full `bun run format:check`: pass
- touched-file Oxlint: clean
- full Oxlint: exit 0; existing unrelated warnings only
- TypeScript LSP and `git diff --check`: clean

No production deployment.

## Sourcery 总结

隔离用户订阅对话框请求，确保只有当前处于打开状态的用户才能更新其数据和请求状态。

错误修复：
- 防止用户切换、对话框关闭或重新打开后，过期的订阅和套餐请求更新对话框。
- 在对话框切换期间清除上一位用户的订阅行，并抑制过期的错误和加载状态变化。

测试：
- 增加对延迟响应、过期的部分失败以及关闭并重新打开流程的竞态条件覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

防止过时的订阅对话框请求更新当前活跃用户或对话框状态。

错误修复：
- 隔离订阅对话框数据和变更请求，确保过时的响应、错误、加载状态和完成事件不会影响已关闭、重新打开或其他用户的对话框。
- 在关闭对话框或切换用户时，立即清除前一位用户的订阅行和对话框状态。

测试：
- 增加对延迟用户切换、过时的部分失败、关闭并重新打开流程以及延迟订阅变更的竞态条件测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent stale subscription dialog requests from updating the currently active user or dialog state.

Bug Fixes:
- Isolate subscription dialog data and mutation requests so stale responses, errors, loading states, and completions cannot affect a closed, reopened, or different user’s dialog.
- Clear the previous user’s subscription rows and dialog state immediately when closing or switching users.

Tests:
- Add race-condition coverage for delayed user switches, stale partial failures, close-and-reopen flows, and deferred subscription mutations.

</details>

</details>