### PR TITLE
fix(web): validate user quota adjustments

### DIFF
--- a/apps/web/src/features/users/components/user-quota-dialog.test.tsx
+++ b/apps/web/src/features/users/components/user-quota-dialog.test.tsx
@@ -1,0 +1,253 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+
+const domWindow = new Window({ url: 'https://console.example.test/admin/users' })
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'HTMLInputElement',
+  'HTMLLabelElement',
+  'SVGElement',
+  'Node',
+  'Element',
+  'Event',
+  'MouseEvent',
+  'PointerEvent',
+  'FocusEvent',
+  'CustomEvent',
+  'MutationObserver',
+  'ResizeObserver',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+Object.defineProperties(globalThis, {
+  requestAnimationFrame: {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => setTimeout(() => callback(0), 0),
+  },
+  cancelAnimationFrame: {
+    configurable: true,
+    value: (handle: number) => clearTimeout(handle),
+  },
+  getComputedStyle: {
+    configurable: true,
+    value: domWindow.getComputedStyle.bind(domWindow),
+  },
+})
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { createInstance } = await import('i18next')
+const { I18nextProvider, initReactI18next } = await import('react-i18next')
+const { api } = await import('@/lib/api')
+const { UserQuotaDialog } = await import('./user-quota-dialog')
+
+const originalPost = api.post
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+const i18n = createInstance()
+await i18n.use(initReactI18next).init({
+  lng: 'en',
+  resources: { en: { translation: {} } },
+})
+
+async function flushEffects() {
+  await new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+function findButton(text: string) {
+  const button = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
+    (candidate) => candidate.textContent?.includes(text)
+  )
+  assert.ok(button, `Could not find button containing ${text}`)
+  return button
+}
+
+function findAmountInput() {
+  const input = document.querySelector<HTMLInputElement>('#user-quota-amount')
+  assert.ok(input, 'Could not find the quota amount input')
+  return input
+}
+
+async function setInputValue(input: HTMLInputElement, value: string) {
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set
+  assert.ok(setValue)
+  await act(async () => {
+    setValue.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushEffects()
+  })
+}
+
+async function renderDialog() {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(
+      <I18nextProvider i18n={i18n}>
+        <UserQuotaDialog
+          open
+          onOpenChange={() => {}}
+          userId={41}
+          currentQuota={100}
+          onSuccess={() => {}}
+        />
+      </I18nextProvider>
+    )
+    await flushEffects()
+  })
+  return { container, root }
+}
+
+afterEach(() => {
+  api.post = originalPost
+  document.body.replaceChildren()
+})
+
+after(() => domWindow.close())
+
+describe('UserQuotaDialog amount validation', () => {
+  test('blocks an empty override, accepts explicit zero, and associates the label', async () => {
+    const requests: unknown[] = []
+    api.post = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true, data: {} } }
+    }) as typeof api.post
+
+    const { root } = await renderDialog()
+    try {
+      const input = findAmountInput()
+      const label = document.querySelector<HTMLLabelElement>(
+        'label[for="user-quota-amount"]'
+      )
+      assert.ok(label)
+      assert.equal(label.htmlFor, input.id)
+
+      await act(async () => {
+        findButton('Override').click()
+        await flushEffects()
+      })
+      const confirm = findButton('Confirm')
+      assert.equal(confirm.disabled, true)
+      confirm.click()
+      await flushEffects()
+      assert.equal(requests.length, 0)
+
+      await setInputValue(input, '0')
+      assert.equal(findButton('Confirm').disabled, false)
+      await act(async () => {
+        findButton('Confirm').click()
+        await flushEffects()
+      })
+
+      assert.deepEqual(requests, [
+        {
+          url: '/api/user/manage',
+          data: { id: 41, action: 'add_quota', mode: 'override', value: 0 },
+        },
+      ])
+    } finally {
+      await act(async () => root.unmount())
+    }
+  })
+
+  test('rejects NaN and non-finite values before submission', async () => {
+    const requests: unknown[] = []
+    api.post = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true, data: {} } }
+    }) as typeof api.post
+
+    for (const value of ['NaN', 'Infinity', '1e309']) {
+      const { root } = await renderDialog()
+      try {
+        const input = findAmountInput()
+        await setInputValue(input, value)
+        assert.equal(
+          findButton('Confirm').disabled,
+          true,
+          `Expected ${value} to be rejected`
+        )
+        findButton('Confirm').click()
+        await flushEffects()
+      } finally {
+        await act(async () => root.unmount())
+        document.body.replaceChildren()
+      }
+    }
+
+    assert.equal(requests.length, 0)
+  })
+
+  test('keeps positive add and subtract submissions unchanged', async () => {
+    const requests: unknown[] = []
+    api.post = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true, data: {} } }
+    }) as typeof api.post
+
+    for (const mode of ['add', 'subtract'] as const) {
+      const { root } = await renderDialog()
+      try {
+        if (mode === 'subtract') {
+          await act(async () => {
+            findButton('Subtract').click()
+            await flushEffects()
+          })
+        }
+        await setInputValue(findAmountInput(), '2')
+        assert.equal(findButton('Confirm').disabled, false)
+        await act(async () => {
+          findButton('Confirm').click()
+          await flushEffects()
+        })
+      } finally {
+        await act(async () => root.unmount())
+        document.body.replaceChildren()
+      }
+    }
+
+    assert.deepEqual(requests, [
+      {
+        url: '/api/user/manage',
+        data: { id: 41, action: 'add_quota', mode: 'add', value: 1000000 },
+      },
+      {
+        url: '/api/user/manage',
+        data: { id: 41, action: 'add_quota', mode: 'subtract', value: 1000000 },
+      },
+    ])
+  })
+})

--- a/apps/web/src/features/users/components/user-quota-dialog.test.tsx
+++ b/apps/web/src/features/users/components/user-quota-dialog.test.tsx
@@ -19,7 +19,9 @@ import { after, afterEach, describe, test } from 'node:test'
 
 import { Window } from 'happy-dom'
 
-const domWindow = new Window({ url: 'https://console.example.test/admin/users' })
+const domWindow = new Window({
+  url: 'https://console.example.test/admin/users',
+})
 for (const key of [
   'window',
   'document',
@@ -83,9 +85,9 @@ async function flushEffects() {
 }
 
 function findButton(text: string) {
-  const button = [...document.querySelectorAll<HTMLButtonElement>('button')].find(
-    (candidate) => candidate.textContent?.includes(text)
-  )
+  const button = [
+    ...document.querySelectorAll<HTMLButtonElement>('button'),
+  ].find((candidate) => candidate.textContent?.includes(text))
   assert.ok(button, `Could not find button containing ${text}`)
   return button
 }

--- a/apps/web/src/features/users/components/user-quota-dialog.tsx
+++ b/apps/web/src/features/users/components/user-quota-dialog.tsx
@@ -39,6 +39,24 @@ interface UserQuotaDialogProps {
   onSuccess: () => void
 }
 
+function getAmountValidation(amount: string, mode: QuotaAdjustMode) {
+  const trimmedAmount = amount.trim()
+  const parsedAmount = trimmedAmount === '' ? null : Number(trimmedAmount)
+  const amountValue =
+    parsedAmount !== null && Number.isFinite(parsedAmount) ? parsedAmount : 0
+  const quotaValue = parseQuotaFromDollars(Math.abs(amountValue))
+
+  return {
+    amountValue,
+    quotaValue,
+    isValid:
+      parsedAmount !== null &&
+      Number.isFinite(parsedAmount) &&
+      Number.isFinite(quotaValue) &&
+      (mode === 'override' || quotaValue > 0),
+  }
+}
+
 export function UserQuotaDialog(props: UserQuotaDialogProps) {
   const { t } = useTranslation()
   const [mode, setMode] = useState<QuotaAdjustMode>('add')
@@ -49,8 +67,8 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
   const currencyLabel = getCurrencyLabel()
   const tokensOnly = currencyMeta.kind === 'tokens'
 
-  const amountValue = Number.parseFloat(amount) || 0
-  const quotaValue = parseQuotaFromDollars(Math.abs(amountValue))
+  const { amountValue, quotaValue, isValid: isAmountValid } =
+    getAmountValidation(amount, mode)
 
   const getPreviewText = () => {
     const current = props.currentQuota
@@ -70,13 +88,19 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
   }
 
   const handleConfirm = async () => {
-    if (!amount && mode !== 'override') return
-    if (quotaValue <= 0 && mode !== 'override') return
+    const {
+      amountValue: submittedAmountValue,
+      quotaValue: submittedQuotaValue,
+      isValid,
+    } = getAmountValidation(amount, mode)
+    if (!isValid) return
 
     setLoading(true)
     try {
       const value =
-        mode === 'override' ? parseQuotaFromDollars(amountValue) : quotaValue
+        mode === 'override'
+          ? parseQuotaFromDollars(submittedAmountValue)
+          : submittedQuotaValue
       const result = await adjustUserQuota({
         id: props.userId,
         action: 'add_quota',
@@ -122,7 +146,7 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
           <Button variant='outline' onClick={handleCancel}>
             {t('Cancel')}
           </Button>
-          <Button onClick={handleConfirm} disabled={loading}>
+          <Button onClick={handleConfirm} disabled={loading || !isAmountValid}>
             {loading ? t('Processing...') : t('Confirm')}
           </Button>
         </>
@@ -160,10 +184,11 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
         </div>
 
         <div className='space-y-2'>
-          <Label>
+          <Label htmlFor='user-quota-amount'>
             {t('Amount')} ({currencyLabel})
           </Label>
           <Input
+            id='user-quota-amount'
             type='number'
             step={tokensOnly ? 1 : 0.000001}
             min={mode === 'override' ? undefined : 0}

--- a/apps/web/src/features/users/components/user-quota-dialog.tsx
+++ b/apps/web/src/features/users/components/user-quota-dialog.tsx
@@ -67,8 +67,11 @@ export function UserQuotaDialog(props: UserQuotaDialogProps) {
   const currencyLabel = getCurrencyLabel()
   const tokensOnly = currencyMeta.kind === 'tokens'
 
-  const { amountValue, quotaValue, isValid: isAmountValid } =
-    getAmountValidation(amount, mode)
+  const {
+    amountValue,
+    quotaValue,
+    isValid: isAmountValid,
+  } = getAmountValidation(amount, mode)
 
   const getPreviewText = () => {
     const current = props.currentQuota


### PR DESCRIPTION
## Summary
- reject empty, NaN, Infinity, overflow-to-Infinity, and zero-value add/subtract adjustments
- preserve explicit zero as a valid override
- revalidate immediately before API submission
- associate the amount label and input
- cover empty override, zero override, non-finite input, and unchanged positive add/subtract requests

## Independent verification
- focused component tests: 3/3 pass
- full Web typecheck: pass
- full format check: pass
- touched Oxlint: no errors (one pre-existing nested-ternary warning in the mode label)
- `git diff --check`: pass

No production deployment.

## Sourcery 摘要

防止提交无效的用户配额调整，同时允许有效的零值覆盖。

Bug 修复：
- 验证配额调整金额，拒绝空值、非有限值、溢出值以及值为零的增加/减少提交，同时保留显式的零值覆盖。
- 在提交请求前立即重新验证配额金额，防止无效值传递到 API。

增强功能：
- 将配额金额标签与其输入框关联，以提升可访问性。

测试：
- 为无效金额、显式零值覆盖、可访问的标签以及未更改的正向调整添加组件测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent invalid user quota adjustments from being submitted while allowing valid zero overrides.

Bug Fixes:
- Validate quota adjustment amounts to reject empty, non-finite, overflowing, and zero-value add/subtract submissions while preserving explicit zero overrides.
- Revalidate quota amounts immediately before submitting requests to prevent invalid values from reaching the API.

Enhancements:
- Associate the quota amount label with its input for improved accessibility.

Tests:
- Add component coverage for invalid amounts, explicit zero overrides, accessible labeling, and unchanged positive adjustments.

</details>