### PR TITLE
fix(web): clear password fields when dialog closes

### DIFF
--- a/apps/web/src/features/profile/components/dialogs/change-password-dialog.test.tsx
+++ b/apps/web/src/features/profile/components/dialogs/change-password-dialog.test.tsx
@@ -2,9 +2,9 @@
 Copyright (C) 2023-2026 QuantumNous
 
 This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/apps/web/src/features/profile/components/dialogs/change-password-dialog.test.tsx
+++ b/apps/web/src/features/profile/components/dialogs/change-password-dialog.test.tsx
@@ -1,0 +1,251 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+
+const domWindow = new Window({
+  url: 'https://console.example.test/profile',
+})
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'HTMLButtonElement',
+  'HTMLInputElement',
+  'SVGElement',
+  'Node',
+  'Element',
+  'Event',
+  'MouseEvent',
+  'PointerEvent',
+  'FocusEvent',
+  'CustomEvent',
+  'MutationObserver',
+  'ResizeObserver',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+Object.defineProperties(globalThis, {
+  requestAnimationFrame: {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => setTimeout(() => callback(0), 0),
+  },
+  cancelAnimationFrame: {
+    configurable: true,
+    value: (handle: number) => clearTimeout(handle),
+  },
+  getComputedStyle: {
+    configurable: true,
+    value: domWindow.getComputedStyle.bind(domWindow),
+  },
+})
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { createInstance } = await import('i18next')
+const { I18nextProvider, initReactI18next } = await import('react-i18next')
+const { toast } = await import('sonner')
+const { api } = await import('@/lib/api')
+const { ChangePasswordDialog } = await import('./change-password-dialog')
+
+const originalPut = api.put
+const originalToastSuccess = toast.success
+const originalToastError = toast.error
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+const i18n = createInstance()
+await i18n.use(initReactI18next).init({
+  lng: 'en',
+  resources: { en: { translation: {} } },
+})
+
+async function flushEffects() {
+  await new Promise((resolve) => setTimeout(resolve, 20))
+}
+
+function dialogElement(
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+  username = 'alice'
+) {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <ChangePasswordDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        username={username}
+      />
+    </I18nextProvider>
+  )
+}
+
+async function renderDialog(onOpenChange: (open: boolean) => void) {
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(dialogElement(true, onOpenChange))
+    await flushEffects()
+  })
+  return { root }
+}
+
+async function rerenderDialog(
+  root: ReturnType<typeof createRoot>,
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+  username = 'alice'
+) {
+  await act(async () => {
+    root.render(dialogElement(open, onOpenChange, username))
+    await flushEffects()
+  })
+}
+
+async function setInputValue(id: string, value: string) {
+  const input = document.querySelector<HTMLInputElement>(`#${id}`)
+  assert.ok(input)
+  const setValue = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    'value'
+  )?.set
+  assert.ok(setValue)
+  await act(async () => {
+    setValue.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+    input.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushEffects()
+  })
+}
+
+function passwordValues() {
+  return ['currentPassword', 'newPassword', 'confirmPassword'].map((id) => {
+    const input = document.querySelector<HTMLInputElement>(`#${id}`)
+    assert.ok(input)
+    return input.value
+  })
+}
+
+function findButton(text: string) {
+  const button = [
+    ...document.querySelectorAll<HTMLButtonElement>('button'),
+  ].find((candidate) => candidate.textContent?.trim() === text)
+  assert.ok(button, `Could not find button ${text}`)
+  return button
+}
+
+async function enterPasswords() {
+  await setInputValue('currentPassword', 'old-password')
+  await setInputValue('newPassword', 'new-password')
+  await setInputValue('confirmPassword', 'new-password')
+}
+
+async function unmount(root: ReturnType<typeof createRoot>) {
+  await act(async () => root.unmount())
+}
+
+afterEach(() => {
+  api.put = originalPut
+  toast.success = originalToastSuccess
+  toast.error = originalToastError
+  document.body.replaceChildren()
+})
+
+after(() => domWindow.close())
+
+describe('ChangePasswordDialog secret reset', () => {
+  test('keeps fields while open but clears them across controlled close and reopen', async () => {
+    const onOpenChange = () => undefined
+    const { root } = await renderDialog(onOpenChange)
+    try {
+      await enterPasswords()
+      await rerenderDialog(root, true, onOpenChange, 'alice-renamed')
+      assert.deepEqual(passwordValues(), [
+        'old-password',
+        'new-password',
+        'new-password',
+      ])
+
+      await rerenderDialog(root, false, onOpenChange)
+      await rerenderDialog(root, true, onOpenChange)
+      assert.deepEqual(passwordValues(), ['', '', ''])
+    } finally {
+      await unmount(root)
+    }
+  })
+
+  test('clears secrets immediately when Cancel requests close', async () => {
+    const openChanges: boolean[] = []
+    const onOpenChange = (open: boolean) => openChanges.push(open)
+    const { root } = await renderDialog(onOpenChange)
+    try {
+      await enterPasswords()
+      await act(async () => {
+        findButton('Cancel').click()
+        await flushEffects()
+      })
+      assert.deepEqual(openChanges, [false])
+      assert.deepEqual(passwordValues(), ['', '', ''])
+    } finally {
+      await unmount(root)
+    }
+  })
+
+  test('clears secrets immediately after a successful password change', async () => {
+    const requests: unknown[] = []
+    api.put = (async (url: string, data: unknown) => {
+      requests.push({ url, data })
+      return { data: { success: true } }
+    }) as typeof api.put
+    toast.success = (() => 'success-toast') as typeof toast.success
+    toast.error = (() => 'error-toast') as typeof toast.error
+    const openChanges: boolean[] = []
+    const onOpenChange = (open: boolean) => openChanges.push(open)
+    const { root } = await renderDialog(onOpenChange)
+    try {
+      await enterPasswords()
+      await act(async () => {
+        findButton('Change Password').click()
+        await flushEffects()
+      })
+      assert.deepEqual(requests, [
+        {
+          url: '/api/user/self',
+          data: {
+            original_password: 'old-password',
+            password: 'new-password',
+          },
+        },
+      ])
+      assert.deepEqual(openChanges, [false])
+      assert.deepEqual(passwordValues(), ['', '', ''])
+    } finally {
+      await unmount(root)
+    }
+  })
+})

--- a/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
+++ b/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Loader2 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -52,33 +52,13 @@ export function ChangePasswordDialog({
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
   const [formData, setFormData] = useState(EMPTY_FORM_DATA)
-  const pendingCloseReset = useRef(false)
 
   useEffect(() => {
-    if (loading) {
-      if (!open) pendingCloseReset.current = true
-      return
-    }
-
-    if (!open || pendingCloseReset.current) {
-      pendingCloseReset.current = false
-      setFormData(EMPTY_FORM_DATA)
-    }
-  }, [loading, open])
+    if (!open) setFormData(EMPTY_FORM_DATA)
+  }, [open])
 
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
-  }
-
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      if (loading) {
-        pendingCloseReset.current = true
-      } else {
-        setFormData(EMPTY_FORM_DATA)
-      }
-    }
-    onOpenChange(nextOpen)
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -119,7 +99,7 @@ export function ChangePasswordDialog({
 
       if (response.success) {
         toast.success(t('Password changed successfully'))
-        handleOpenChange(false)
+        onOpenChange(false)
       } else {
         toast.error(response.message || t('Failed to change password'))
       }
@@ -135,7 +115,7 @@ export function ChangePasswordDialog({
   return (
     <Dialog
       open={open}
-      onOpenChange={handleOpenChange}
+      onOpenChange={onOpenChange}
       title={t('Change Password')}
       description={
         <>
@@ -150,7 +130,7 @@ export function ChangePasswordDialog({
           <Button
             type='button'
             variant='outline'
-            onClick={() => handleOpenChange(false)}
+            onClick={() => onOpenChange(false)}
             disabled={loading}
           >
             {t('Cancel')}

--- a/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
+++ b/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
@@ -57,6 +57,11 @@ export function ChangePasswordDialog({
     if (!open) setFormData(EMPTY_FORM_DATA)
   }, [open])
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) setFormData(EMPTY_FORM_DATA)
+    onOpenChange(nextOpen)
+  }
+
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
   }
@@ -99,7 +104,7 @@ export function ChangePasswordDialog({
 
       if (response.success) {
         toast.success(t('Password changed successfully'))
-        onOpenChange(false)
+        handleOpenChange(false)
       } else {
         toast.error(response.message || t('Failed to change password'))
       }
@@ -115,7 +120,7 @@ export function ChangePasswordDialog({
   return (
     <Dialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       title={t('Change Password')}
       description={
         <>
@@ -130,7 +135,7 @@ export function ChangePasswordDialog({
           <Button
             type='button'
             variant='outline'
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
             disabled={loading}
           >
             {t('Cancel')}

--- a/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
+++ b/apps/web/src/features/profile/components/dialogs/change-password-dialog.tsx
@@ -17,7 +17,7 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 For commercial licensing, please contact support@quantumnous.com
 */
 import { Loader2 } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
@@ -32,6 +32,12 @@ import { updateUserProfile } from '../../api'
 // Change Password Dialog Component
 // ============================================================================
 
+const EMPTY_FORM_DATA = {
+  originalPassword: '',
+  newPassword: '',
+  confirmPassword: '',
+}
+
 interface ChangePasswordDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -45,14 +51,34 @@ export function ChangePasswordDialog({
 }: ChangePasswordDialogProps) {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(false)
-  const [formData, setFormData] = useState({
-    originalPassword: '',
-    newPassword: '',
-    confirmPassword: '',
-  })
+  const [formData, setFormData] = useState(EMPTY_FORM_DATA)
+  const pendingCloseReset = useRef(false)
+
+  useEffect(() => {
+    if (loading) {
+      if (!open) pendingCloseReset.current = true
+      return
+    }
+
+    if (!open || pendingCloseReset.current) {
+      pendingCloseReset.current = false
+      setFormData(EMPTY_FORM_DATA)
+    }
+  }, [loading, open])
 
   const handleChange = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      if (loading) {
+        pendingCloseReset.current = true
+      } else {
+        setFormData(EMPTY_FORM_DATA)
+      }
+    }
+    onOpenChange(nextOpen)
   }
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -93,12 +119,7 @@ export function ChangePasswordDialog({
 
       if (response.success) {
         toast.success(t('Password changed successfully'))
-        onOpenChange(false)
-        setFormData({
-          originalPassword: '',
-          newPassword: '',
-          confirmPassword: '',
-        })
+        handleOpenChange(false)
       } else {
         toast.error(response.message || t('Failed to change password'))
       }
@@ -114,7 +135,7 @@ export function ChangePasswordDialog({
   return (
     <Dialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       title={t('Change Password')}
       description={
         <>
@@ -129,7 +150,7 @@ export function ChangePasswordDialog({
           <Button
             type='button'
             variant='outline'
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
             disabled={loading}
           >
             {t('Cancel')}


### PR DESCRIPTION
## Summary
- clear all password fields when controlled `open` becomes false
- centralize dialog, cancel, and successful-submit close requests so secrets clear immediately
- keep fields intact while the dialog remains open
- cover controlled close→reopen, Cancel, and successful submission

## Independent verification
- focused component tests: 3/3 pass
- full Web typecheck: pass
- touched Oxlint: clean
- full format check, TypeScript LSP, and `git diff --check`: pass

No production deployment.

## Sourcery 摘要

确保更改密码对话框关闭时立即清除密码机密，同时在对话框打开期间保留这些密码。

错误修复：
- 每当更改密码对话框关闭时清除所有密码字段，包括受控关闭、取消操作和成功提交。

改进：
- 在对话框保持打开期间保留已输入的密码字段。

测试：
- 增加组件测试，覆盖受控关闭并重新打开、取消操作以及成功提交密码时的机密清除。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保更改密码对话框关闭时立即清除密码机密，同时在会话保持打开期间保留这些机密。

错误修复：
- 每当更改密码对话框关闭时清除所有密码字段，包括受控关闭、取消和提交成功的情况。

改进：
- 在对话框保持打开期间保留已输入的密码值。

测试：
- 添加组件测试，覆盖受控关闭后重新打开、取消操作，以及密码更改成功后的密码机密清除。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

确保更改密码对话框关闭时立即清除密码机密，同时在活动会话期间保留这些密码。

错误修复：
- 每当更改密码对话框关闭时清除所有密码字段，包括受控关闭、取消操作和成功提交。

增强功能：
- 在对话框保持打开期间保留已输入的密码值。

测试：
- 为受控关闭和重新打开、取消操作以及成功更改密码后的机密清除添加组件测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure password secrets are cleared immediately whenever the change-password dialog closes while preserving them during the active session.

Bug Fixes:
- Clear all password fields whenever the change-password dialog closes, including controlled closes, cancellation, and successful submissions.

Enhancements:
- Preserve entered password values while the dialog remains open.

Tests:
- Add component coverage for controlled close and reopen, cancellation, and successful password-change secret clearing.

</details>

</details>

</details>