### PR TITLE
feat(web): add guided JSON configuration editing

### DIFF
--- a/apps/web/src/components/json-code-editor.tsx
+++ b/apps/web/src/components/json-code-editor.tsx
@@ -19,6 +19,7 @@ For commercial licensing, please contact support@quantumnous.com
 import { AlertCircle, Braces, CheckCircle2, Code2, Copy } from 'lucide-react'
 import {
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -92,20 +93,54 @@ export function JsonSpecification({
 
   return (
     <details className='bg-muted/10 border-t text-xs' open={defaultOpen}>
-      <summary className='text-muted-foreground hover:text-foreground cursor-pointer px-3 py-2 font-medium select-none'>
-        <span className='ml-1 inline-flex flex-wrap items-center gap-2'>
+      <summary className='text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 cursor-pointer px-3 py-2.5 font-medium select-none focus-visible:ring-[3px] focus-visible:outline-none'>
+        <span className='ml-1 inline-flex max-w-[calc(100%_-_1rem)] flex-wrap items-center gap-2'>
           <span>{t('Field specification')}</span>
-          <Badge variant='outline' className='font-mono font-normal'>
+          <Badge
+            variant='outline'
+            className='max-w-full font-mono font-normal [overflow-wrap:anywhere] whitespace-normal'
+          >
             {specification.rootType}
           </Badge>
         </span>
       </summary>
       <div className='border-t'>
+        <ul
+          className='divide-y sm:hidden'
+          aria-label={t('Field specification')}
+        >
+          {specification.fields.map((field) => (
+            <li key={field.path} className='space-y-2.5 px-3 py-3'>
+              <div className='flex min-w-0 items-start justify-between gap-3'>
+                <code className='text-foreground min-w-0 font-medium [overflow-wrap:anywhere]'>
+                  {field.path}
+                </code>
+                <span className='text-muted-foreground shrink-0'>
+                  {requirementLabel(field.required)}
+                </span>
+              </div>
+              <dl className='grid grid-cols-[4.5rem_minmax(0,1fr)] gap-x-3 gap-y-1.5'>
+                <dt className='text-muted-foreground'>{t('Type')}</dt>
+                <dd className='text-muted-foreground font-mono [overflow-wrap:anywhere]'>
+                  {field.type}
+                </dd>
+                <dt className='text-muted-foreground'>{t('Rules')}</dt>
+                <dd className='text-muted-foreground font-mono [overflow-wrap:anywhere] whitespace-pre-wrap'>
+                  {field.rules || '—'}
+                </dd>
+                <dt className='text-muted-foreground'>{t('Example')}</dt>
+                <dd className='text-muted-foreground font-mono [overflow-wrap:anywhere] whitespace-pre-wrap'>
+                  {field.example || '—'}
+                </dd>
+              </dl>
+            </li>
+          ))}
+        </ul>
         <div
           role='region'
           aria-label={t('Field specification')}
           tabIndex={0}
-          className='focus-visible:ring-ring/50 max-w-full overflow-x-auto focus-visible:ring-[3px] focus-visible:outline-none'
+          className='focus-visible:ring-ring/50 hidden max-w-full overflow-x-auto focus-visible:ring-[3px] focus-visible:outline-none sm:block'
         >
           <table className='w-full min-w-[640px] border-collapse text-left'>
             <caption className='sr-only'>{t('Field specification')}</caption>
@@ -143,10 +178,10 @@ export function JsonSpecification({
                   <td className='text-muted-foreground px-3 py-2'>
                     {requirementLabel(field.required)}
                   </td>
-                  <td className='text-muted-foreground px-3 py-2 font-mono whitespace-normal'>
+                  <td className='text-muted-foreground px-3 py-2 font-mono [overflow-wrap:anywhere] whitespace-normal'>
                     {field.rules || '—'}
                   </td>
-                  <td className='text-muted-foreground px-3 py-2 font-mono whitespace-normal'>
+                  <td className='text-muted-foreground px-3 py-2 font-mono [overflow-wrap:anywhere] whitespace-normal'>
                     {field.example || '—'}
                   </td>
                 </tr>
@@ -161,34 +196,118 @@ export function JsonSpecification({
 
 export function JsonExample({
   example,
+  currentValue = '',
   disabled = false,
   onUseExample,
 }: {
   example: string
+  currentValue?: string
   disabled?: boolean
   onUseExample: (example: string) => void
 }) {
   const { t } = useTranslation()
+  const replacementSignature = `${currentValue}\u0000${example}`
+  const [pendingReplacement, setPendingReplacement] = useState<string | null>(
+    null
+  )
+  const needsConfirmation =
+    Boolean(currentValue.trim()) && currentValue !== example
+  const replacementPending =
+    needsConfirmation && pendingReplacement === replacementSignature
+
+  const handleCopyExample = async () => {
+    const didCopy = await copyToClipboard(example)
+    if (didCopy) {
+      toast.success(t('Copied to clipboard'))
+      return
+    }
+
+    toast.error(t('Failed to copy'))
+  }
+
+  const handleUseExample = () => {
+    if (needsConfirmation) {
+      setPendingReplacement(replacementSignature)
+      return
+    }
+
+    onUseExample(example)
+  }
+
+  const confirmReplacement = () => {
+    onUseExample(example)
+    setPendingReplacement(null)
+  }
 
   return (
     <details className='bg-muted/10 border-t text-xs'>
-      <summary className='text-muted-foreground hover:text-foreground cursor-pointer px-3 py-2 font-medium select-none'>
+      <summary className='text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 cursor-pointer px-3 py-2.5 font-medium select-none focus-visible:ring-[3px] focus-visible:outline-none'>
         <span className='ml-1'>{t('Configuration example')}</span>
       </summary>
       <div className='space-y-2 border-t px-3 py-3'>
-        <pre className='bg-background/70 text-muted-foreground max-h-40 overflow-auto rounded-md border p-2 font-mono whitespace-pre-wrap'>
+        <pre className='bg-background/70 text-muted-foreground max-h-40 overflow-auto rounded-md border p-2 font-mono [overflow-wrap:anywhere] whitespace-pre-wrap'>
           {example}
         </pre>
-        <Button
-          type='button'
-          variant='outline'
-          size='sm'
-          className='h-7 text-xs'
-          onClick={() => onUseExample(example)}
-          disabled={disabled}
-        >
-          {t('Fill Template')}
-        </Button>
+        <div className='flex flex-wrap gap-2'>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='h-7 text-xs'
+            onClick={() => void handleCopyExample()}
+            disabled={disabled}
+          >
+            <Copy className='mr-1 h-3.5 w-3.5' aria-hidden='true' />
+            {t('Copy')}
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            className='h-7 text-xs'
+            onClick={handleUseExample}
+            disabled={disabled || currentValue === example}
+          >
+            {t('Fill Template')}
+          </Button>
+        </div>
+        {replacementPending && (
+          <div
+            role='alert'
+            className='border-destructive/30 bg-destructive/5 space-y-2 rounded-md border p-2.5'
+          >
+            <p className='text-foreground font-medium'>
+              {t('Discard unsaved JSON changes?')}
+            </p>
+            <p className='text-muted-foreground'>
+              {t(
+                'Continuing will replace the unsaved JSON currently in the editor.'
+              )}
+            </p>
+            <div className='flex flex-wrap gap-2'>
+              <Button
+                type='button'
+                variant='destructive'
+                size='sm'
+                className='h-7 text-xs'
+                onClick={confirmReplacement}
+                disabled={disabled}
+              >
+                {t('Replace')}
+              </Button>
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                className='h-7 text-xs'
+                onClick={() => setPendingReplacement(null)}
+                disabled={disabled}
+              >
+                {t('Cancel')}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </details>
   )
@@ -227,6 +346,7 @@ export function JsonCodeEditor({
   ...rootProps
 }: JsonCodeEditorProps) {
   const { t } = useTranslation()
+  const validationStatusId = useId()
   const resolvedExample = example ?? validJsonExample(placeholder)
   const mountRef = useRef<HTMLDivElement>(null)
   const editorRef = useRef<Yace | null>(null)
@@ -378,11 +498,10 @@ export function JsonCodeEditor({
       editor.textarea.removeAttribute('aria-invalid')
     }
 
-    if (ariaDescribedBy) {
-      editor.textarea.setAttribute('aria-describedby', ariaDescribedBy)
-    } else {
-      editor.textarea.removeAttribute('aria-describedby')
-    }
+    const resolvedAriaDescribedBy = [ariaDescribedBy, validationStatusId]
+      .filter(Boolean)
+      .join(' ')
+    editor.textarea.setAttribute('aria-describedby', resolvedAriaDescribedBy)
   }, [
     ariaDescribedBy,
     ariaInvalid,
@@ -393,6 +512,7 @@ export function JsonCodeEditor({
     jsonStatus.isValid,
     name,
     placeholder,
+    validationStatusId,
   ])
 
   const formatJson = () => {
@@ -424,49 +544,63 @@ export function JsonCodeEditor({
       data-form-root={dataFormRoot}
       {...rootProps}
     >
-      <div className='bg-muted/30 flex h-8 items-center justify-between border-b px-2'>
+      <div className='bg-muted/30 flex min-h-8 flex-wrap items-center justify-between gap-x-2 gap-y-1 border-b px-2 py-1'>
         <div className='text-muted-foreground flex min-w-0 items-center gap-1.5 text-xs font-medium'>
           <Braces className='h-3.5 w-3.5' aria-hidden='true' />
           <span>{t('JSON')}</span>
-          <span className='text-muted-foreground/70 font-mono'>
+          <span className='text-muted-foreground/70 hidden font-mono sm:inline'>
             {cursorText}
           </span>
         </div>
-        <div className='flex items-center gap-2'>
+        <div className='ml-auto flex min-w-0 items-center gap-1 sm:gap-2'>
           <span
+            id={validationStatusId}
+            role='status'
+            aria-live='polite'
+            aria-atomic='true'
             className={cn(
-              'flex items-center gap-1 text-xs',
+              'flex min-w-0 items-center gap-1 text-xs',
               jsonStatus.isValid ? 'text-success' : 'text-destructive'
             )}
           >
             {jsonStatus.isValid ? (
-              <CheckCircle2 className='h-3.5 w-3.5' aria-hidden='true' />
+              <CheckCircle2
+                className='h-3.5 w-3.5 shrink-0'
+                aria-hidden='true'
+              />
             ) : (
-              <AlertCircle className='h-3.5 w-3.5' aria-hidden='true' />
+              <AlertCircle
+                className='h-3.5 w-3.5 shrink-0'
+                aria-hidden='true'
+              />
             )}
-            {statusMessage}
+            <span className='truncate'>{statusMessage}</span>
           </span>
           <Button
             type='button'
             variant='ghost'
             size='sm'
-            className='h-6 px-2 text-xs'
+            className='h-6 px-1.5 text-xs sm:px-2'
             onClick={handleCopy}
             disabled={disabled || !value}
+            aria-label={t('Copy')}
+            title={t('Copy')}
           >
-            <Copy className='mr-1 h-3.5 w-3.5' aria-hidden='true' />
-            {t('Copy')}
+            <Copy className='h-3.5 w-3.5 sm:mr-1' aria-hidden='true' />
+            <span className='sr-only sm:not-sr-only'>{t('Copy')}</span>
           </Button>
           <Button
             type='button'
             variant='ghost'
             size='sm'
-            className='h-6 px-2 text-xs'
+            className='h-6 px-1.5 text-xs sm:px-2'
             onClick={formatJson}
             disabled={disabled || !jsonStatus.isValid || !value.trim()}
+            aria-label={t('Format JSON')}
+            title={t('Format JSON')}
           >
-            <Code2 className='mr-1 h-3.5 w-3.5' aria-hidden='true' />
-            {t('Format JSON')}
+            <Code2 className='h-3.5 w-3.5 sm:mr-1' aria-hidden='true' />
+            <span className='sr-only sm:not-sr-only'>{t('Format JSON')}</span>
           </Button>
         </div>
       </div>
@@ -491,6 +625,7 @@ export function JsonCodeEditor({
       {resolvedExample && (
         <JsonExample
           example={resolvedExample}
+          currentValue={value}
           disabled={disabled}
           onUseExample={onChange}
         />

--- a/apps/web/src/components/json-code-editor/__tests__/json-code-editor.test.tsx
+++ b/apps/web/src/components/json-code-editor/__tests__/json-code-editor.test.tsx
@@ -68,6 +68,12 @@ await i18next.use(initReactI18next).init({
         'Configuration example': 'Configuration example',
         'Field specification': 'Field specification',
         'Fill Template': 'Fill Template',
+        Copy: 'Copy',
+        Cancel: 'Cancel',
+        Replace: 'Replace',
+        'Discard unsaved JSON changes?': 'Discard unsaved JSON changes?',
+        'Continuing will replace the unsaved JSON currently in the editor.':
+          'Continuing will replace the unsaved JSON currently in the editor.',
       },
     },
   },
@@ -130,7 +136,13 @@ describe('JsonCodeEditor component', () => {
     assert.equal(textarea.name, 'model_config')
     assert.equal(textarea.placeholder, '{"model":"gpt"}')
     assert.equal(textarea.disabled, true)
-    assert.equal(textarea.getAttribute('aria-describedby'), 'model-help')
+    const validationStatus = rendered.container.querySelector('[role="status"]')
+    assert.ok(validationStatus)
+    assert.equal(validationStatus.getAttribute('aria-live'), 'polite')
+    assert.deepEqual(textarea.getAttribute('aria-describedby')?.split(' '), [
+      'model-help',
+      validationStatus.id,
+    ])
     assert.equal(textarea.getAttribute('aria-invalid'), 'true')
     assert.equal(textarea.getAttribute('data-form-root'), 'settings-form')
 
@@ -210,6 +222,68 @@ describe('JsonCodeEditor component', () => {
     await unmountEditor(rendered)
   })
 
+  test('copies an example and confirms before replacing populated JSON', async () => {
+    const changes: string[] = []
+    const clipboardWrites: string[] = []
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (value: string) => {
+          clipboardWrites.push(value)
+        },
+      },
+    })
+    const example = '{\n  "default": 1\n}'
+    const rendered = await renderEditor({
+      value: '{"existing":true}',
+      onChange: (value) => changes.push(value),
+      example,
+    })
+    const details = rendered.container.querySelector('details')
+    assert.ok(details)
+    const buttons = [...details.querySelectorAll('button')]
+    const copyButton = buttons.find((button) => button.textContent === 'Copy')
+    const fillButton = buttons.find((button) =>
+      button.textContent?.includes('Fill Template')
+    )
+    assert.ok(copyButton)
+    assert.ok(fillButton)
+
+    await act(async () => {
+      copyButton.click()
+      await Promise.resolve()
+    })
+    assert.deepEqual(clipboardWrites, [example])
+    assert.deepEqual(changes, [])
+
+    await act(async () => fillButton.click())
+    assert.deepEqual(changes, [])
+    const replacementAlert = details.querySelector('[role="alert"]')
+    assert.ok(replacementAlert)
+    assert.equal(
+      replacementAlert.textContent?.includes('Discard unsaved JSON changes?'),
+      true
+    )
+
+    const cancelButton = [...replacementAlert.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Cancel'
+    )
+    assert.ok(cancelButton)
+    await act(async () => cancelButton.click())
+    assert.equal(details.querySelector('[role="alert"]'), null)
+    assert.deepEqual(changes, [])
+
+    await act(async () => fillButton.click())
+    const confirmButton = [
+      ...details.querySelectorAll<HTMLButtonElement>('[role="alert"] button'),
+    ].find((button) => button.textContent === 'Replace')
+    assert.ok(confirmButton)
+    await act(async () => confirmButton.click())
+    assert.deepEqual(changes, [example])
+
+    await unmountEditor(rendered)
+  })
+
   test('renders an accessible field specification with types and constraints', async () => {
     const rendered = await renderEditor({
       value: '{"enabled":true}',
@@ -256,6 +330,13 @@ describe('JsonCodeEditor component', () => {
       'Field specification'
     )
     assert.equal(table.querySelector('th[scope="row"]')?.textContent, 'enabled')
+
+    const mobileList = details.querySelector(
+      'ul[aria-label="Field specification"]'
+    )
+    assert.ok(mobileList)
+    assert.equal(mobileList.querySelector('li code')?.textContent, 'enabled')
+    assert.equal(mobileList.textContent?.includes('default: false'), true)
 
     await unmountEditor(rendered)
   })

--- a/apps/web/src/components/json-editor.tsx
+++ b/apps/web/src/components/json-editor.tsx
@@ -277,6 +277,7 @@ export function JsonEditor({
           {resolvedExample && (
             <JsonExample
               example={resolvedExample}
+              currentValue={jsonValue}
               disabled={disabled}
               onUseExample={handleUseExample}
             />

--- a/apps/web/src/features/system-settings/operations/__tests__/raw-json-draft-state.test.ts
+++ b/apps/web/src/features/system-settings/operations/__tests__/raw-json-draft-state.test.ts
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2025 LIghtJUNction
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import {
+  hasUnsavedJsonDraft,
+  shouldApplyRawJsonServerValue,
+} from '../raw-json-draft-state'
+
+describe('raw JSON draft state', () => {
+  test('distinguishes unsaved editor content from the loaded baseline', () => {
+    assert.equal(hasUnsavedJsonDraft('{"value":2}', '{"value":1}'), true)
+    assert.equal(hasUnsavedJsonDraft('{"value":1}', '{"value":1}'), false)
+  })
+
+  test('preserves a dirty draft when the same setting refetches', () => {
+    assert.equal(
+      shouldApplyRawJsonServerValue({
+        loadedKey: 'setting-a',
+        selectedKey: 'setting-a',
+        editorValue: '{"draft":true}',
+        baselineValue: '{"draft":false}',
+      }),
+      false
+    )
+  })
+
+  test('hydrates clean drafts and deliberate setting switches', () => {
+    assert.equal(
+      shouldApplyRawJsonServerValue({
+        loadedKey: 'setting-a',
+        selectedKey: 'setting-a',
+        editorValue: '{"value":1}',
+        baselineValue: '{"value":1}',
+      }),
+      true
+    )
+    assert.equal(
+      shouldApplyRawJsonServerValue({
+        loadedKey: 'setting-a',
+        selectedKey: 'setting-b',
+        editorValue: '{"draft":true}',
+        baselineValue: '{"draft":false}',
+      }),
+      true
+    )
+  })
+})

--- a/apps/web/src/features/system-settings/operations/raw-json-configuration-section.tsx
+++ b/apps/web/src/features/system-settings/operations/raw-json-configuration-section.tsx
@@ -16,17 +16,31 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 For commercial licensing, please contact support@quantumnous.com
 */
-import { Download, FileUp, RefreshCw, Sparkles } from 'lucide-react'
+import {
+  AlertCircle,
+  CheckCircle2,
+  Download,
+  FileUp,
+  RefreshCw,
+  Sparkles,
+} from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { ConfirmDialog } from '@/components/confirm-dialog'
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
+} from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -36,9 +50,14 @@ import { SystemJsonCodeEditor } from '@/features/system-settings/components/syst
 import type { SystemJsonConfigurationKey } from '@/features/system-settings/components/system-json-configurations'
 
 import { updateSystemOptions, validateSystemOptions } from '../api'
+import { FormNavigationGuard } from '../components/form-navigation-guard'
 import { SettingsPageActionsPortal } from '../components/settings-page-context'
 import { SettingsSection } from '../components/settings-section'
 import { useSystemOptions } from '../hooks/use-system-options'
+import {
+  hasUnsavedJsonDraft,
+  shouldApplyRawJsonServerValue,
+} from './raw-json-draft-state'
 
 type RawJsonDescriptor = {
   key: SystemJsonConfigurationKey
@@ -149,17 +168,30 @@ export function RawJsonConfigurationSection() {
   const { t } = useTranslation()
   const optionsQuery = useSystemOptions()
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const loadedKeyRef = useRef<RawJsonConfigurationKey | null>(null)
   const [selectedKey, setSelectedKey] = useState<RawJsonConfigurationKey>(
     'group_ratio_setting.group_warnings'
   )
   const [editorValue, setEditorValue] = useState('')
   const [baselineValue, setBaselineValue] = useState('')
-  const [validationMessage, setValidationMessage] = useState<string | null>(
-    null
-  )
+  const [validationFeedback, setValidationFeedback] = useState<{
+    kind: 'success' | 'error'
+    message: string
+  } | null>(null)
+  const [pendingReplacement, setPendingReplacement] = useState<
+    | { kind: 'configuration'; key: RawJsonConfigurationKey }
+    | { kind: 'import'; value: string }
+    | null
+  >(null)
   const [isValidating, setIsValidating] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
+  const editorValueRef = useRef(editorValue)
+  const baselineValueRef = useRef(baselineValue)
   const descriptor = descriptorMap.get(selectedKey)
+  const dirty = hasUnsavedJsonDraft(editorValue, baselineValue)
+  const isBusy = isValidating || isSaving
+  const controlsDisabled =
+    optionsQuery.isLoading || optionsQuery.isError || !descriptor || isBusy
   const availableDescriptors = useMemo(
     () =>
       RAW_JSON_DESCRIPTORS.filter((item) =>
@@ -167,35 +199,91 @@ export function RawJsonConfigurationSection() {
       ),
     [optionsQuery.data?.data]
   )
+  const selectItems = useMemo(
+    () =>
+      availableDescriptors.map((item) => ({
+        value: item.key,
+        label: `${t(item.label)} · ${item.key}`,
+      })),
+    [availableDescriptors, t]
+  )
+
+  editorValueRef.current = editorValue
+  baselineValueRef.current = baselineValue
 
   useEffect(() => {
     if (
+      !dirty &&
       availableDescriptors.length > 0 &&
       !availableDescriptors.some((item) => item.key === selectedKey)
     ) {
       setSelectedKey(availableDescriptors[0].key)
     }
-  }, [availableDescriptors, selectedKey])
+  }, [availableDescriptors, dirty, selectedKey])
 
   useEffect(() => {
     const raw =
       optionsQuery.data?.data?.find((option) => option.key === selectedKey)
         ?.value ?? ''
     const formatted = formatJson(raw)
-    setEditorValue(formatted)
-    setBaselineValue(formatted)
-    setValidationMessage(null)
+
+    if (
+      shouldApplyRawJsonServerValue({
+        loadedKey: loadedKeyRef.current,
+        selectedKey,
+        editorValue: editorValueRef.current,
+        baselineValue: baselineValueRef.current,
+      })
+    ) {
+      setEditorValue(formatted)
+      setBaselineValue(formatted)
+      setValidationFeedback(null)
+    }
+    loadedKeyRef.current = selectedKey
   }, [optionsQuery.data?.data, selectedKey])
+
+  const replaceEditorValue = (value: string) => {
+    setEditorValue(value)
+    setValidationFeedback(null)
+  }
+
+  const requestConfigurationChange = (value: string | null) => {
+    if (!value || !isRawJsonConfigurationKey(value) || value === selectedKey) {
+      return
+    }
+    if (dirty) {
+      setPendingReplacement({ kind: 'configuration', key: value })
+      return
+    }
+    setSelectedKey(value)
+  }
+
+  const confirmPendingReplacement = () => {
+    if (!pendingReplacement) return
+
+    if (pendingReplacement.kind === 'configuration') {
+      setSelectedKey(pendingReplacement.key)
+    } else {
+      replaceEditorValue(pendingReplacement.value)
+    }
+    setPendingReplacement(null)
+  }
 
   const validate = async () => {
     if (!selectedKey || !editorValue.trim()) {
-      setValidationMessage(t('A JSON value is required.'))
+      setValidationFeedback({
+        kind: 'error',
+        message: t('A JSON value is required.'),
+      })
       return false
     }
     try {
       JSON.parse(editorValue)
     } catch {
-      setValidationMessage(t('Invalid JSON. Please fix the syntax first.'))
+      setValidationFeedback({
+        kind: 'error',
+        message: t('Invalid JSON. Please fix the syntax first.'),
+      })
       return false
     }
     setIsValidating(true)
@@ -204,17 +292,25 @@ export function RawJsonConfigurationSection() {
         [selectedKey]: editorValue,
       })
       if (!response.success) {
-        setValidationMessage(response.message || t('Configuration is invalid.'))
+        setValidationFeedback({
+          kind: 'error',
+          message: response.message || t('Configuration is invalid.'),
+        })
         return false
       }
-      setValidationMessage(t('Configuration validated.'))
+      setValidationFeedback({
+        kind: 'success',
+        message: t('Configuration validated.'),
+      })
       return true
     } catch (error) {
-      setValidationMessage(
-        error instanceof Error
-          ? error.message
-          : t('Configuration check failed.')
-      )
+      setValidationFeedback({
+        kind: 'error',
+        message:
+          error instanceof Error
+            ? error.message
+            : t('Configuration check failed.'),
+      })
       return false
     } finally {
       setIsValidating(false)
@@ -247,14 +343,38 @@ export function RawJsonConfigurationSection() {
     const file = event.target.files?.[0]
     event.target.value = ''
     if (!file) return
-    void file.text().then((text) => {
-      try {
-        setEditorValue(parseImport(text))
-        setValidationMessage(null)
-      } catch {
-        setValidationMessage(t('The imported file is not valid JSON.'))
-      }
-    })
+
+    void file
+      .text()
+      .then((text) => {
+        try {
+          const importedValue = parseImport(text)
+          if (
+            hasUnsavedJsonDraft(
+              editorValueRef.current,
+              baselineValueRef.current
+            )
+          ) {
+            setPendingReplacement({ kind: 'import', value: importedValue })
+            return
+          }
+          replaceEditorValue(importedValue)
+        } catch {
+          setValidationFeedback({
+            kind: 'error',
+            message: t('The imported file is not valid JSON.'),
+          })
+        }
+      })
+      .catch((error: unknown) => {
+        setValidationFeedback({
+          kind: 'error',
+          message:
+            error instanceof Error
+              ? error.message
+              : t('Configuration check failed.'),
+        })
+      })
   }
 
   const askAssistant = () => {
@@ -265,36 +385,83 @@ export function RawJsonConfigurationSection() {
     )
   }
 
-  const dirty = editorValue !== baselineValue
-
   return (
     <SettingsSection title={t('Raw JSON Configuration')}>
+      <FormNavigationGuard when={dirty} />
+      <ConfirmDialog
+        open={Boolean(pendingReplacement)}
+        onOpenChange={(open) => {
+          if (!open) setPendingReplacement(null)
+        }}
+        title={t('Discard unsaved JSON changes?')}
+        desc={t(
+          'Continuing will replace the unsaved JSON currently in the editor.'
+        )}
+        confirmText={t('Replace')}
+        destructive
+        handleConfirm={confirmPendingReplacement}
+      />
       <div className='space-y-4'>
-        <p className='text-muted-foreground text-sm'>
+        <p
+          id='raw-json-configuration-description'
+          className='text-muted-foreground text-sm'
+        >
           {t(
             'Edit one safe-listed JSON setting at a time. Imports are checked locally and by the server before any write.'
           )}
         </p>
+        {optionsQuery.isError && (
+          <Alert variant='destructive'>
+            <AlertCircle />
+            <AlertTitle>{t('Failed to load')}</AlertTitle>
+            <AlertDescription>
+              {optionsQuery.error instanceof Error
+                ? optionsQuery.error.message
+                : t('Configuration check failed.')}
+            </AlertDescription>
+            <AlertAction>
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                onClick={() => void optionsQuery.refetch()}
+                disabled={optionsQuery.isFetching}
+              >
+                <RefreshCw
+                  className={optionsQuery.isFetching ? 'animate-spin' : ''}
+                  aria-hidden='true'
+                />
+                {t('Retry')}
+              </Button>
+            </AlertAction>
+          </Alert>
+        )}
         <div className='flex flex-wrap items-end gap-3'>
-          <div className='min-w-56 flex-1 space-y-2'>
-            <Label>{t('Configuration key')}</Label>
+          <div className='min-w-0 flex-1 basis-full space-y-2 sm:basis-64'>
+            <Label htmlFor='raw-json-configuration-key'>
+              {t('Configuration key')}
+            </Label>
             <Select
+              items={selectItems}
               value={selectedKey}
-              onValueChange={(value) => {
-                if (value && isRawJsonConfigurationKey(value)) {
-                  setSelectedKey(value)
-                }
-              }}
+              onValueChange={requestConfigurationChange}
+              disabled={controlsDisabled || availableDescriptors.length === 0}
             >
-              <SelectTrigger>
+              <SelectTrigger
+                id='raw-json-configuration-key'
+                aria-describedby='raw-json-configuration-description'
+                className='w-full max-w-full'
+              >
                 <SelectValue placeholder={t('Select')} />
               </SelectTrigger>
-              <SelectContent>
-                {availableDescriptors.map((item) => (
-                  <SelectItem key={item.key} value={item.key}>
-                    {t(item.label)} · {item.key}
-                  </SelectItem>
-                ))}
+              <SelectContent alignItemWithTrigger={false}>
+                <SelectGroup>
+                  {availableDescriptors.map((item) => (
+                    <SelectItem key={item.key} value={item.key}>
+                      {t(item.label)} · {item.key}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
               </SelectContent>
             </Select>
           </div>
@@ -309,6 +476,7 @@ export function RawJsonConfigurationSection() {
             type='button'
             variant='outline'
             onClick={() => fileInputRef.current?.click()}
+            disabled={controlsDisabled}
           >
             <FileUp data-icon='inline-start' />
             {t('Import JSON')}
@@ -322,7 +490,12 @@ export function RawJsonConfigurationSection() {
             <Download data-icon='inline-start' />
             {t('Export JSON')}
           </Button>
-          <Button type='button' variant='outline' onClick={askAssistant}>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={askAssistant}
+            disabled={isBusy}
+          >
             <Sparkles data-icon='inline-start' />
             {t('Ask AI to edit')}
           </Button>
@@ -331,25 +504,24 @@ export function RawJsonConfigurationSection() {
           configurationKey={selectedKey}
           specificationDefaultOpen
           value={editorValue}
-          onChange={(value) => {
-            setEditorValue(value)
-            setValidationMessage(null)
-          }}
-          disabled={optionsQuery.isLoading || !descriptor}
-          heightClassName='h-[28rem] min-h-[28rem] max-h-[28rem]'
-          ariaLabel={t('JSON')}
+          onChange={replaceEditorValue}
+          disabled={controlsDisabled}
+          heightClassName='h-80 min-h-80 max-h-80 sm:h-[28rem] sm:min-h-[28rem] sm:max-h-[28rem]'
+          ariaLabel={`${t('JSON')} — ${descriptor ? t(descriptor.label) : selectedKey}`}
         />
-        {validationMessage && (
+        {validationFeedback && (
           <Alert
             variant={
-              validationMessage === t('Configuration validated.')
-                ? 'default'
-                : 'destructive'
+              validationFeedback.kind === 'success' ? 'default' : 'destructive'
             }
           >
-            <RefreshCw />
+            {validationFeedback.kind === 'success' ? (
+              <CheckCircle2 />
+            ) : (
+              <AlertCircle />
+            )}
             <AlertTitle>{t('Configuration check')}</AlertTitle>
-            <AlertDescription>{validationMessage}</AlertDescription>
+            <AlertDescription>{validationFeedback.message}</AlertDescription>
           </Alert>
         )}
         <SettingsPageActionsPortal>
@@ -357,14 +529,14 @@ export function RawJsonConfigurationSection() {
             type='button'
             variant='outline'
             onClick={() => void validate()}
-            disabled={isValidating || isSaving || !dirty}
+            disabled={controlsDisabled || !dirty}
           >
             {isValidating ? t('Checking...') : t('Validate configuration')}
           </Button>
           <Button
             type='button'
             onClick={() => void save()}
-            disabled={isValidating || isSaving || !dirty}
+            disabled={controlsDisabled || !dirty}
           >
             {isSaving ? t('Saving...') : t('Save Changes')}
           </Button>

--- a/apps/web/src/features/system-settings/operations/raw-json-draft-state.ts
+++ b/apps/web/src/features/system-settings/operations/raw-json-draft-state.ts
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2025 LIghtJUNction
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+export function hasUnsavedJsonDraft(
+  editorValue: string,
+  baselineValue: string
+): boolean {
+  return editorValue !== baselineValue
+}
+
+export function shouldApplyRawJsonServerValue({
+  loadedKey,
+  selectedKey,
+  editorValue,
+  baselineValue,
+}: {
+  loadedKey: string | null
+  selectedKey: string
+  editorValue: string
+  baselineValue: string
+}): boolean {
+  return (
+    loadedKey !== selectedKey ||
+    !hasUnsavedJsonDraft(editorValue, baselineValue)
+  )
+}

--- a/apps/web/src/i18n/locales/en.json
+++ b/apps/web/src/i18n/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "Continuing will replace the unsaved JSON currently in the editor.": "Continuing will replace the unsaved JSON currently in the editor.",
+  "Discard unsaved JSON changes?": "Discard unsaved JSON changes?",
   "translation": {
     "360": "360",
     "1000": "1000",

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -1,4 +1,6 @@
 {
+  "Continuing will replace the unsaved JSON currently in the editor.": "Si vous continuez, le JSON non enregistré dans l’éditeur sera remplacé.",
+  "Discard unsaved JSON changes?": "Abandonner les modifications JSON non enregistrées ?",
   "translation": {
     "360": "360",
     "1000": "1000",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -1,4 +1,6 @@
 {
+  "Continuing will replace the unsaved JSON currently in the editor.": "続行すると、エディター内の未保存の JSON が置き換えられます。",
+  "Discard unsaved JSON changes?": "未保存の JSON 変更を破棄しますか？",
   "translation": {
     "360": "360",
     "1000": "1000",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -1,4 +1,6 @@
 {
+  "Continuing will replace the unsaved JSON currently in the editor.": "Если продолжить, несохранённый JSON в редакторе будет заменён.",
+  "Discard unsaved JSON changes?": "Отменить несохранённые изменения JSON?",
   "translation": {
     "360": "360",
     "1000": "1000",

--- a/apps/web/src/i18n/locales/vi.json
+++ b/apps/web/src/i18n/locales/vi.json
@@ -1,4 +1,6 @@
 {
+  "Continuing will replace the unsaved JSON currently in the editor.": "Nếu tiếp tục, JSON chưa lưu trong trình soạn thảo sẽ bị thay thế.",
+  "Discard unsaved JSON changes?": "Hủy các thay đổi JSON chưa lưu?",
   "translation": {
     "360": "360",
     "1000": "1000",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -1,4 +1,6 @@
 {
+  "Continuing will replace the unsaved JSON currently in the editor.": "繼續操作將取代編輯器中尚未儲存的 JSON。",
+  "Discard unsaved JSON changes?": "放棄尚未儲存的 JSON 變更？",
   "translation": {
     "360": "360",
     "1000": "1000",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -1,4 +1,6 @@
 {
+  "Continuing will replace the unsaved JSON currently in the editor.": "继续操作将替换编辑器中尚未保存的 JSON。",
+  "Discard unsaved JSON changes?": "放弃未保存的 JSON 更改？",
   "translation": {
     "360": "360",
     "1000": "1000",


### PR DESCRIPTION
## Summary
- add reusable JSON field specifications and safe fill/copy examples
- add raw JSON import/export/validation with dirty-draft protection
- complete new UI copy across all seven supported locales

## Verification
- `bun test --timeout 15000 src/components/json-code-editor/__tests__/json-code-editor.test.tsx src/features/system-settings/operations/__tests__/raw-json-draft-state.test.ts` (9 passed)
- `bun run typecheck`
- `bun run format:check`
- `bun run copyright:check`
- `bun run lint` (existing project warnings only)
- `bun run build:check`
- focused LSP diagnostics: clean

This PR is independent of the go-v0.1.59 T0 production promotion and must not be folded into or deployed as that immutable backend release.