### PR TITLE
fix(web): translate 2FA verification prompt in zh, zh-TW, ja, ru, vi, fr

### DIFF
--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -4859,7 +4859,7 @@
     "Playground experiments and live conversations.": "Expériences Playground et conversations en direct.",
     "Please agree to the legal terms first": "Veuillez accepter les conditions légales d'abord",
     "Please bind an email or set up a Passkey before proceeding": "Associez un e-mail ou configurez une Passkey avant de continuer",
-    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Please bind an email, enable 2FA, or set up a Passkey before proceeding",
+    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Associez un e-mail, activez 2FA ou configurez une Passkey avant de continuer",
     "Please complete the security check to continue.": "Veuillez compléter la vérification de sécurité pour continuer.",
     "Please confirm that you understand the consequences": "Veuillez confirmer que vous comprenez les conséquences",
     "Please confirm your password": "Veuillez confirmer votre mot de passe",

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -4859,7 +4859,7 @@
     "Playground experiments and live conversations.": "Playgroundの実験とライブ会話。",
     "Please agree to the legal terms first": "先に利用規約に同意してください",
     "Please bind an email or set up a Passkey before proceeding": "メールアドレスを紐付けるか、Passkeyを設定してから続行してください",
-    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Please bind an email, enable 2FA, or set up a Passkey before proceeding",
+    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "メールアドレスを紐付けるか、2FAを有効にするか、Passkeyを設定してから続行してください",
     "Please complete the security check to continue.": "続行するにはセキュリティチェックを完了してください。",
     "Please confirm that you understand the consequences": "結果を理解したことを確認してください",
     "Please confirm your password": "パスワードを確認してください",

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -4859,7 +4859,7 @@
     "Playground experiments and live conversations.": "Эксперименты в песочнице и живые беседы.",
     "Please agree to the legal terms first": "Сначала согласитесь с юридическими условиями",
     "Please bind an email or set up a Passkey before proceeding": "Привяжите электронную почту или настройте Passkey, прежде чем продолжить",
-    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Please bind an email, enable 2FA, or set up a Passkey before proceeding",
+    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Привяжите электронную почту, включите двухфакторную аутентификацию или настройте Passkey, прежде чем продолжить",
     "Please complete the security check to continue.": "Пожалуйста, завершите проверку безопасности, чтобы продолжить.",
     "Please confirm that you understand the consequences": "Пожалуйста, подтвердите, что понимаете последствия",
     "Please confirm your password": "Пожалуйста, подтвердите пароль",

--- a/apps/web/src/i18n/locales/vi.json
+++ b/apps/web/src/i18n/locales/vi.json
@@ -4859,7 +4859,7 @@
     "Playground experiments and live conversations.": "Các thí nghiệm Playground và trò chuyện trực tiếp.",
     "Please agree to the legal terms first": "Vui lòng đồng ý với các điều khoản pháp lý trước",
     "Please bind an email or set up a Passkey before proceeding": "Hãy liên kết email hoặc thiết lập Passkey trước khi tiếp tục",
-    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Please bind an email, enable 2FA, or set up a Passkey before proceeding",
+    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Hãy liên kết email, bật 2FA hoặc thiết lập Passkey trước khi tiếp tục",
     "Please complete the security check to continue.": "Vui lòng hoàn thành kiểm tra bảo mật để tiếp tục.",
     "Please confirm that you understand the consequences": "Vui lòng xác nhận rằng bạn hiểu hậu quả",
     "Please confirm your password": "Vui lòng xác nhận mật khẩu",

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -4859,7 +4859,7 @@
     "Playground experiments and live conversations.": "Playground 實驗和實時對話。",
     "Please agree to the legal terms first": "請先同意法律條款",
     "Please bind an email or set up a Passkey before proceeding": "請綁定電子郵件或設定 Passkey 後繼續",
-    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Please bind an email, enable 2FA, or set up a Passkey before proceeding",
+    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "請綁定電子郵件、啟用雙重驗證或設定 Passkey 後繼續",
     "Please complete the security check to continue.": "請完成安全驗證以繼續。",
     "Please confirm that you understand the consequences": "請確認您了解後果",
     "Please confirm your password": "請確認密碼",

--- a/apps/web/src/i18n/locales/zh.json
+++ b/apps/web/src/i18n/locales/zh.json
@@ -4859,7 +4859,7 @@
     "Playground experiments and live conversations.": "Playground 实验和实时对话。",
     "Please agree to the legal terms first": "请先同意法律条款",
     "Please bind an email or set up a Passkey before proceeding": "请绑定邮箱或设置 Passkey 后继续",
-    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "Please bind an email, enable 2FA, or set up a Passkey before proceeding",
+    "Please bind an email, enable 2FA, or set up a Passkey before proceeding": "请绑定邮箱、启用双重认证或设置 Passkey 后继续",
     "Please complete the security check to continue.": "请完成安全验证以继续。",
     "Please confirm that you understand the consequences": "请确认您了解后果",
     "Please confirm your password": "请确认密码",


### PR DESCRIPTION
## Summary

Fixes #154.

A single i18n key was untranslated in all 6 non-English locale files (`zh.json`, `zh-TW.json`, `ja.json`, `ru.json`, `vi.json`, `fr.json`). The toast that fires when a user has no email, 2FA, or Passkey configured showed English text to non-English-speaking users.

## Change

6 files, 1 line each — replaced the English placeholder value with the correct translation. No reconstruction, no refactor.

## Verification

- All 6 locale files parse as valid JSON
- All i18n tests pass: `bun test src/i18n` → 6 pass, 0 fail
- The sibling key `"Please bind an email or set up a Passkey before proceeding"` (already correctly translated) confirms the expected phrasing conventions for each locale

## Verification of not-a-duplicate

- No open issues or PRs report this string (checked via GitHub API before opening #154)

## Sourcery 摘要

错误修复：
- 在法语、日语、俄语、越南语、简体中文和繁体中文语言环境中翻译 2FA 验证提示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Translate the 2FA verification prompt in the French, Japanese, Russian, Vietnamese, Simplified Chinese, and Traditional Chinese locales.

</details>