### PR TITLE
test(go): close leaked sqlite handle in advanced security options test (fixes Windows-only failure)

### DIFF
--- a/apps/api-go/model/option_advanced_security_test.go
+++ b/apps/api-go/model/option_advanced_security_test.go
@@ -29,6 +29,10 @@ func TestUpdateAdvancedSecurityOptionsPersistsAndAppliesAsUnit(t *testing.T) {
 	common.OptionMapRWMutex.Unlock()
 	t.Cleanup(func() {
 		DB = originalDB
+		sqlDB, err := database.DB()
+		if err == nil {
+			_ = sqlDB.Close()
+		}
 		_ = setting.ApplyAdvancedSecuritySettings(
 			originalSettings.Enabled,
 			originalSettings.OnPrompt,


### PR DESCRIPTION
## What / 改动

Close the leaked `*sql.DB` handle in `TestUpdateAdvancedSecurityOptionsPersistsAndAppliesAsUnit` by closing it inside the existing `t.Cleanup`, exactly like the sibling `TestUpdateOptionReturnsDatabaseErrors` and the other model tests (`console_activation_test.go`, `gift_test.go`, `cache_snapshot_test.go`).

Fixes #156

## Why / 原因

The test opens a GORM SQLite database in `t.TempDir()` but never closes it. On Windows, `t.TempDir()` cleanup runs `RemoveAll` while the SQLite file handle is still open, so the test **always fails on Windows** even though every assertion passes:

```
--- FAIL: TestUpdateAdvancedSecurityOptionsPersistsAndAppliesAsUnit (1.48s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat C:\Users\<user>\AppData\Local\Temp\...\options.db:
    The process cannot access the file because it is being used by another process.
```

Reproduction: `cd apps/api-go && go test ./model/ -run "TestUpdateAdvancedSecurityOptionsPersistsAndAppliesAsUnit" -count=1 -v` on Windows → FAIL before this PR, PASS after. See #156 for full details (reproduction steps, expected vs actual, affected area, impact).

## Verification / 验证

- Windows 11, go1.26.5:
  - Before: `go test ./model/ -run "TestUpdateAdvancedSecurityOptionsPersistsAndAppliesAsUnit" -count=1 -v` → FAIL (unlinkat error), reproduced with `-count=2` and in full package run.
  - After: same command → `--- PASS` (3/3 runs with `-count=3`).
  - Full package regression: `go test ./model/ -count=1` → `ok github.com/LIghtJUNction/api.lmm.best/model` (previously FAIL).
- No product code touched: the diff only adds the handle close inside the test's `t.Cleanup`.

## Scope / 范围

Single-file, 4-line addition to `apps/api-go/model/option_advanced_security_test.go`; no functional changes.

## Sourcery 总结

确保高级安全选项测试在删除临时文件前释放其 SQLite 句柄。

错误修复：
- 在高级安全选项测试清理过程中关闭 SQLite 数据库句柄，以防止 Windows 特有的临时目录清理失败。

测试：
- 修复模型测试的资源清理问题，使其在 Windows 上以及完整软件包运行期间都能可靠通过。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure the advanced security options test releases its SQLite handle before temporary files are removed.

Bug Fixes:
- Close the SQLite database handle during advanced security options test cleanup to prevent Windows-specific temporary-directory cleanup failures.

Tests:
- Fix the model test’s resource cleanup so it passes reliably on Windows and during full package runs.

</details>