### PR TITLE
fix(open-source-bounties): validate ownership before minting MCP confirmations

### DIFF
--- a/apps/api-go/controller/open_source_bounty_mcp_confirmation_order_test.go
+++ b/apps/api-go/controller/open_source_bounty_mcp_confirmation_order_test.go
@@ -1,0 +1,135 @@
+package controller
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/LIghtJUNction/api.lmm.best/common"
+	"github.com/LIghtJUNction/api.lmm.best/model"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenSourceBountyMCPConfirmationOnlyAfterOwnershipCheck proves that
+// ownership-scoped confirmed tools reject an unrelated caller BEFORE minting a
+// confirmation: no confirmation row may appear and no confirmation form may be
+// returned, while the legitimate owner keeps the normal confirmation flow.
+func TestOpenSourceBountyMCPConfirmationOnlyAfterOwnershipCheck(t *testing.T) {
+	db, user, token := setupOpenSourceBountyMCPControllerTest(t)
+
+	// The contributor who accepts the challenge.
+	participant := model.User{Username: "mcp-participant", Password: "password", AffCode: "mcp-participant", Quota: 0, Role: common.RoleCommonUser, Status: common.UserStatusEnabled}
+	require.NoError(t, db.Create(&participant).Error)
+
+	// An unrelated L1 user: owns nothing, participates in nothing, but holds a
+	// valid developer-access MCP token and can reach the tools directly.
+	levelOne := model.TrustLevelMinUser + 1
+	outsider := model.User{Username: "mcp-outsider", Password: "password", AffCode: "mcp-outsider", Quota: 0, Role: common.RoleCommonUser, Status: common.UserStatusEnabled, TrustLevelOverride: &levelOne}
+	require.NoError(t, db.Create(&outsider).Error)
+
+	project, err := model.CreateOpenSourceBountyDraft(user.Id, model.OpenSourceBountyDraftInput{
+		RepositoryUrl: "https://github.com/example/mcp-confirmation-order", Title: "MCP confirmation ordering",
+		Description: "Confirmation must be minted only after ownership is established.",
+		Rules:       "The Issue must include reproduction, expected behavior, actual behavior, impact, and the linked pull request must include verification.",
+		RewardQuota: 200, RewardSlots: 1,
+	})
+	require.NoError(t, err)
+	// Publish the draft through the real funding path so the challenge
+	// lifecycle below (accept -> submit -> review) stays realistic.
+	publishedProject, _, err := model.PublishOpenSourceBounty(user.Id, project.Id)
+	require.NoError(t, err)
+
+	challenge, err := model.AcceptOpenSourceBounty(participant.Id, publishedProject.Id, "mcp-participant")
+	require.NoError(t, err)
+
+	server := httptest.NewServer(NewOpenSourceBountyMCPHandler())
+	t.Cleanup(server.Close)
+
+	ctx := context.Background()
+	outsideToken, _, err := model.RotateOpenSourceBountyMCPToken(outsider.Id)
+	require.NoError(t, err)
+	outsideClient := mcp.NewClient(&mcp.Implementation{Name: "mcp-outside-client", Version: "1.0.0"}, &mcp.ClientOptions{
+		MultiRoundTrip: &mcp.MultiRoundTripOptions{Disabled: true},
+	})
+	outsideSession, err := outsideClient.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:             server.URL,
+		HTTPClient:           &http.Client{Transport: openSourceBountyBearerTransport{token: outsideToken}},
+		DisableStandaloneSSE: true,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = outsideSession.Close() })
+
+	ownerClient := mcp.NewClient(&mcp.Implementation{Name: "mcp-owner-client", Version: "1.0.0"}, &mcp.ClientOptions{
+		MultiRoundTrip: &mcp.MultiRoundTripOptions{Disabled: true},
+	})
+	ownerSession, err := ownerClient.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:             server.URL,
+		HTTPClient:           &http.Client{Transport: openSourceBountyBearerTransport{token: token}},
+		DisableStandaloneSSE: true,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ownerSession.Close() })
+
+	// Submit the challenge so reject/rate/withdraw all see a realistic state.
+	challenge, err = model.SubmitOpenSourceBountyChallenge(participant.Id, publishedProject.Id,
+		"https://github.com/example/mcp-confirmation-order/issues/1",
+		"https://github.com/example/mcp-confirmation-order/pull/2",
+		"Confirmation ordering verification.")
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name      string
+		tool      string
+		arguments map[string]any
+	}{
+		{
+			name:      "reject",
+			tool:      "open_source_bounties.reject",
+			arguments: map[string]any{"challenge_id": challenge.Id, "review_note": "rejecting outsider test", "rating_score": 1, "rating_comment": "does not reproduce"},
+		},
+		{
+			name:      "withdraw",
+			tool:      "open_source_bounties.withdraw",
+			arguments: map[string]any{"challenge_id": challenge.Id},
+		},
+		{
+			name:      "rate_owner",
+			tool:      "open_source_bounties.rate_owner",
+			arguments: map[string]any{"challenge_id": challenge.Id, "score": 5, "comment": "good publisher"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := outsideSession.CallTool(ctx, &mcp.CallToolParams{Name: tc.tool, Arguments: tc.arguments})
+			require.NoError(t, err)
+			assert.False(t, result.NeedsInput(), "the unrelated caller must not receive a confirmation form")
+			assert.True(t, result.IsError, "the unrelated caller must be rejected before confirmation")
+
+			var confirmations int64
+			require.NoError(t, db.Model(&model.OpenSourceBountyMCPConfirmation{}).
+				Where("user_id = ?", outsider.Id).Count(&confirmations).Error)
+			assert.Zero(t, confirmations, "no confirmation row may be minted for the unrelated caller")
+		})
+	}
+
+	// The legitimate challenge state is unchanged by the rejected outsider.
+	var untouched model.OpenSourceBountyChallenge
+	require.NoError(t, db.First(&untouched, challenge.Id).Error)
+	assert.Equal(t, model.OpenSourceBountyChallengeSubmitted, untouched.Status)
+
+	// The actual owner still gets the normal confirmation flow for reject.
+	ownerResult, err := ownerSession.CallTool(ctx, &mcp.CallToolParams{Name: "open_source_bounties.reject", Arguments: map[string]any{
+		"challenge_id": challenge.Id, "review_note": "not accepted", "rating_score": 2, "rating_comment": "not a fix",
+	}})
+	require.NoError(t, err)
+	require.True(t, ownerResult.NeedsInput(), "the project owner must still receive the confirmation form")
+	require.NotEmpty(t, ownerResult.RequestState)
+
+	// The owner's legitimate confirmation row exists exactly once.
+	var ownerConfirmations int64
+	require.NoError(t, db.Model(&model.OpenSourceBountyMCPConfirmation{}).
+		Where("user_id = ? AND tool_name = ?", user.Id, "open_source_bounties.reject").Count(&ownerConfirmations).Error)
+	assert.Equal(t, int64(1), ownerConfirmations, "the owner's confirmable action mints exactly one confirmation row")
+}

--- a/apps/api-go/controller/open_source_bounty_mcp_server.go
+++ b/apps/api-go/controller/open_source_bounty_mcp_server.go
@@ -487,6 +487,15 @@ func registerOpenSourceBountyMCPTools(server *mcp.Server) {
 				err := model.DB.First(&challenge, int(challengeId)).Error
 				return nil, bountyMCPOutput{Message: "Publisher/verifier rating already saved.", Data: &challenge}, bountyMCPError(err)
 			}
+			var participantProof struct {
+				Id int `json:"id"`
+			}
+			if err := model.DB.Table("open_source_bounty_challenges AS challenge").
+				Select("challenge.id").
+				Where("challenge.id = ? AND challenge.participant_user_id = ?", input.ChallengeId, userId).
+				Scan(&participantProof).Error; err != nil || participantProof.Id == 0 {
+				return nil, bountyMCPOutput{}, bountyMCPError(&model.OpenSourceBountyError{Code: "OPEN_SOURCE_BOUNTY_FORBIDDEN", Message: "challenge is unavailable"})
+			}
 			message := fmt.Sprintf("Publish your %d/5 rating for the publisher/verifier of challenge %d? This rating and comment will be visible to both sides.", input.Score, input.ChallengeId)
 			pending, operation, err := bountyMCPConfirmedOperation(request, userId, "open_source_bounties.rate_owner", input, message)
 			if err != nil || pending != nil {
@@ -509,6 +518,16 @@ func registerOpenSourceBountyMCPTools(server *mcp.Server) {
 				var challenge model.OpenSourceBountyChallenge
 				err := model.DB.First(&challenge, int(challengeId)).Error
 				return nil, bountyMCPOutput{Message: "Submission rejection and contributor rating already saved.", Data: &challenge}, bountyMCPError(err)
+			}
+			var ownerProof struct {
+				Id int `json:"id"`
+			}
+			if err := model.DB.Table("open_source_bounty_challenges AS challenge").
+				Joins("JOIN open_source_bounty_projects project ON project.id = challenge.project_id AND project.owner_user_id = ?", userId).
+				Where("challenge.id = ?", input.ChallengeId).
+				Select("challenge.id").
+				Scan(&ownerProof).Error; err != nil || ownerProof.Id == 0 {
+				return nil, bountyMCPOutput{}, bountyMCPError(&model.OpenSourceBountyError{Code: "OPEN_SOURCE_BOUNTY_FORBIDDEN", Message: "challenge is unavailable"})
 			}
 			message := fmt.Sprintf("Reject challenge %d, publicly rate the contributor %d/5, and release the reward slot?", input.ChallengeId, input.RatingScore)
 			pending, operation, err := bountyMCPConfirmedOperation(request, userId, "open_source_bounties.reject", input, message)
@@ -633,6 +652,15 @@ func registerOpenSourceBountyMCPTools(server *mcp.Server) {
 				var challenge model.OpenSourceBountyChallenge
 				err := model.DB.First(&challenge, int(challengeId)).Error
 				return nil, bountyMCPOutput{Message: "Challenge withdrawal already completed.", Data: &challenge}, bountyMCPError(err)
+			}
+			var participantProof struct {
+				Id int `json:"id"`
+			}
+			if err := model.DB.Table("open_source_bounty_challenges AS challenge").
+				Select("challenge.id").
+				Where("challenge.id = ? AND challenge.participant_user_id = ?", input.ChallengeId, userId).
+				Scan(&participantProof).Error; err != nil || participantProof.Id == 0 {
+				return nil, bountyMCPOutput{}, bountyMCPError(&model.OpenSourceBountyError{Code: "OPEN_SOURCE_BOUNTY_FORBIDDEN", Message: "challenge is unavailable"})
 			}
 			pending, operation, err := bountyMCPConfirmedOperation(request, userId, "open_source_bounties.withdraw", input, fmt.Sprintf("Withdraw from challenge %d and release its reward slot?", input.ChallengeId))
 			if err != nil || pending != nil {


### PR DESCRIPTION
## What / 改动

在 `open_source_bounty_mcp_server.go` 中，将 rate_owner / reject / withdraw 三个工具的确认铸造（mint confirmation）移到所有权校验之后：先 JOIN 校验当前用户是否持有该 bounty 的所有权，校验失败直接返回 `OPEN_SOURCE_BOUNTY_FORBIDDEN`（fail-closed），不再先铸造确认再查所有权。

新增回归测试 `TestOpenSourceBountyMCPConfirmationOnlyAfterOwnershipCheck`（`open_source_bounty_mcp_confirmation_order_test.go`），表驱动覆盖三处工具的越权场景，并验证合法 owner 仍走正常确认流程。

## Why / 原因

原实现的顺序是先铸造确认、后校验所有权，导致非所有权调用方也能触发确认铸造，形成越权通道。此 PR 将校验前置并关闭失败路径。

## Verification / 验证

- Windows 11, go1.26.5:
  - `go test ./controller/ -run 'TestOpenSourceBountyMCPConfirmationOnlyAfterOwnershipCheck' -count=1` → `ok`（10.9s）
- 改动仅新增代码：控制器 +28 行（3 处 hunk 均为 mint 前的所有权校验），新测试文件 +135 行；无既有逻辑改动。

## Scope / 范围

单包改动：`apps/api-go/controller/open_source_bounty_mcp_server.go` + 新增测试文件，不影响其他路由或数据表。

Closes #158

## Sourcery 摘要

在为受保护的操作铸造 MCP 确认之前，强制验证开源赏金的所有权。

错误修复：
- 通过先执行所有权检查并返回故障安全的禁止错误，防止未经授权的用户为开源赏金的评级、拒绝和提取操作铸造 MCP 确认。

测试：
- 添加回归测试，确认未经授权的调用不会创建任何确认记录，同时合法所有者仍保留正常的确认流程。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在为受保护的开源赏金操作生成 MCP 确认之前，验证挑战所有权。

错误修复：
- 通过先执行所有权检查并返回默认拒绝的禁止错误，防止未经授权的用户为开源赏金的评级、拒绝和提取操作生成 MCP 确认。

测试：
- 添加回归测试，验证未经授权的调用不会创建任何确认记录，同时合法所有者仍可正常完成确认流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate challenge ownership before minting MCP confirmations for protected open-source bounty operations.

Bug Fixes:
- Prevent unauthorized users from minting MCP confirmations for open-source bounty rating, rejection, and withdrawal operations by enforcing ownership checks first and returning a fail-closed forbidden error.

Tests:
- Add regression coverage verifying unauthorized calls create no confirmation records while legitimate owners retain the normal confirmation flow.

</details>

</details>