### PR TITLE
fix(format): normalize mjs checkouts to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 # JavaScript/TypeScript files
 *.js text eol=lf
 *.jsx text eol=lf
+*.mjs text eol=lf
 *.ts text eol=lf
 *.tsx text eol=lf
 *.html text eol=lf


### PR DESCRIPTION
# LMM API Pull Request

## 变更说明 / Summary

- Add the missing `*.mjs text eol=lf` rule alongside the existing JavaScript and TypeScript rules.
- Keep Web `.mjs` scripts aligned with the formatter's explicit `endOfLine: "lf"` configuration.
- Prevent fresh Windows checkouts with `core.autocrlf=true` from turning tracked LF `.mjs` files into CRLF and failing `format:check` despite no source change.

Compatibility note: Git does not rewrite unchanged tracked files when only attributes change. Existing Windows worktrees that already contain CRLF `.mjs` files need those tracked files refreshed after preserving any local edits; fresh clones and worktrees use LF automatically.

## 与上游的关系 / Upstream relationship

- [ ] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [x] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A

## 关联 Issue / Related issue

N/A. The failure was reproduced locally, and repository-wide searches for CRLF, line-ending, Windows-format, and `.mjs` formatting work found no duplicate issue or pull request.

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [x] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

Baseline (`28b66973`, fresh Windows worktree, `core.autocrlf=true`):

```text
git ls-files --eol -- apps/web/scripts/add-copyright.mjs
i/lf w/crlf attr/text=auto

oxfmt --check apps/web/scripts/add-copyright.mjs
exit 1
```

Fixed commit (`1857b9ba`, fresh Windows worktree, same Git and dependency configuration):

```text
git ls-files --eol -- apps/web/scripts/add-copyright.mjs
i/lf w/lf attr/text eol=lf

bunx bun@1.3.14 run --filter @lmm/web format:check
passed (1,334 files)

bunx bun@1.3.14 run --filter @lmm/web copyright:check
passed (1,310 checked; added 0; updated 0)

bunx bun@1.3.14 run --filter @lmm/web lint
passed

bunx bun@1.3.14 run --filter @lmm/web typecheck
passed

bunx bun@1.3.14 run --filter @lmm/web test
passed (199 files)

bunx bun@1.3.14 run --filter @lmm/web build
passed

bunx bun@1.3.14 run --filter @lmm/web bundle:check
passed (765,567 / 786,432 gzip bytes)
```

No source-level regression test was added because the behavior occurs while Git materializes a checkout, before application code or the Web test runner executes. The before/after fresh-worktree commands above exercise that boundary directly.

## 截图或日志 / Screenshots or logs

N/A; repository checkout and formatting behavior only.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Sourcery 摘要

将 `.mjs` 检出时的行尾规范化为 LF，以防止 Windows 工作树无法通过格式检查。

错误修复：
- 确保已跟踪的 `.mjs` 文件以 LF 行尾检出，从而保证 Windows 上的格式检查保持一致。

构建：
- 为 `.mjs` 文件添加 Git 属性，以强制使用 LF 行尾。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize `.mjs` checkout line endings to LF to prevent Windows worktrees from failing formatting checks.

Bug Fixes:
- Ensure tracked `.mjs` files are checked out with LF line endings so formatting checks remain consistent on Windows.

Build:
- Add Git attributes for `.mjs` files to enforce LF line endings.

</details>