### PR TITLE
fix(go): restrict private IP detection to RFC1918

### DIFF
--- a/apps/api-go/common/utils.go
+++ b/apps/api-go/common/utils.go
@@ -49,18 +49,9 @@ func GetIp() (ip string) {
 
 	for _, a := range ips {
 		if ipNet, ok := a.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
-			if ipNet.IP.To4() != nil {
+			if isPrivateIPv4(ipNet.IP) {
 				ip = ipNet.IP.String()
-				if strings.HasPrefix(ip, "10") {
-					return
-				}
-				if strings.HasPrefix(ip, "172") {
-					return
-				}
-				if strings.HasPrefix(ip, "192.168") {
-					return
-				}
-				ip = ""
+				return
 			}
 		}
 	}
@@ -77,18 +68,16 @@ func GetNetworkIps() []string {
 
 	for _, a := range ips {
 		if ipNet, ok := a.(*net.IPNet); ok && !ipNet.IP.IsLoopback() {
-			if ipNet.IP.To4() != nil {
-				ip := ipNet.IP.String()
-				// Include common private network ranges
-				if strings.HasPrefix(ip, "10.") ||
-					strings.HasPrefix(ip, "172.") ||
-					strings.HasPrefix(ip, "192.168.") {
-					networkIps = append(networkIps, ip)
-				}
+			if isPrivateIPv4(ipNet.IP) {
+				networkIps = append(networkIps, ipNet.IP.String())
 			}
 		}
 	}
 	return networkIps
+}
+
+func isPrivateIPv4(ip net.IP) bool {
+	return ip.To4() != nil && ip.IsPrivate()
 }
 
 // IsRunningInContainer detects if the application is running inside a container

--- a/apps/api-go/common/utils_ip_test.go
+++ b/apps/api-go/common/utils_ip_test.go
@@ -1,0 +1,33 @@
+package common
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsPrivateIPv4UsesRFC1918Boundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want bool
+	}{
+		{name: "ten network start", ip: "10.0.0.0", want: true},
+		{name: "ten network end", ip: "10.255.255.255", want: true},
+		{name: "carrier grade NAT", ip: "100.64.0.1", want: false},
+		{name: "before 172 private range", ip: "172.15.255.255", want: false},
+		{name: "172 private range start", ip: "172.16.0.0", want: true},
+		{name: "172 private range end", ip: "172.31.255.255", want: true},
+		{name: "after 172 private range", ip: "172.32.0.0", want: false},
+		{name: "192 private range", ip: "192.168.1.1", want: true},
+		{name: "documentation address", ip: "192.0.2.1", want: false},
+		{name: "IPv6 unique local", ip: "fd00::1", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isPrivateIPv4(net.ParseIP(test.ip)); got != test.want {
+				t.Fatalf("isPrivateIPv4(%q) = %t, want %t", test.ip, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# LMM API Pull Request

> LMM Forge 的 Go 服务保留上游兼容层。请说明本次变更对悬赏协作、交付跟踪或兼容行为的影响，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

`GetIp` and `GetNetworkIps` classified private IPv4 addresses with string prefixes. This accepted `100.*` through `109.*` in `GetIp` and the whole `172/8` range in both helpers, even though RFC1918 only reserves `10/8`, `172.16/12`, and `192.168/16`.

This change:

- shares one IPv4-only private-address predicate between both callers;
- uses Go's `net.IP.IsPrivate()` for RFC1918 boundary semantics;
- adds table-driven coverage for both edges of each private range and nearby public/CGNAT/IPv6 addresses.

The compatibility impact is limited to rejecting non-RFC1918 interface addresses from startup network URLs and `admin_info.server_ip`. Actual RFC1918 addresses remain accepted.

## 与上游的关系 / Upstream relationship

- [ ] LMM API 独有变更 / LMM API-specific change
- [x] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: The same prefix predicates are still present in [QuantumNous/new-api `common/utils.go`](https://github.com/QuantumNous/new-api/blob/2b6f1dfefbe217fed31fc0726717cc7de6958e8e/common/utils.go).

## 关联 Issue / Related issue

Closes #172

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
command: go test ./common -run TestIsPrivateIPv4UsesRFC1918Boundaries -count=1
before fix: failed for 100.64.0.1, 172.15.255.255, and 172.32.0.0
after fix: passed

command: GOMAXPROCS=2 go test ./common -count=1
result: passed

command: GOMAXPROCS=2 go vet ./...
result: passed

command: api_lmm_packages=$(go list ./... | rg -v '/internal/appcli$') &&
         GOMAXPROCS=2 go test -p 2 $api_lmm_packages
result: passed

command: GOMAXPROCS=2 go test -p 2 ./...
result: all executed packages passed except three internal/appcli release-layout tests;
        those tests could not start /usr/bin/bsdtar because this local container
        lacks libarchive-tools. The CI workflow installs that prerequisite.

command: test -z "$(gofmt -l apps/api-go/common/utils.go apps/api-go/common/utils_ip_test.go)" &&
         git diff --check
result: passed
```

## 截图或日志 / Screenshots or logs

N/A

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Sourcery 总结

修正私有 IPv4 地址检测，使其在整个网络地址报告过程中始终遵循 RFC1918 边界。

错误修复：
- 将启动时网络 URL 和服务器 IP 报告中的私有 IPv4 检测限制为 RFC1918 范围，避免接受 CGNAT、相邻的 172/8 地址以及其他非私有地址。

增强功能：
- 在两个网络地址辅助函数之间共享同一个仅适用于 IPv4 的私有地址判断谓词。

测试：
- 增加基于表格的测试覆盖 RFC1918 边界，以及附近的公网地址、CGNAT 地址和 IPv6 地址。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct private IPv4 detection to follow RFC1918 boundaries consistently across network address reporting.

Bug Fixes:
- Restrict private IPv4 detection in startup network URLs and server IP reporting to RFC1918 ranges, preventing CGNAT, adjacent 172/8 addresses, and other non-private addresses from being accepted.

Enhancements:
- Share a single IPv4-only private-address predicate across both network address helpers.

Tests:
- Add table-driven coverage for RFC1918 boundaries and nearby public, CGNAT, and IPv6 addresses.

</details>