### PR TITLE
fix(appcli): handle directory sync on Windows

### DIFF
--- a/apps/api-go/internal/appcli/backend.go
+++ b/apps/api-go/internal/appcli/backend.go
@@ -240,7 +240,7 @@ func (runtime *backendRuntime) selectProvider(selection string) (backendProvider
 	if err != nil {
 		return backendProvider{}, fmt.Errorf("open canonical backend directory for sync: %w", err)
 	}
-	syncErr := dir.Sync()
+	syncErr := flushDirectory(dir)
 	closeErr := dir.Close()
 	if syncErr != nil {
 		return backendProvider{}, fmt.Errorf("sync canonical backend directory: %w", syncErr)

--- a/apps/api-go/internal/appcli/deploy.go
+++ b/apps/api-go/internal/appcli/deploy.go
@@ -684,7 +684,7 @@ func syncDirectory(path string) error {
 		return fmt.Errorf("open directory for sync: %w", err)
 	}
 	defer directory.Close()
-	if err := directory.Sync(); err != nil {
+	if err := flushDirectory(directory); err != nil {
 		return fmt.Errorf("sync directory: %w", err)
 	}
 	return nil

--- a/apps/api-go/internal/appcli/deploy_production_transaction.go
+++ b/apps/api-go/internal/appcli/deploy_production_transaction.go
@@ -459,7 +459,7 @@ func (runtime *productionRuntime) prepareLegacyProviderRollback(manifest product
 		return fmt.Errorf("open provider directory after legacy unlink: %w", err)
 	}
 	defer directory.Close()
-	if err := directory.Sync(); err != nil {
+	if err := flushDirectory(directory); err != nil {
 		return fmt.Errorf("sync provider directory after legacy unlink: %w", err)
 	}
 	return nil

--- a/apps/api-go/internal/appcli/sync_directory_nonwindows.go
+++ b/apps/api-go/internal/appcli/sync_directory_nonwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package appcli
+
+import "os"
+
+func flushDirectory(directory *os.File) error {
+	return directory.Sync()
+}

--- a/apps/api-go/internal/appcli/sync_directory_test.go
+++ b/apps/api-go/internal/appcli/sync_directory_test.go
@@ -1,0 +1,19 @@
+package appcli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestSyncDirectory(t *testing.T) {
+	if err := syncDirectory(t.TempDir()); err != nil {
+		t.Fatalf("syncDirectory() error = %v", err)
+	}
+}
+
+func TestSyncDirectoryRejectsMissingPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing")
+	if err := syncDirectory(path); err == nil {
+		t.Fatal("syncDirectory() accepted a missing path")
+	}
+}

--- a/apps/api-go/internal/appcli/sync_directory_test.go
+++ b/apps/api-go/internal/appcli/sync_directory_test.go
@@ -1,6 +1,8 @@
 package appcli
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -15,5 +17,31 @@ func TestSyncDirectoryRejectsMissingPath(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing")
 	if err := syncDirectory(path); err == nil {
 		t.Fatal("syncDirectory() accepted a missing path")
+	}
+}
+
+func TestPrepareLegacyProviderRollbackRemovesActiveProviderLink(t *testing.T) {
+	root := t.TempDir()
+	installedBinary := filepath.Join(root, backendCanonicalName)
+	if err := os.Symlink(backendGoName, installedBinary); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &productionRuntime{
+		paths: productionPaths{InstalledBinary: installedBinary},
+	}
+	manifest := productionManifest{
+		PreviousProviderTarget: "legacy-regular",
+		NewProviderTarget:      backendGoName,
+		Go: productionPackageTransition{
+			RollbackPackageName: productionAURPackageName,
+			RollbackIdentity:    productionAURPackageName + " 0.1.69-1",
+		},
+	}
+
+	if err := runtime.prepareLegacyProviderRollback(manifest); err != nil {
+		t.Fatalf("prepareLegacyProviderRollback() error = %v", err)
+	}
+	if _, err := os.Lstat(installedBinary); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("provider link still exists: %v", err)
 	}
 }

--- a/apps/api-go/internal/appcli/sync_directory_windows.go
+++ b/apps/api-go/internal/appcli/sync_directory_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package appcli
+
+import "os"
+
+func flushDirectory(_ *os.File) error {
+	// FlushFileBuffers does not support directory handles on Windows.
+	return nil
+}


### PR DESCRIPTION
# LMM API Pull Request

## 变更说明 / Summary

`syncDirectory` opened a directory and called `os.File.Sync()`. On Windows,
Go maps that call to `FlushFileBuffers`, which rejects the directory handle
returned by `os.Open` with `Access is denied`. As a result, otherwise successful
atomic operations failed after publishing their output. Current affected paths
include route-contract generation, native build artifacts, and GeoIP database
replacement.

This change keeps `syncDirectory` responsible for opening and validating the
path, but delegates the final flush to platform-specific helpers:

- non-Windows builds preserve the existing `directory.Sync()` behavior;
- Windows skips only the unsupported directory flush;
- file-content sync and atomic rename behavior are unchanged.

A regression test covers a valid directory on every platform, and a second test
ensures the Windows behavior does not accidentally accept a missing path.

Compatibility impact: Windows callers no longer report a false failure after a
successful atomic operation. Non-Windows behavior is unchanged. No migration,
configuration, public API, documentation, or localization change is required.

Changelog intent: Windows compatibility fix for appcli atomic operations.

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A. This fixes the current Go appcli
implementation and is not an upstream sync or backport.

## 关联 Issue / Related issue

N/A. I searched all-state Issues and PRs for `sync directory`, `fsync`,
`FlushFileBuffers`, `Access is denied`, and `internal/appcli Windows`; no open or
merged Go appcli implementation was found. Closed PR #39 concerned the separate
Rust migration workspace and does not modify this code.

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

Environment: Windows 11 amd64, Go 1.26.5.

Before the change, `TestSyncDirectory` failed twice with Windows
`Access is denied`. After the change:

```text
go test ./internal/appcli -run '^TestSyncDirectory' -count=3
PASS

go test ./internal/appcli -run '^(TestSyncDirectory|TestSyncDirectoryRejectsMissingPath|TestNativeDeployBuildProducesVersionedBinaryFrontendAndPackage|TestRouteContractPrintGenerateVerify|TestEdgePolicyInstallBacksUpRemovesLegacyAndRestores|TestAwaitRemoteReleaseStatusWaitsForTerminalPhase|TestAmbiguousDispatchRemoteAbortedPersistsAcrossStatusAndReload|TestLoadProductionReleaseControllerStateMigratesLegacyDispatch|TestProductionActivationDispatchFaultReconciliation|TestProductionActivationRejectsTamperedRemoteOperatorBeforeDispatch)$' -count=2
PASS

go vet ./...
PASS

GOOS=linux CGO_ENABLED=0 go test -c ./internal/appcli
PASS

gofmt -d internal/appcli/deploy.go internal/appcli/sync_directory_nonwindows.go internal/appcli/sync_directory_windows.go internal/appcli/sync_directory_test.go
PASS (no output)

git diff --check upstream/main...HEAD
PASS
```

The complete `internal/appcli` suite still contains unrelated Windows-only
failures around POSIX ownership/executable modes, hard-coded Linux production
tools such as `/usr/bin/bsdtar`, systemd/pacman paths, symlink semantics, and
persistent-cookie mode `0600`. Those paths are outside this PR and remain
unchanged; this PR does not claim the complete production-deployment suite is
Windows-compatible.

## 截图或日志 / Screenshots or logs

N/A; this is a platform-specific backend filesystem fix with no UI change.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；此修复没有破坏性变化或迁移要求。
- [x] 我已补充相关测试，并在上方记录实际验证结果。
- [x] 文档、配置和多语言文案不受影响。
- [x] 代码、日志、截图和提交记录中不包含敏感信息。

## Sourcery 摘要

修复 Windows 目录同步问题，确保成功的原子操作不再错误地报告失败。

错误修复：
- 修复在同步已发布目录时错误失败的 Windows 原子操作。
- 保留非 Windows 平台上的目录同步功能，同时允许有效的 Windows 目录成功完成。

测试：
- 添加跨平台测试，覆盖有效目录同步和拒绝缺失路径的情况。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复 Windows 目录同步问题，确保成功的原子操作不再报告虚假失败。

Bug 修复：
- 防止 Windows 原子操作在同步已发布目录时被错误地判定为失败。
- 保持非 Windows 平台上的目录同步行为，同时允许有效的 Windows 目录成功完成同步。

测试：
- 增加跨平台测试，覆盖成功的目录同步以及对缺失路径的拒绝处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Windows directory synchronization so successful atomic operations no longer report spurious failures.

Bug Fixes:
- Prevent Windows atomic operations from falsely failing when synchronizing published directories.
- Preserve directory synchronization behavior on non-Windows platforms while allowing valid Windows directories to complete successfully.

Tests:
- Add cross-platform coverage for successful directory synchronization and rejection of missing paths.

</details>

</details>