### PR TITLE
fix(web): ignore stale deployment settings refreshes

### DIFF
--- a/apps/web/src/features/models/api.ts
+++ b/apps/web/src/features/models/api.ts
@@ -289,7 +289,11 @@ export async function deletePrefillGroup(
  * Get deployment settings (io.net config)
  */
 export async function getDeploymentSettings(): Promise<DeploymentSettingsResponse> {
-  const res = await api.get('/api/deployments/settings')
+  const res = await api.get('/api/deployments/settings', {
+    // A manual/focus refresh must start a newer request instead of sharing an
+    // older in-flight response. The hook generation guard discards the loser.
+    disableDuplicate: true,
+  })
   return res.data
 }
 

--- a/apps/web/src/features/models/hooks/use-model-deployment-settings.test.tsx
+++ b/apps/web/src/features/models/hooks/use-model-deployment-settings.test.tsx
@@ -1,0 +1,162 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import type { AxiosAdapter, AxiosResponse } from 'axios'
+import { Window } from 'happy-dom'
+import type { Root } from 'react-dom/client'
+
+const domWindow = new Window({ url: 'https://console.example.test/models' })
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'Node',
+  'Element',
+  'Event',
+  'MutationObserver',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { api } = await import('@/lib/api')
+const deploymentSettingsModule = await import('./use-model-deployment-settings')
+const { clearConnectionCache, useModelDeploymentSettings } =
+  deploymentSettingsModule
+
+const originalAPIAdapter = api.defaults.adapter
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+type HookValue = ReturnType<typeof useModelDeploymentSettings>
+let currentHook: HookValue | null = null
+
+function response(
+  config: Parameters<AxiosAdapter>[0],
+  data: unknown
+): AxiosResponse {
+  return {
+    config,
+    data,
+    headers: {},
+    status: 200,
+    statusText: 'OK',
+  }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function Harness() {
+  currentHook = useModelDeploymentSettings()
+  return null
+}
+
+async function mountHarness(): Promise<{
+  root: Root
+  container: HTMLDivElement
+}> {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+  await act(async () => {
+    root.render(<Harness />)
+  })
+  return { root, container }
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+afterEach(() => {
+  api.defaults.adapter = originalAPIAdapter
+  clearConnectionCache()
+  currentHook = null
+})
+
+after(() => domWindow.close())
+
+describe('useModelDeploymentSettings', () => {
+  test('ignores a stale settings response after a newer refresh completes', async () => {
+    const older = deferred<unknown>()
+    const newer = deferred<unknown>()
+    const secondRequestStarted = deferred<void>()
+    let settingsRequests = 0
+    let connectionRequests = 0
+
+    api.defaults.adapter = async (config) => {
+      if (config.url === '/api/deployments/settings') {
+        settingsRequests += 1
+        if (settingsRequests === 2) secondRequestStarted.resolve()
+        const pending = settingsRequests === 1 ? older : newer
+        const data = await pending.promise
+        return response(config, data)
+      }
+      if (config.url === '/api/deployments/settings/test-connection') {
+        connectionRequests += 1
+        return response(config, { success: true })
+      }
+      throw new Error(`unexpected request: ${String(config.url)}`)
+    }
+
+    const { root } = await mountHarness()
+
+    try {
+      await flushEffects()
+      assert.equal(settingsRequests, 1)
+
+      await act(async () => {
+        void currentHook?.refresh()
+      })
+      await secondRequestStarted.promise
+      assert.equal(settingsRequests, 2)
+
+      newer.resolve({ success: true, data: { enabled: false } })
+      await flushEffects()
+      assert.equal(currentHook?.isIoNetEnabled, false)
+      assert.equal(currentHook?.loading, false)
+      assert.equal(currentHook?.loadingPhase, 'done')
+
+      older.resolve({ success: true, data: { enabled: true } })
+      await flushEffects()
+
+      assert.equal(currentHook?.isIoNetEnabled, false)
+      assert.equal(currentHook?.loading, false)
+      assert.equal(currentHook?.loadingPhase, 'done')
+      assert.equal(connectionRequests, 0)
+    } finally {
+      await act(async () => root.unmount())
+    }
+  })
+})

--- a/apps/web/src/features/models/hooks/use-model-deployment-settings.ts
+++ b/apps/web/src/features/models/hooks/use-model-deployment-settings.ts
@@ -64,15 +64,21 @@ export function useModelDeploymentSettings() {
     error: null,
   })
   const initialLoadRef = useRef(true)
+  const fetchGenerationRef = useRef(0)
 
   // Parallel fetch: settings + connection test (when enabled)
   const fetchAll = useCallback(async (useCache = true) => {
+    const generation = ++fetchGenerationRef.current
+    const isCurrent = () => fetchGenerationRef.current === generation
+
     setLoading(true)
     setLoadingPhase('settings')
 
     try {
       // Step 1: Fetch settings first (usually fast)
       const response = await getDeploymentSettings()
+      if (!isCurrent()) return
+
       const isEnabled = response?.success && response?.data?.enabled === true
 
       setSettings({
@@ -82,8 +88,6 @@ export function useModelDeploymentSettings() {
       if (!isEnabled) {
         // Not enabled, done
         setConnectionState({ loading: false, ok: null, error: null })
-        setLoadingPhase('done')
-        setLoading(false)
         return
       }
 
@@ -92,8 +96,6 @@ export function useModelDeploymentSettings() {
         const cached = getCachedConnection()
         if (cached !== null) {
           setConnectionState({ loading: false, ok: cached, error: null })
-          setLoadingPhase('done')
-          setLoading(false)
           return
         }
       }
@@ -104,6 +106,8 @@ export function useModelDeploymentSettings() {
 
       try {
         const connResponse = await testDeploymentConnection()
+        if (!isCurrent()) return
+
         if (connResponse?.success) {
           setCachedConnection(true)
           setConnectionState({ loading: false, ok: true, error: null })
@@ -113,17 +117,23 @@ export function useModelDeploymentSettings() {
           setConnectionState({ loading: false, ok: false, error: message })
         }
       } catch (error: unknown) {
+        if (!isCurrent()) return
+
         const errMsg =
           error instanceof Error ? error.message : 'Connection failed'
         setCachedConnection(false)
         setConnectionState({ loading: false, ok: false, error: errMsg })
       }
     } catch {
+      if (!isCurrent()) return
+
       // Settings fetch failed, use defaults
       setConnectionState({ loading: false, ok: null, error: null })
     } finally {
-      setLoadingPhase('done')
-      setLoading(false)
+      if (isCurrent()) {
+        setLoadingPhase('done')
+        setLoading(false)
+      }
     }
   }, [])
 


### PR DESCRIPTION
Closes #171.

## Summary

`useModelDeploymentSettings` can start overlapping `fetchAll()` calls during the initial load, focus refreshes, or manual refreshes. Before this change, an older request that resolved last could overwrite newer settings, connection state, loading state, and the module-level connection cache.

This change:

- assigns each settings refresh a monotonically increasing generation;
- commits settings, connection results, cache writes, and final loading state only from the latest generation;
- ignores stale failures as well as stale successful responses;
- adds a deterministic regression test where a newer disabled response resolves before an older enabled response.

The stale older response is now ignored and does not trigger a connection probe or rewrite the UI state.

## Validation

A regression test is included at `apps/web/src/features/models/hooks/use-model-deployment-settings.test.tsx`. Repository CI will run the web test/typecheck/lint/build gates for this branch.

The change is scoped to request ordering in the deployment-settings hook; API contracts and deployment behavior are unchanged.

## Sourcery 摘要

忽略过时的 deployment-settings 刷新结果，确保只有最新请求可以控制钩子状态。

错误修复：
- 防止过时的 deployment-settings 刷新结果覆盖更新的设置、连接状态、加载状态或缓存的连接结果。

测试：
- 添加回归测试，涵盖多个刷新请求重叠且较新的响应先于较旧响应完成的情况。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保只有最新的 deployment-settings 刷新操作可以更新钩子状态和连接结果。

错误修复：
- 防止过时的 deployment-settings 刷新操作覆盖较新的设置、连接状态、加载状态或缓存的连接结果。

测试：
- 添加回归测试，涵盖刷新操作重叠且较新的响应先于较旧的响应完成的情况。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

忽略过时的部署设置刷新结果，确保只有最新的刷新操作能够控制钩子状态和连接结果。

错误修复：
- 防止过时的部署设置刷新覆盖更新的设置、连接状态、加载状态或缓存的连接结果。

增强功能：
- 确保只有最新的并发刷新操作可以提交部署设置和连接结果。

测试：
- 添加回归测试，覆盖较新的响应先于较旧的响应完成的并发刷新场景。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

忽略过时的 deployment-settings 刷新结果，确保只有最新的刷新操作会控制钩子状态和连接结果。

Bug 修复：
- 防止过时的 deployment-settings 刷新操作覆盖更新的设置、连接状态、加载状态或缓存的连接结果。

增强功能：
- 确保手动刷新和焦点刷新发起独立的请求，以便最新的刷新操作可以取代较早的进行中请求。

测试：
- 添加回归测试，覆盖刷新操作重叠且较新的响应先于较旧的响应完成的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ignore stale deployment-settings refresh results so only the latest refresh controls hook state and connection results.

Bug Fixes:
- Prevent stale deployment-settings refreshes from overwriting newer settings, connection state, loading state, or cached connection results.

Enhancements:
- Ensure manual and focus refreshes issue independent requests so the latest refresh can supersede older in-flight requests.

Tests:
- Add a regression test covering overlapping refreshes where the newer response resolves before the older response.

</details>

</details>

</details>

</details>