### PR TITLE
fix(web): isolate temporary email detail state

### DIFF
--- a/apps/web/src/features/email-activations/hooks.test.tsx
+++ b/apps/web/src/features/email-activations/hooks.test.tsx
@@ -1,0 +1,178 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { after, afterEach, describe, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+
+const domWindow = new Window()
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'Node',
+  'Element',
+  'Event',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+
+const { act } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { QueryClient, QueryClientProvider } =
+  await import('@tanstack/react-query')
+const { api } = await import('@/lib/api')
+const { useHeroSmsActivationDetail } = await import('./hooks')
+
+const originalGet = api.get
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+function detailResponse({
+  id,
+  email,
+  code,
+}: {
+  id: string
+  email: string
+  code: string
+}) {
+  return {
+    data: {
+      success: true,
+      data: {
+        id,
+        order_id: `order-${id}`,
+        domain_id: `domain-${id}`,
+        email,
+        code,
+        status: 'completed',
+        charge_quota: 10,
+        cancel_reason: '',
+        created_at: '2026-08-30T00:00:00Z',
+        updated_at: '2026-08-30T00:01:00Z',
+      },
+    },
+  }
+}
+
+async function waitForText(container: HTMLElement, text: string) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    if (container.textContent === text) return
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+    })
+  }
+  assert.equal(container.textContent, text)
+}
+
+afterEach(() => {
+  api.get = originalGet
+  document.body.replaceChildren()
+})
+
+after(() => domWindow.close())
+
+describe('email activation detail query', () => {
+  test('does not expose the previous activation while a new detail is loading', async () => {
+    const secondResponse = deferred<ReturnType<typeof detailResponse>>()
+    let secondRequested = false
+
+    api.get = (async (url: string) => {
+      if (url.endsWith('/A')) {
+        return detailResponse({
+          id: 'A',
+          email: 'alpha@example.test',
+          code: '111111',
+        })
+      }
+      if (url.endsWith('/B')) {
+        secondRequested = true
+        return secondResponse.promise
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    }) as typeof api.get
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const container = document.createElement('div')
+    document.body.append(container)
+    const root = createRoot(container)
+
+    function DetailProbe({ activationId }: { activationId: string }) {
+      const query = useHeroSmsActivationDetail(activationId)
+      const activation = query.data?.activation
+      return (
+        <div>
+          {activation
+            ? `${activation.id}|${activation.email}|${activation.code}`
+            : 'loading'}
+        </div>
+      )
+    }
+
+    const render = async (activationId: string) => {
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <DetailProbe activationId={activationId} />
+          </QueryClientProvider>
+        )
+      })
+    }
+
+    try {
+      await render('A')
+      await waitForText(container, 'A|alpha@example.test|111111')
+
+      await render('B')
+      assert.equal(secondRequested, true)
+      assert.equal(container.textContent, 'loading')
+      assert.doesNotMatch(container.textContent ?? '', /alpha|111111/)
+
+      secondResponse.resolve(
+        detailResponse({
+          id: 'B',
+          email: 'beta@example.test',
+          code: '222222',
+        })
+      )
+      await waitForText(container, 'B|beta@example.test|222222')
+      assert.doesNotMatch(container.textContent ?? '', /alpha|111111/)
+    } finally {
+      await act(async () => root.unmount())
+      queryClient.clear()
+    }
+  })
+})

--- a/apps/web/src/features/email-activations/hooks.ts
+++ b/apps/web/src/features/email-activations/hooks.ts
@@ -149,7 +149,6 @@ export function useHeroSmsActivationDetail(
     queryKey: heroSmsQueryKeys.activation(activationId || 'none'),
     queryFn: () => getHeroSmsActivationDetail(String(activationId)),
     enabled: enabled && activationId != null,
-    placeholderData: (previousData) => previousData,
     refetchInterval: (query) => {
       if (!isHeroSmsActiveStatus(query.state.data?.activation.status)) {
         return false

--- a/apps/web/src/features/email-activations/page.tsx
+++ b/apps/web/src/features/email-activations/page.tsx
@@ -357,7 +357,8 @@ export function EmailActivationsPage() {
   const { t } = useTranslation()
   const [activationKind, setActivationKind] = useState<'sms' | 'email'>('sms')
   useHeroSmsTranslations()
-  const isMobile = useMediaQuery('(max-width: 640px)')
+  // Match Tailwind's `sm` breakpoint: at 640px the side drawer uses desktop layout.
+  const isMobile = useMediaQuery('(max-width: 639px)')
   const queryClient = useQueryClient()
   const emailMode = activationKind === 'email'
 

--- a/apps/web/src/features/email-activations/page.tsx
+++ b/apps/web/src/features/email-activations/page.tsx
@@ -39,6 +39,11 @@ import { ConfirmDialog } from '@/components/confirm-dialog'
 import { CopyButton } from '@/components/copy-button'
 import { useDataTable } from '@/components/data-table/hooks/use-data-table'
 import { DataTablePage } from '@/components/data-table/layout/data-table-page'
+import {
+  sideDrawerContentClassName,
+  sideDrawerFormClassName,
+  sideDrawerHeaderClassName,
+} from '@/components/drawer-layout'
 import { ErrorState } from '@/components/error-state'
 import { SectionPageLayout } from '@/components/layout/components/section-page-layout'
 import { LoadingState } from '@/components/loading-state'
@@ -420,6 +425,16 @@ export function EmailActivationsPage() {
     detailTarget?.id ?? null,
     emailMode && !!detailTarget
   )
+  const detailActivation =
+    detailTarget &&
+    detailQuery.data?.activation &&
+    String(detailQuery.data.activation.id) === String(detailTarget.id)
+      ? detailQuery.data.activation
+      : null
+  const detailFeedback =
+    !detailActivation && !detailQuery.isPending
+      ? describeHeroSmsError(parseHeroSmsError(detailQuery.error), t)
+      : null
 
   const productsLoading =
     !!trimmedSite && (debouncedSite !== trimmedSite || productsQuery.isLoading)
@@ -1278,9 +1293,11 @@ export function EmailActivationsPage() {
         >
           <SheetContent
             side={isMobile ? 'bottom' : 'right'}
-            className='max-h-[88dvh] w-full overflow-y-auto sm:max-w-xl'
+            className={sideDrawerContentClassName(
+              'h-[88dvh] sm:h-dvh sm:max-w-xl'
+            )}
           >
-            <SheetHeader>
+            <SheetHeader className={sideDrawerHeaderClassName()}>
               <SheetTitle>{t('Activation details')}</SheetTitle>
               <SheetDescription>
                 {t(
@@ -1289,104 +1306,107 @@ export function EmailActivationsPage() {
               </SheetDescription>
             </SheetHeader>
 
-            <div className='mt-6 space-y-4'>
-              {detailQuery.isLoading && !detailQuery.data ? (
-                <LoadingState message={t('Loading activation details...')} />
-              ) : null}
-
-              {(() => {
-                const detailActivation =
-                  detailQuery.data?.activation ?? detailTarget
-                if (!detailActivation) {
-                  return null
-                }
-
-                return (
-                  <>
-                    <div className='flex flex-wrap items-start justify-between gap-3'>
-                      <div className='min-w-0 space-y-2'>
-                        <HeroSmsStatusBadge
-                          status={detailActivation.status}
-                          t={t}
-                        />
-                        <div className='min-w-0'>
-                          <p className='text-muted-foreground text-xs'>
-                            {t('Email')}
+            <div
+              className={sideDrawerFormClassName('gap-4')}
+              aria-busy={!detailActivation && detailQuery.isPending}
+            >
+              {!detailActivation && detailQuery.isPending ? (
+                <div role='status' aria-live='polite'>
+                  <LoadingState message={t('Loading activation details...')} />
+                </div>
+              ) : detailFeedback ? (
+                <div role='alert'>
+                  <ErrorState
+                    title={detailFeedback.title}
+                    description={detailFeedback.description}
+                    onRetry={() => void detailQuery.refetch()}
+                  />
+                </div>
+              ) : detailActivation ? (
+                <>
+                  <div className='flex flex-wrap items-start justify-between gap-3'>
+                    <div className='min-w-0 space-y-2'>
+                      <HeroSmsStatusBadge
+                        status={detailActivation.status}
+                        t={t}
+                      />
+                      <div className='min-w-0'>
+                        <p className='text-muted-foreground text-xs'>
+                          {t('Email')}
+                        </p>
+                        <div className='flex items-center gap-2'>
+                          <p className='truncate font-semibold'>
+                            {detailActivation.email || '—'}
                           </p>
-                          <div className='flex items-center gap-2'>
-                            <p className='truncate font-semibold'>
-                              {detailActivation.email || '—'}
-                            </p>
-                            {detailActivation.email ? (
-                              <CopyButton value={detailActivation.email} />
-                            ) : null}
-                          </div>
-                        </div>
-                        <div className='min-w-0'>
-                          <p className='text-muted-foreground text-xs'>
-                            {t('Verification code')}
-                          </p>
-                          <div className='flex items-center gap-2'>
-                            <p className='font-semibold'>
-                              {detailActivation.code || '—'}
-                            </p>
-                            {detailActivation.code ? (
-                              <CopyButton value={detailActivation.code} />
-                            ) : null}
-                          </div>
+                          {detailActivation.email ? (
+                            <CopyButton value={detailActivation.email} />
+                          ) : null}
                         </div>
                       </div>
-                      <Badge variant='outline'>
-                        {t('Order #{{id}}', { id: detailActivation.order_id })}
-                      </Badge>
+                      <div className='min-w-0'>
+                        <p className='text-muted-foreground text-xs'>
+                          {t('Verification code')}
+                        </p>
+                        <div className='flex items-center gap-2'>
+                          <p className='font-semibold'>
+                            {detailActivation.code || '—'}
+                          </p>
+                          {detailActivation.code ? (
+                            <CopyButton value={detailActivation.code} />
+                          ) : null}
+                        </div>
+                      </div>
                     </div>
+                    <Badge variant='outline'>
+                      {t('Order #{{id}}', { id: detailActivation.order_id })}
+                    </Badge>
+                  </div>
 
-                    {detailActivation.message ? (
-                      <Alert>
-                        <HugeiconsIcon
-                          icon={InformationCircleIcon}
-                          strokeWidth={2}
-                          aria-hidden='true'
-                        />
-                        <AlertTitle>{t('Provider message')}</AlertTitle>
-                        <AlertDescription>
-                          {detailActivation.message}
-                        </AlertDescription>
-                      </Alert>
-                    ) : null}
+                  {detailActivation.message ? (
+                    <Alert>
+                      <HugeiconsIcon
+                        icon={InformationCircleIcon}
+                        strokeWidth={2}
+                        aria-hidden='true'
+                      />
+                      <AlertTitle>{t('Provider message')}</AlertTitle>
+                      <AlertDescription>
+                        {detailActivation.message}
+                      </AlertDescription>
+                    </Alert>
+                  ) : null}
 
-                    <div className='grid gap-4 rounded-xl border p-4 sm:grid-cols-2'>
-                      <MetaItem
-                        label={t('Site')}
-                        value={detailActivation.site || '—'}
-                      />
-                      <MetaItem
-                        label={t('Domain')}
-                        value={detailActivation.domain || '—'}
-                      />
-                      <MetaItem
-                        label={t('Created')}
-                        value={formatDateTime(detailActivation.created_at)}
-                      />
-                      <MetaItem
-                        label={t('Updated')}
-                        value={formatDateTime(detailActivation.updated_at)}
-                      />
-                      <MetaItem
-                        label={t('Quota charge')}
-                        value={formatNumber(detailActivation.charge_quota)}
-                      />
-                      <MetaItem
-                        label={t('Cancellation reason')}
-                        value={formatCancellationReason(
-                          detailActivation.cancel_reason,
-                          t
-                        )}
-                      />
-                    </div>
-                  </>
-                )
-              })()}
+                  <div className='grid gap-4 rounded-xl border p-4 sm:grid-cols-2'>
+                    <MetaItem
+                      label={t('Site')}
+                      value={detailActivation.site || '—'}
+                    />
+                    <MetaItem
+                      label={t('Domain')}
+                      value={detailActivation.domain || '—'}
+                    />
+                    <MetaItem
+                      label={t('Created')}
+                      value={formatDateTime(detailActivation.created_at)}
+                    />
+                    <MetaItem
+                      label={t('Updated')}
+                      value={formatDateTime(detailActivation.updated_at)}
+                    />
+                    <MetaItem
+                      label={t('Quota charge')}
+                      value={formatNumber(detailActivation.charge_quota)}
+                    />
+                    <MetaItem
+                      label={t('Cancellation reason')}
+                      value={formatCancellationReason(
+                        detailActivation.cancel_reason,
+                        t
+                      )}
+                    />
+                  </div>
+                </>
+              ) : null}
             </div>
           </SheetContent>
         </Sheet>


### PR DESCRIPTION
## Summary\n- Prevent temporary email detail A from appearing while detail B is loading.\n- Fail closed on mismatched detail identities and expose loading/error/retry states.\n- Keep the detail sheet height stable on desktop and mobile.\n\n## Verification\n- Regression test for deferred A-to-B detail switching.\n- Web typecheck, lint, format check, 200-file web test suite, and production build pass.\n- Browser verified at 1440x900 and 390x844 with no console, page, HTTP, or overflow errors.\n\nScope is limited to apps/web.

## Sourcery 摘要

隔离电子邮件激活详情状态，确保选择变更不会显示过时数据，并让抽屉提供可靠的请求反馈。

错误修复：
- 在加载其他激活项时，防止显示过时的电子邮件激活详情；当返回的详情与所选激活项不匹配时，采用安全失败策略。
- 为激活详情请求提供明确的加载、错误和重试状态。

改进：
- 确保激活详情抽屉在桌面端和移动端视口中的布局保持稳定。

测试：
- 添加回归测试，覆盖从一个激活详情延迟切换到另一个激活详情的场景，确保不会暴露之前激活项的信息。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

在切换选择项时隔离电子邮件激活详情状态，并提供可靠的请求反馈。

Bug 修复：
- 在不同激活项之间切换时，防止显示过时的电子邮件激活详情；当返回的详情与所选激活项不匹配时安全失败。
- 为激活详情请求提供明确的加载、错误和重试反馈。

增强功能：
- 确保激活详情抽屉在桌面端和移动端视口中的布局和高度保持一致。

测试：
- 添加回归测试，覆盖激活详情之间延迟切换的场景，确保之前激活项的数据保持隐藏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Isolate email activation detail state during selection changes and provide reliable request feedback.

Bug Fixes:
- Prevent stale email activation details from appearing when switching between activations and fail safely when returned details do not match the selected activation.
- Provide explicit loading, error, and retry feedback for activation detail requests.

Enhancements:
- Keep the activation detail drawer layout and height consistent across desktop and mobile viewports.

Tests:
- Add a regression test covering delayed switching between activation details to ensure previous activation data remains hidden.

</details>

</details>