### PR TITLE
fix(go): flush OpenAI chat chunks immediately

### DIFF
--- a/apps/api-go/relay/channel/openai/relay-openai.go
+++ b/apps/api-go/relay/channel/openai/relay-openai.go
@@ -138,7 +138,7 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 	isAudioModel := strings.Contains(strings.ToLower(model), "audio")
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
-		if lastStreamData != "" && !lastStreamDataSent {
+		if lastStreamData != "" && !lastStreamDataSent && !shouldHoldOpenAIUsageChunk(info, lastStreamData) {
 			if err := HandleStreamFormat(c, info, lastStreamData, info.ChannelSetting.ForceFormat, info.ChannelSetting.ThinkingToContent); err != nil {
 				common.SysLog("error handling stream format: " + err.Error())
 				sr.Error(err)

--- a/apps/api-go/relay/channel/openai/relay-openai.go
+++ b/apps/api-go/relay/channel/openai/relay-openai.go
@@ -17,6 +17,7 @@ import (
 	"github.com/LIghtJUNction/api.lmm.best/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 )
 
 func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, forceFormat bool, thinkToContent bool) error {
@@ -100,6 +101,17 @@ func sendStreamData(c *gin.Context, info *relaycommon.RelayInfo, data string, fo
 	return helper.ObjectData(c, lastStreamResponse)
 }
 
+func shouldHoldOpenAIUsageChunk(info *relaycommon.RelayInfo, data string) bool {
+	if info == nil || info.RelayFormat != types.RelayFormatOpenAI || info.ShouldIncludeUsage {
+		return false
+	}
+	usage := gjson.Get(data, "usage")
+	if !usage.Exists() || usage.Type != gjson.JSON {
+		return false
+	}
+	return usage.Get("prompt_tokens").Int() != 0 || usage.Get("completion_tokens").Int() != 0
+}
+
 func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Response) (*dto.Usage, *types.NewAPIError) {
 	if resp == nil || resp.Body == nil {
 		logger.LogError(c, "invalid response or response body")
@@ -117,6 +129,7 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 	var toolCount int
 	var usage = &dto.Usage{}
 	var lastStreamData string
+	var lastStreamDataSent bool
 	var secondLastStreamData string // 存储倒数第二个stream data，用于音频模型
 	seenStreamToolCalls := make(map[string]struct{})
 	var streamFunctionCallNames []string
@@ -125,11 +138,12 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 	isAudioModel := strings.Contains(strings.ToLower(model), "audio")
 
 	helper.StreamScannerHandler(c, resp, info, func(data string, sr *helper.StreamResult) {
-		if lastStreamData != "" {
+		if lastStreamData != "" && !lastStreamDataSent {
 			if err := HandleStreamFormat(c, info, lastStreamData, info.ChannelSetting.ForceFormat, info.ChannelSetting.ThinkingToContent); err != nil {
 				common.SysLog("error handling stream format: " + err.Error())
 				sr.Error(err)
 			}
+			lastStreamDataSent = true
 		}
 		if len(data) > 0 {
 			// 对音频模型，保存倒数第二个stream data
@@ -138,10 +152,18 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 			}
 
 			lastStreamData = data
+			lastStreamDataSent = false
 			collectStreamFunctionCallNames(data, seenStreamToolCalls, &streamFunctionCallNames)
 			if err := processTokenData(info.RelayMode, data, &responseTextBuilder, &toolCount); err != nil {
 				logger.LogError(c, "error processing stream token data: "+err.Error())
 				sr.Error(err)
+			}
+			if info.RelayFormat == types.RelayFormatOpenAI && !shouldHoldOpenAIUsageChunk(info, data) {
+				if err := HandleStreamFormat(c, info, data, info.ChannelSetting.ForceFormat, info.ChannelSetting.ThinkingToContent); err != nil {
+					common.SysLog("error handling stream format: " + err.Error())
+					sr.Error(err)
+				}
+				lastStreamDataSent = true
 			}
 		}
 	})
@@ -172,7 +194,7 @@ func OaiStreamHandler(c *gin.Context, info *relaycommon.RelayInfo, resp *http.Re
 	}
 
 	if info.RelayFormat == types.RelayFormatOpenAI {
-		if shouldSendLastResp {
+		if shouldSendLastResp && !lastStreamDataSent {
 			_ = sendStreamData(c, info, lastStreamData, info.ChannelSetting.ForceFormat, info.ChannelSetting.ThinkingToContent)
 		}
 	}

--- a/apps/api-go/relay/channel/openai/relay_openai_stream_test.go
+++ b/apps/api-go/relay/channel/openai/relay_openai_stream_test.go
@@ -1,0 +1,179 @@
+package openai
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/LIghtJUNction/api.lmm.best/constant"
+	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
+	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	relaytypes "github.com/LIghtJUNction/api.lmm.best/relaykit/types"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type firstFlushWriter struct {
+	*httptest.ResponseRecorder
+	flushed chan struct{}
+	once    sync.Once
+}
+
+func (w *firstFlushWriter) Flush() {
+	w.ResponseRecorder.Flush()
+	w.once.Do(func() {
+		close(w.flushed)
+	})
+}
+
+func runOaiStreamWithPausedFirstChunk(t *testing.T, shouldIncludeUsage, forceFormat bool) (bool, string) {
+	t.Helper()
+
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	reader, writer := io.Pipe()
+	t.Cleanup(func() {
+		_ = reader.Close()
+		_ = writer.Close()
+	})
+
+	downstream := &firstFlushWriter{
+		ResponseRecorder: httptest.NewRecorder(),
+		flushed:          make(chan struct{}),
+	}
+	c, _ := gin.CreateTestContext(downstream)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       reader,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta: &relaycommon.ChannelMeta{
+			UpstreamModelName: "gpt-test",
+		},
+		IsStream:           true,
+		RelayMode:          relayconstant.RelayModeChatCompletions,
+		RelayFormat:        relaytypes.RelayFormatOpenAI,
+		ShouldIncludeUsage: shouldIncludeUsage,
+		DisablePing:        true,
+	}
+	info.ChannelSetting.ForceFormat = forceFormat
+
+	type streamResult struct {
+		usageErr error
+		apiErr   *relaytypes.NewAPIError
+	}
+	done := make(chan streamResult, 1)
+	go func() {
+		usage, apiErr := OaiStreamHandler(c, info, resp)
+		var usageErr error
+		if usage == nil {
+			usageErr = fmt.Errorf("usage is nil")
+		}
+		done <- streamResult{usageErr: usageErr, apiErr: apiErr}
+	}()
+
+	firstChunk := `{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1710000000,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"},"finish_reason":null}]}`
+	_, err := fmt.Fprintf(writer, "data: %s\n\n", firstChunk)
+	require.NoError(t, err)
+
+	flushedBeforeNextEvent := false
+	select {
+	case <-downstream.flushed:
+		flushedBeforeNextEvent = true
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	usageChunk := `{"id":"chatcmpl-1","object":"chat.completion.chunk","created":1710000000,"model":"gpt-test","choices":[],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+	_, err = fmt.Fprintf(writer, "data: %s\n\ndata: [DONE]\n\n", usageChunk)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	select {
+	case result := <-done:
+		require.NoError(t, result.usageErr)
+		require.Nil(t, result.apiErr)
+	case <-time.After(2 * time.Second):
+		t.Fatal("stream handler did not finish")
+	}
+
+	return flushedBeforeNextEvent, downstream.Body.String()
+}
+
+func TestOaiStreamHandlerFlushesFirstChunkBeforeNextEvent(t *testing.T) {
+	flushedBeforeNextEvent, body := runOaiStreamWithPausedFirstChunk(t, true, false)
+
+	require.True(t, flushedBeforeNextEvent, "first chat chunk must flush before the next upstream event")
+	require.Contains(t, body, `"content":"hello"`)
+	require.Contains(t, body, `"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2`)
+}
+
+func TestOaiStreamHandlerFlushesFirstChunkWhenUsageExcluded(t *testing.T) {
+	flushedBeforeNextEvent, body := runOaiStreamWithPausedFirstChunk(t, false, false)
+
+	require.True(t, flushedBeforeNextEvent, "excluding usage must not delay the first chat chunk")
+	require.Contains(t, body, `"content":"hello"`)
+	require.NotContains(t, body, `"usage":`)
+}
+
+func TestOaiStreamHandlerFlushesFirstChunkWithForcedFormat(t *testing.T) {
+	flushedBeforeNextEvent, body := runOaiStreamWithPausedFirstChunk(t, true, true)
+
+	require.True(t, flushedBeforeNextEvent, "forced-format chat chunks must flush immediately")
+	require.Contains(t, body, `"content":"hello"`)
+}
+
+func TestOaiStreamHandlerAudioUsageStillUsesSecondLastChunk(t *testing.T) {
+	oldMode := gin.Mode()
+	gin.SetMode(gin.TestMode)
+	t.Cleanup(func() { gin.SetMode(oldMode) })
+
+	oldTimeout := constant.StreamingTimeout
+	constant.StreamingTimeout = 30
+	t.Cleanup(func() { constant.StreamingTimeout = oldTimeout })
+
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-audio","object":"chat.completion.chunk","created":1710000000,"model":"gpt-audio","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-audio","object":"chat.completion.chunk","created":1710000000,"model":"gpt-audio","choices":[],"usage":{"prompt_tokens":4,"completion_tokens":5,"total_tokens":9}}`,
+		`data: {"id":"chatcmpl-audio","object":"chat.completion.chunk","created":1710000000,"model":"gpt-audio","choices":[],"finish_reason":"stop"}`,
+		`data: [DONE]`,
+		``,
+	}, "\n")
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	info := &relaycommon.RelayInfo{
+		ChannelMeta:        &relaycommon.ChannelMeta{UpstreamModelName: "gpt-audio"},
+		IsStream:           true,
+		RelayMode:          relayconstant.RelayModeChatCompletions,
+		RelayFormat:        relaytypes.RelayFormatOpenAI,
+		ShouldIncludeUsage: true,
+		DisablePing:        true,
+	}
+
+	usage, apiErr := OaiStreamHandler(c, info, resp)
+	require.Nil(t, apiErr)
+	require.NotNil(t, usage)
+	require.Equal(t, 4, usage.PromptTokens)
+	require.Equal(t, 5, usage.CompletionTokens)
+	require.Equal(t, 9, usage.TotalTokens)
+}

--- a/apps/api-go/relay/channel/openai/relay_openai_stream_test.go
+++ b/apps/api-go/relay/channel/openai/relay_openai_stream_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/LIghtJUNction/api.lmm.best/constant"
 	relaycommon "github.com/LIghtJUNction/api.lmm.best/relay/common"
 	relayconstant "github.com/LIghtJUNction/api.lmm.best/relay/constant"
+	"github.com/LIghtJUNction/api.lmm.best/relaykit/dto"
 	relaytypes "github.com/LIghtJUNction/api.lmm.best/relaykit/types"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -136,7 +137,9 @@ func TestOaiStreamHandlerFlushesFirstChunkWithForcedFormat(t *testing.T) {
 	require.Contains(t, body, `"content":"hello"`)
 }
 
-func TestOaiStreamHandlerAudioUsageStillUsesSecondLastChunk(t *testing.T) {
+func runOaiAudioStream(t *testing.T, shouldIncludeUsage bool) (*dto.Usage, string) {
+	t.Helper()
+
 	oldMode := gin.Mode()
 	gin.SetMode(gin.TestMode)
 	t.Cleanup(func() { gin.SetMode(oldMode) })
@@ -166,14 +169,28 @@ func TestOaiStreamHandlerAudioUsageStillUsesSecondLastChunk(t *testing.T) {
 		IsStream:           true,
 		RelayMode:          relayconstant.RelayModeChatCompletions,
 		RelayFormat:        relaytypes.RelayFormatOpenAI,
-		ShouldIncludeUsage: true,
+		ShouldIncludeUsage: shouldIncludeUsage,
 		DisablePing:        true,
 	}
 
 	usage, apiErr := OaiStreamHandler(c, info, resp)
 	require.Nil(t, apiErr)
 	require.NotNil(t, usage)
+	return usage, recorder.Body.String()
+}
+
+func TestOaiStreamHandlerAudioUsageStillUsesSecondLastChunk(t *testing.T) {
+	usage, _ := runOaiAudioStream(t, true)
+
 	require.Equal(t, 4, usage.PromptTokens)
 	require.Equal(t, 5, usage.CompletionTokens)
 	require.Equal(t, 9, usage.TotalTokens)
+}
+
+func TestOaiStreamHandlerDoesNotLeakHeldUsageBeforeLaterEvent(t *testing.T) {
+	usage, body := runOaiAudioStream(t, false)
+
+	require.Equal(t, 9, usage.TotalTokens)
+	require.Contains(t, body, `"finish_reason":"stop"`)
+	require.NotContains(t, body, `"usage":`)
 }


### PR DESCRIPTION
## 变更说明 / Summary

Go 默认后端的 `OaiStreamHandler` 会保留当前 OpenAI SSE 事件，直到下一事件到达后才向客户端发送。这会让首个聊天内容块额外等待一个上游事件间隔，直接增加 TTFT。

本修复对 OpenAI -> OpenAI 流立即调用现有格式化/flush 路径，并跟踪末块是否已经发送以避免流结束时重复输出。为保持兼容性：

- `include_usage=false` 时，现有结算逻辑认可的 usage 尾块仍会保留到结束判断，因此不会泄露 usage。
- OpenAI -> Claude/Gemini 的跨协议转换仍使用原有逐事件保留路径。
- `force_format` 和 `thinking_to_content` 继续经过现有 `HandleStreamFormat`。
- 音频模型从倒数第二块提取 usage 的逻辑保持不变并有回归测试。

新增端到端 handler 回归测试，通过暂停 `io.Pipe` 上游来证明第一块必须在第二个 SSE 事件写入前完成 downstream flush。

文档和配置无需变更：请求/响应结构及配置项不变，仅移除代理自身的一事件缓冲延迟。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: reproduced on current `LIghtJUNction/api.lmm.best` `main` at `3d891a1692cdb3b30b4e4824b6ce3fc4c8aea6fe`. Searches for TTFT, first token/chunk, and SSE buffering found no open duplicate issue or PR.

## 关联 Issue / Related issue

N/A. No issue was opened for this bounded, locally reproduced bug fix.

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [x] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
RED (before fix):
go test ./relay/channel/openai -run '^TestOaiStreamHandlerFlushesFirstChunkBeforeNextEvent$' -count=1
FAIL: first chat chunk must flush before the next upstream event

GREEN:
go test ./relay/channel/openai -count=1
PASS

go test ./relay/channel/openai -run '^TestOaiStreamHandler' -count=1
PASS

go vet ./relay/channel/openai
PASS

bun run lint:go
PASS (go vet ./...)

bun run typecheck:go
PASS (go test -run '^$' ./...)

CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' -o out/lmm-api-go .
PASS

gofmt -l apps/api-go/relay/channel/openai/relay-openai.go apps/api-go/relay/channel/openai/relay_openai_stream_test.go
PASS (no output)

git diff --check
PASS
```

Additional environment notes:

- `bun run test:go` was run. The changed `relay/channel/openai` package passed; the overall command failed on pre-existing Windows-incompatible `internal/appcli` tests (Unix ownership/fsync and `/usr/bin/bsdtar`) plus `TestUpstreamGetBody_HTTP2CannotRetryWithoutGetBody`, whose Windows socket error differs from its expected text. The latter was retried with `-count=3` and remained an OS-specific assertion failure.
- `bun run build:go` completed the Go compile but its final Unix `ln` step is unavailable on Windows. The equivalent direct `CGO_ENABLED=0 go build` command above passed.
- `go test -race` is unavailable in this checkout because `go env CGO_ENABLED` is `0` (`-race requires cgo`). CI should provide the Linux full-suite signal.

## 截图或日志 / Screenshots or logs

N/A. Backend SSE behavior is covered by the deterministic paused-upstream regression tests above.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 Issues 和 PRs，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；此变更没有请求/响应结构或配置层面的破坏性变化。
- [x] 我已补充相关测试，并在上方记录实际验证结果和环境限制。
- [x] 文档、示例配置和多语言文案不受影响。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Sourcery 摘要

立即刷新 OpenAI 聊天流块，以减少首个令牌的延迟，同时不改变响应兼容性。

错误修复：
- 立即刷新 OpenAI 到 OpenAI 的聊天块，而不是等待下一个上游 SSE 事件，从而降低首个令牌延迟，同时保留用量处理逻辑并防止最终输出重复。

改进：
- 在添加确定性的流刷新回归测试的同时，保留现有格式、跨协议转换和音频模型用量处理行为。

测试：
- 添加端到端处理程序测试，验证首个块立即刷新、排除用量、强制格式化和音频用量提取。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

立即刷新 OpenAI 聊天流块，同时保持 usage 兼容性和现有的流式传输行为。

Bug 修复：
- 立即刷新 OpenAI 到 OpenAI 的聊天块，而不是等待下一个上游 SSE 事件，从而降低首个 token 的延迟，同时保留 usage 处理并防止最终输出重复。

增强功能：
- 保持现有的格式化、跨协议流式传输、强制格式化、思考内容转换以及音频 usage 行为。

测试：
- 增加端到端回归测试，覆盖首个数据块的即时刷新、usage 排除、强制格式化以及音频模型 usage 提取。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Flush OpenAI chat stream chunks immediately while preserving usage compatibility and existing streaming behavior.

Bug Fixes:
- Flush OpenAI-to-OpenAI chat chunks immediately instead of waiting for the next upstream SSE event, reducing first-token latency while preserving usage handling and preventing duplicate final output.

Enhancements:
- Preserve existing formatting, cross-protocol streaming, forced-format, thinking conversion, and audio usage behavior.

Tests:
- Add end-to-end regression coverage for immediate first-chunk flushing, usage exclusion, forced formatting, and audio-model usage extraction.

</details>

</details>