### PR TITLE
feat(web): streamline drawing workbench UI

### DIFF
--- a/apps/web/src/features/drawing/index.test.tsx
+++ b/apps/web/src/features/drawing/index.test.tsx
@@ -193,6 +193,82 @@ describe('Drawing mobile controls', () => {
         assert.match(select.className, /\bh-11\b/)
         assert.match(select.className, /\bsm:h-8\b/)
       }
+
+      const composer = rendered.container.querySelector(
+        '[data-slot="drawing-composer"]'
+      )
+      const inspector = rendered.container.querySelector(
+        '[data-slot="drawing-inspector"]'
+      )
+      assert.ok(composer)
+      assert.ok(inspector)
+      assert.ok(composer.querySelector('#drawing-reference-images'))
+      assert.match(composer.textContent ?? '', /Generate image/)
+      assert.doesNotMatch(inspector.textContent ?? '', /Generate image/)
+      assert.doesNotMatch(
+        rendered.container.innerHTML,
+        /radial-gradient\(circle/
+      )
+    } finally {
+      await act(async () => rendered.root.unmount())
+      rendered.queryClient.clear()
+    }
+  })
+
+  test('keeps MCP configuration out of the primary workflow until requested', async () => {
+    api.get = (async (url: string) => {
+      if (url === '/api/assistant/status') {
+        return {
+          data: {
+            success: true,
+            data: {
+              enabled: true,
+              model: 'assistant-test',
+              developer_access_granted: true,
+              funding: { mode: 'super_administrator' },
+            },
+          },
+        }
+      }
+      if (url === '/api/pricing') return { data: pricing }
+      if (url === '/api/user/self/groups') {
+        return {
+          data: {
+            success: true,
+            data: pricing.usable_group,
+          },
+        }
+      }
+      throw new Error(`unexpected GET ${url}`)
+    }) as typeof api.get
+
+    const rendered = await renderDrawing()
+    try {
+      await act(
+        async () =>
+          await waitForCondition(
+            () => rendered.container.querySelectorAll('select').length === 5,
+            'drawing controls did not render'
+          )
+      )
+
+      assert.equal(
+        rendered.container.querySelector('#drawing-mcp-endpoint'),
+        null
+      )
+      const mcpButton = [...rendered.container.querySelectorAll('button')].find(
+        (button) => button.textContent?.includes('Drawing MCP')
+      )
+      assert.ok(mcpButton)
+      assert.equal(mcpButton.getAttribute('aria-expanded'), 'false')
+
+      await act(async () => {
+        mcpButton.click()
+        await flushEffects()
+      })
+
+      assert.ok(rendered.container.querySelector('#drawing-mcp-endpoint'))
+      assert.equal(mcpButton.getAttribute('aria-expanded'), 'true')
     } finally {
       await act(async () => rendered.root.unmount())
       rendered.queryClient.clear()

--- a/apps/web/src/features/drawing/index.tsx
+++ b/apps/web/src/features/drawing/index.tsx
@@ -1,3 +1,6 @@
+/*
+Copyright (C) 2026 LIghtJUNction
+*/
 import {
   Cancel01Icon,
   Copy01Icon,
@@ -8,9 +11,6 @@ import {
   SparklesIcon,
 } from '@hugeicons/core-free-icons'
 import { HugeiconsIcon } from '@hugeicons/react'
-/*
-Copyright (C) 2026 LIghtJUNction
-*/
 import { useQuery } from '@tanstack/react-query'
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/apps/web/src/features/drawing/index.tsx
+++ b/apps/web/src/features/drawing/index.tsx
@@ -1,16 +1,17 @@
+import {
+  Cancel01Icon,
+  Copy01Icon,
+  Image01Icon,
+  ImageAdd01Icon,
+  Loading03Icon,
+  McpServerIcon,
+  SparklesIcon,
+} from '@hugeicons/core-free-icons'
+import { HugeiconsIcon } from '@hugeicons/react'
 /*
 Copyright (C) 2026 LIghtJUNction
 */
 import { useQuery } from '@tanstack/react-query'
-import {
-  Copy,
-  ImageIcon,
-  ImagePlus,
-  RefreshCw,
-  ServerCog,
-  Sparkles,
-  X,
-} from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
@@ -22,7 +23,15 @@ import {
   AlertDescription,
   AlertTitle,
 } from '@/components/ui/alert'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { NativeSelect, NativeSelectOption } from '@/components/ui/native-select'
@@ -141,6 +150,7 @@ export function Drawing() {
   const [generating, setGenerating] = useState(false)
   const [drawingMcpToken, setDrawingMcpToken] = useState('')
   const [drawingMcpPending, setDrawingMcpPending] = useState(false)
+  const [drawingMcpOpen, setDrawingMcpOpen] = useState(false)
   const referenceInputRef = useRef<HTMLInputElement>(null)
   const previewUrlsRef = useRef(new Set<string>())
 
@@ -512,32 +522,35 @@ export function Drawing() {
     )
   } else {
     content = (
-      <div className='grid gap-5 xl:grid-cols-[minmax(0,1fr)_20rem] xl:items-stretch'>
+      <div className='grid gap-4 xl:grid-cols-[minmax(0,1fr)_19rem] xl:items-stretch'>
         <section
-          className='relative flex min-h-[620px] min-w-0 flex-col overflow-hidden rounded-2xl border border-white/10 bg-[#111210] shadow-2xl shadow-black/10'
+          data-slot='drawing-canvas'
+          className='relative flex min-h-[36rem] min-w-0 flex-col overflow-hidden rounded-lg border border-white/10 bg-[#111210]'
           aria-live='polite'
           aria-labelledby='drawing-canvas-title'
         >
-          <div className='pointer-events-none absolute inset-0 bg-[radial-gradient(circle,rgba(255,255,255,0.07)_1px,transparent_1px)] [background-size:24px_24px] opacity-60' />
-          <header className='relative flex items-center justify-between gap-4 border-b border-white/10 bg-black/10 px-4 py-3 sm:px-5'>
+          <header className='flex items-center justify-between gap-4 border-b border-white/10 px-4 py-3 sm:px-5'>
             <div className='flex min-w-0 items-center gap-3'>
-              <div className='bg-primary/15 text-primary flex size-9 shrink-0 items-center justify-center rounded-lg'>
-                <Sparkles className='size-4' aria-hidden='true' />
+              <div className='bg-primary/15 text-primary flex size-8 shrink-0 items-center justify-center rounded-md'>
+                <HugeiconsIcon
+                  icon={SparklesIcon}
+                  className='size-4'
+                  strokeWidth={2}
+                  aria-hidden='true'
+                />
               </div>
-              <div className='min-w-0'>
-                <p className='text-[10px] font-medium tracking-[0.16em] text-white/45 uppercase'>
-                  {t('Canvas')}
-                </p>
-                <h2
-                  id='drawing-canvas-title'
-                  className='truncate text-sm font-medium text-white/90'
-                >
-                  {selectedModel || t('Preview')}
-                </h2>
-              </div>
+              <h2
+                id='drawing-canvas-title'
+                className='truncate text-sm font-medium text-white/90'
+              >
+                {selectedModel || t('Preview')}
+              </h2>
             </div>
-            <div className='flex shrink-0 items-center gap-2 text-xs'>
-              <span className='rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-white/65'>
+            <div className='flex shrink-0 items-center gap-2'>
+              <Badge
+                variant='outline'
+                className='border-white/15 bg-white/5 text-white/80'
+              >
                 {generating
                   ? referenceImages.length > 0
                     ? t('Editing...')
@@ -547,26 +560,31 @@ export function Drawing() {
                     : referenceImages.length > 0
                       ? t('Edit image')
                       : t('Draft')}
-              </span>
+              </Badge>
               {selectedGroup ? (
-                <span className='hidden rounded-full border border-white/10 px-2.5 py-1 text-white/45 sm:inline'>
+                <Badge
+                  variant='outline'
+                  className='hidden border-white/15 text-white/70 sm:inline-flex'
+                >
                   {selectedGroup}
-                </span>
+                </Badge>
               ) : null}
             </div>
           </header>
 
-          <div className='relative flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-4 sm:p-8'>
+          <div className='flex min-h-0 flex-1 items-center justify-center overflow-y-auto p-4 sm:p-8'>
             {generating ? (
-              <div className='flex flex-col items-center justify-center text-center text-white/65'>
-                <div className='bg-primary/15 text-primary mb-5 flex size-16 items-center justify-center rounded-2xl'>
-                  <RefreshCw
+              <div className='flex flex-col items-center justify-center text-center text-white/80'>
+                <div className='bg-primary/15 text-primary mb-4 flex size-12 items-center justify-center rounded-lg'>
+                  <HugeiconsIcon
+                    icon={Loading03Icon}
                     className='size-7 animate-spin'
+                    strokeWidth={2}
                     aria-hidden='true'
                   />
                 </div>
                 <p className='text-sm'>{t('Generation in progress...')}</p>
-                <p className='mt-2 max-w-xs text-xs leading-5 text-white/40'>
+                <p className='mt-2 max-w-xs text-xs leading-5 text-white/65'>
                   {t('Your request is ready to run.')}
                 </p>
               </div>
@@ -577,7 +595,7 @@ export function Drawing() {
                   if (!src) return null
                   return (
                     <figure
-                      className='group relative min-w-0 overflow-hidden rounded-xl border border-white/10 bg-black/30 p-2'
+                      className='group relative min-w-0 overflow-hidden rounded-lg border border-white/10 bg-black/30 p-2'
                       key={image.url ?? image.b64_json ?? image.revised_prompt}
                     >
                       <img
@@ -596,36 +614,46 @@ export function Drawing() {
                 })}
               </div>
             ) : (
-              <div className='max-w-md text-center text-white/55'>
-                <div className='mx-auto mb-5 flex size-16 items-center justify-center rounded-2xl border border-white/10 bg-white/5'>
-                  <ImageIcon
-                    className='size-7 text-white/35'
-                    aria-hidden='true'
-                  />
-                </div>
-                <p className='text-sm text-white/75'>
-                  {t('Your generated images will appear here.')}
-                </p>
-                <p className='mt-2 text-xs leading-5 text-white/40'>
-                  {hasPrompt
-                    ? t(
-                        'Review the generated images here when the request finishes.'
-                      )
-                    : t(
-                        'Describe an image, choose a group, and generate a preview.'
-                      )}
-                </p>
-              </div>
+              <Empty className='max-w-md text-white'>
+                <EmptyHeader>
+                  <EmptyMedia
+                    variant='icon'
+                    className='size-10 bg-white/10 text-white/75'
+                  >
+                    <HugeiconsIcon
+                      icon={Image01Icon}
+                      className='size-5'
+                      strokeWidth={2}
+                      aria-hidden='true'
+                    />
+                  </EmptyMedia>
+                  <EmptyTitle className='text-white/85'>
+                    {t('Your generated images will appear here.')}
+                  </EmptyTitle>
+                  <EmptyDescription className='text-xs text-white/65'>
+                    {hasPrompt
+                      ? t(
+                          'Review the generated images here when the request finishes.'
+                        )
+                      : t(
+                          'Describe an image, choose a group, and generate a preview.'
+                        )}
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
             )}
           </div>
 
-          <div className='relative border-t border-white/10 p-3 sm:p-4'>
-            <div className='rounded-xl border border-white/10 bg-black/55 p-3 shadow-xl shadow-black/20 backdrop-blur sm:p-4'>
+          <div
+            data-slot='drawing-composer'
+            className='border-t border-white/10 bg-black/20 p-3 sm:p-4'
+          >
+            <div className='rounded-lg border border-white/10 bg-black/35 p-3 sm:p-4'>
               <div className='mb-2 flex items-center justify-between gap-3'>
-                <Label htmlFor='drawing-prompt-input' className='text-white/80'>
+                <Label htmlFor='drawing-prompt-input' className='text-white/85'>
                   {t('Prompt')}
                 </Label>
-                <span className='text-xs text-white/35 tabular-nums'>
+                <span className='text-xs text-white/60 tabular-nums'>
                   {prompt.length}/2000
                 </span>
               </div>
@@ -636,50 +664,10 @@ export function Drawing() {
                 placeholder={t('Describe what you want to see...')}
                 maxLength={2000}
                 rows={3}
-                className='min-h-20 resize-none border-0 bg-transparent px-0 py-1 text-base text-white shadow-none placeholder:text-white/30 focus-visible:ring-0'
+                style={{ backgroundColor: 'transparent' }}
+                className='min-h-20 resize-none border-0 bg-transparent px-0 py-1 text-base text-white shadow-none placeholder:text-white/50 focus-visible:ring-0'
               />
-              <div className='mt-2 flex items-center justify-between gap-3 text-xs'>
-                <span className='truncate text-white/40'>
-                  {t('Be specific about the subject, mood, and style.')}
-                </span>
-                <span className='shrink-0 text-white/55'>
-                  {hasPrompt ? t('Ready') : t('Draft')}
-                </span>
-              </div>
-            </div>
-          </div>
-        </section>
 
-        <aside className='border-border/70 bg-card/30 flex min-w-0 flex-col rounded-2xl border'>
-          <div className='border-border/70 border-b p-5'>
-            <div className='flex items-start justify-between gap-3'>
-              <div>
-                <p className='text-muted-foreground mb-2 text-xs font-medium tracking-[0.14em] uppercase'>
-                  {t('Inspector')}
-                </p>
-                <h2 className='text-lg font-medium'>{t('Generation setup')}</h2>
-              </div>
-              {configurationReady ? (
-                <span className='text-primary pt-1 text-xs font-medium'>
-                  {t('Ready')}
-                </span>
-              ) : null}
-            </div>
-            <p className='text-muted-foreground mt-2 text-xs leading-5'>
-              {t('Choose a route and output settings.')}
-            </p>
-          </div>
-
-          <div className='grid gap-5 p-5'>
-            <div className='grid gap-3'>
-              <div className='flex items-center justify-between gap-3'>
-                <Label htmlFor='drawing-reference-images'>
-                  {t('Reference images')}
-                </Label>
-                <span className='text-muted-foreground text-xs tabular-nums'>
-                  {referenceImages.length}/{maxReferenceImages}
-                </span>
-              </div>
               <input
                 ref={referenceInputRef}
                 id='drawing-reference-images'
@@ -693,26 +681,27 @@ export function Drawing() {
                   event.target.value = ''
                 }}
               />
-              {referenceImages.length === 0 ? (
-                <Button
-                  type='button'
-                  variant='outline'
-                  className='text-muted-foreground hover:text-foreground h-24 border-dashed'
-                  disabled={generating}
-                  onClick={() => referenceInputRef.current?.click()}
-                >
-                  <ImagePlus className='mr-2 size-4' aria-hidden='true' />
-                  {t('Add reference images')}
-                </Button>
-              ) : (
-                <>
-                  <div className='grid grid-cols-2 gap-2'>
+
+              {referenceImages.length > 0 ? (
+                <div className='mt-3 border-t border-white/10 pt-3'>
+                  <div className='mb-2 flex items-center justify-between gap-3'>
+                    <Label
+                      htmlFor='drawing-reference-images'
+                      className='text-xs text-white/75'
+                    >
+                      {t('Reference images')}
+                    </Label>
+                    <span className='text-xs text-white/60 tabular-nums'>
+                      {referenceImages.length}/{maxReferenceImages}
+                    </span>
+                  </div>
+                  <div className='flex gap-2 overflow-x-auto pb-1'>
                     {referenceImages.map((image, index) => {
                       const label = referenceImageLabel(index)
                       return (
                         <figure
                           key={image.id}
-                          className='group relative aspect-square min-w-0 overflow-hidden rounded-xl border bg-black/10'
+                          className='group relative size-16 shrink-0 overflow-hidden rounded-md border border-white/15 bg-black/30 sm:size-20'
                           title={image.file.name}
                         >
                           <img
@@ -720,62 +709,133 @@ export function Drawing() {
                             alt={label}
                             className='size-full object-cover'
                           />
-                          <figcaption className='absolute bottom-1.5 left-1.5 rounded-md bg-black/75 px-2 py-1 text-[11px] font-medium text-white'>
+                          <figcaption className='absolute inset-x-1 bottom-1 truncate rounded-sm bg-black/80 px-1.5 py-0.5 text-[10px] font-medium text-white'>
                             {label}
                           </figcaption>
                           <Button
                             type='button'
                             variant='secondary'
-                            size='icon'
-                            className='absolute top-1.5 right-1.5 size-7 rounded-full bg-black/75 text-white opacity-90 hover:bg-black'
+                            size='icon-xs'
+                            className='absolute top-1 right-1 bg-black/80 text-white hover:bg-black'
                             disabled={generating}
                             aria-label={t('Remove {{name}}', { name: label })}
                             onClick={() => removeReferenceImage(image.id)}
                           >
-                            <X className='size-3.5' aria-hidden='true' />
+                            <HugeiconsIcon
+                              icon={Cancel01Icon}
+                              strokeWidth={2}
+                              aria-hidden='true'
+                            />
                           </Button>
                         </figure>
                       )
                     })}
                   </div>
+                  <p className='mt-2 text-xs leading-5 text-white/65'>
+                    {t(
+                      'Use the image labels in your prompt to describe how each reference should be used.'
+                    )}
+                  </p>
+                </div>
+              ) : null}
+
+              {error ? (
+                <Alert variant='destructive' className='mt-3'>
+                  <AlertTitle>{t('Request failed')}</AlertTitle>
+                  <AlertDescription>{error}</AlertDescription>
+                  <AlertAction>
+                    <Button
+                      type='button'
+                      size='sm'
+                      variant='outline'
+                      onClick={() => void generate()}
+                      disabled={generating}
+                    >
+                      {t('Retry')}
+                    </Button>
+                  </AlertAction>
+                </Alert>
+              ) : null}
+
+              <div className='mt-3 flex flex-col gap-3 border-t border-white/10 pt-3 sm:flex-row sm:items-center sm:justify-between'>
+                <div className='flex min-w-0 items-center gap-3'>
                   <Button
                     type='button'
                     variant='outline'
                     size='sm'
+                    className='border-white/15 bg-white/5 text-white hover:bg-white/10 hover:text-white'
                     disabled={
                       generating || referenceImages.length >= maxReferenceImages
                     }
                     onClick={() => referenceInputRef.current?.click()}
                   >
-                    <ImagePlus className='mr-2 size-4' aria-hidden='true' />
+                    <HugeiconsIcon
+                      icon={ImageAdd01Icon}
+                      data-icon='inline-start'
+                      strokeWidth={2}
+                      aria-hidden='true'
+                    />
                     {t('Add reference images')}
                   </Button>
-                </>
-              )}
-              <p className='text-muted-foreground text-xs leading-5'>
-                {t(
-                  'PNG, JPEG or WebP, up to {{count}} images and {{size}} MB each.',
-                  {
-                    count: maxReferenceImages,
-                    size: maxReferenceImageBytes / 1024 / 1024,
-                  }
-                )}
-              </p>
-              {referenceImages.length > 0 ? (
-                <div className='bg-muted/40 grid gap-1 rounded-lg border px-3 py-2 text-xs leading-5'>
-                  <span className='font-medium'>
-                    {t(
-                      'Reference images switch this request to image editing.'
-                    )}
-                  </span>
-                  <span className='text-muted-foreground'>
-                    {t(
-                      'Use the image labels in your prompt to describe how each reference should be used.'
-                    )}
+                  <span className='hidden truncate text-xs text-white/65 md:block'>
+                    {referenceImages.length > 0
+                      ? t(
+                          'Reference images switch this request to image editing.'
+                        )
+                      : t('Be specific about the subject, mood, and style.')}
                   </span>
                 </div>
+                <Button
+                  type='button'
+                  size='lg'
+                  className='w-full sm:w-auto sm:min-w-36'
+                  onClick={() => void generate()}
+                  disabled={
+                    generating ||
+                    !prompt.trim() ||
+                    !selectedGroup ||
+                    !selectedModel
+                  }
+                >
+                  <HugeiconsIcon
+                    icon={generating ? Loading03Icon : Image01Icon}
+                    data-icon='inline-start'
+                    className={generating ? 'animate-spin' : undefined}
+                    strokeWidth={2}
+                    aria-hidden='true'
+                  />
+                  {generating
+                    ? referenceImages.length > 0
+                      ? t('Editing...')
+                      : t('Generating...')
+                    : referenceImages.length > 0
+                      ? t('Edit image')
+                      : t('Generate image')}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <aside
+          data-slot='drawing-inspector'
+          className='bg-card flex min-w-0 flex-col rounded-lg border'
+        >
+          <div className='border-b p-4'>
+            <div className='flex items-start justify-between gap-3'>
+              <h2 className='text-base font-semibold'>
+                {t('Generation setup')}
+              </h2>
+              {configurationReady ? (
+                <Badge variant='secondary'>{t('Ready')}</Badge>
               ) : null}
             </div>
+            <p className='text-muted-foreground mt-2 text-xs leading-5'>
+              {t('Choose a route and output settings.')}
+            </p>
+          </div>
+
+          <div className='grid gap-5 p-4'>
             <div className='grid gap-2'>
               <Label htmlFor='drawing-group'>{t('Routing group')}</Label>
               <NativeSelect
@@ -871,49 +931,8 @@ export function Drawing() {
             </div>
           </div>
 
-          <div className='mt-auto grid gap-3 border-t p-5'>
-            {error ? (
-              <Alert variant='destructive'>
-                <AlertTitle>{t('Request failed')}</AlertTitle>
-                <AlertDescription>{error}</AlertDescription>
-                <AlertAction>
-                  <Button
-                    type='button'
-                    size='sm'
-                    variant='outline'
-                    onClick={() => void generate()}
-                    disabled={generating}
-                  >
-                    {t('Retry')}
-                  </Button>
-                </AlertAction>
-              </Alert>
-            ) : null}
-            <Button
-              type='button'
-              className='h-11 w-full'
-              onClick={() => void generate()}
-              disabled={
-                generating || !prompt.trim() || !selectedGroup || !selectedModel
-              }
-            >
-              {generating ? (
-                <RefreshCw
-                  className='mr-2 size-4 animate-spin'
-                  aria-hidden='true'
-                />
-              ) : (
-                <ImageIcon className='mr-2 size-4' aria-hidden='true' />
-              )}
-              {generating
-                ? referenceImages.length > 0
-                  ? t('Editing...')
-                  : t('Generating...')
-                : referenceImages.length > 0
-                  ? t('Edit image')
-                  : t('Generate image')}
-            </Button>
-            <p className='text-muted-foreground text-center text-xs leading-5'>
+          <div className='mt-auto border-t p-4'>
+            <p className='text-muted-foreground text-xs leading-5'>
               {t('Billing follows the selected group configuration.')}
             </p>
           </div>
@@ -925,21 +944,50 @@ export function Drawing() {
   return (
     <SectionPageLayout>
       <SectionPageLayout.Title>{t('Drawing studio')}</SectionPageLayout.Title>
+      {accessGranted ? (
+        <SectionPageLayout.Actions>
+          <Button
+            type='button'
+            size='sm'
+            variant='outline'
+            aria-expanded={drawingMcpOpen}
+            aria-controls='drawing-mcp-panel'
+            onClick={() => setDrawingMcpOpen((open) => !open)}
+          >
+            <HugeiconsIcon
+              icon={McpServerIcon}
+              data-icon='inline-start'
+              strokeWidth={2}
+              aria-hidden='true'
+            />
+            {t('Drawing MCP')}
+          </Button>
+        </SectionPageLayout.Actions>
+      ) : null}
       <SectionPageLayout.Content>
         <div className='mx-auto w-full max-w-7xl pb-16'>
-          <header className='mb-8 grid gap-2'>
+          <header className='mb-4 grid gap-2'>
             <p className='text-muted-foreground text-sm'>
               {t(
                 'Create images through the same safe, group-aware relay used by the API.'
               )}
             </p>
           </header>
-          {accessGranted ? (
-            <section className='bg-card mb-5 grid gap-4 border p-4 sm:p-5'>
+          {content}
+          {accessGranted && drawingMcpOpen ? (
+            <section
+              id='drawing-mcp-panel'
+              className='bg-card mt-4 grid gap-4 rounded-lg border p-4 sm:p-5'
+            >
               <div className='flex flex-wrap items-start justify-between gap-3'>
                 <div className='flex min-w-0 items-start gap-3'>
-                  <span className='bg-primary/10 text-primary flex size-9 shrink-0 items-center justify-center rounded-lg'>
-                    <ServerCog className='size-4' aria-hidden='true' />
+                  <span className='bg-primary/10 text-primary flex size-9 shrink-0 items-center justify-center rounded-md'>
+                    <HugeiconsIcon
+                      icon={McpServerIcon}
+                      className='size-4'
+                      strokeWidth={2}
+                      aria-hidden='true'
+                    />
                   </span>
                   <div className='min-w-0'>
                     <h2 className='text-sm font-semibold'>
@@ -959,7 +1007,13 @@ export function Drawing() {
                   onClick={() => void copyDrawingMcpConfig()}
                   disabled={drawingMcpPending}
                 >
-                  <Copy data-icon='inline-start' />
+                  <HugeiconsIcon
+                    icon={drawingMcpPending ? Loading03Icon : Copy01Icon}
+                    data-icon='inline-start'
+                    className={drawingMcpPending ? 'animate-spin' : undefined}
+                    strokeWidth={2}
+                    aria-hidden='true'
+                  />
                   {drawingMcpPending
                     ? t('Loading')
                     : drawingMcpToken
@@ -999,7 +1053,6 @@ export function Drawing() {
               ) : null}
             </section>
           ) : null}
-          {content}
         </div>
       </SectionPageLayout.Content>
     </SectionPageLayout>


### PR DESCRIPTION
# LMM API Pull Request

## 变更说明 / Summary

Streamline the authenticated drawing workbench around its primary generation workflow.

- Keep the canvas, prompt, reference images, request errors, and generate/edit action in one composer.
- Reduce the inspector to routing and output settings so the primary action remains reachable on compact screens.
- Move Drawing MCP configuration behind a page action and render it only when requested.
- Replace page-local status and empty-state treatments with shared `Badge` and `Empty` primitives, and align icons with the configured Hugeicons library.
- Remove the decorative dot grid, heavy shadows, oversized radii, and low-contrast canvas text.
- Preserve all existing generation, image-edit, token, billing, and query behavior.

Compatibility impact: none. No API, request payload, route, billing, authorization, or translation-key contract changes.

Release note intent: include as a drawing workbench UX improvement in the next web release notes.

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A; this changes an LMM Forge authenticated workflow.

## 关联 Issue / Related issue

None. Open issues and pull requests were searched before implementation; no duplicate drawing-workbench work was found.

## 变更类型 / Type of change

- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [x] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
command: bun test src/features/drawing/index.test.tsx
result: 3 passed, 0 failed

command: bun run typecheck
result: passed

command: bun run lint
result: passed

command: bun run build
result: production build passed

command: bunx oxfmt --check src/features/drawing/index.tsx src/features/drawing/index.test.tsx
result: passed
```

Focused regressions cover full-width mobile selects, composer ownership of reference upload and the primary action, MCP default-collapse/expand behavior, removal of the decorative grid, and recovery when no usable preview is returned.

## 截图或日志 / Screenshots or logs

Rendered locally with the repository's synthetic persona runtime and a temporary read-only image catalog fixture (removed after verification; not included in this PR):

| State | Viewport | Result |
| --- | --- | --- |
| Light, empty generation | 1440 x 1000 | Canvas/composer and inspector aligned; no horizontal overflow |
| Light, empty generation | 390 x 844 | Prompt, reference upload, and primary action visible before the inspector; no clipping |
| Mobile inspector | 390 x 844 | All five native selects remain readable with 44 px mobile height |
| Mobile MCP expanded | 390 x 844 | Panel renders after the primary workflow; endpoint input stays within bounds |
| Dark mode | 1440 x 1000 | Semantic inspector surfaces and dark canvas remain readable |
| Reference-image edit state | 1440 x 1000 | Reference thumbnail, ordinal label, removal action, and Edit image CTA render in the composer |

No screenshot artifact is attached because the authenticated route was rendered with local synthetic data. No production credentials, cookies, tokens, or user data were used.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；本次无破坏性变化。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果。
- [x] 文档和多语言文案不需要更新：没有新增 API、配置、流程文档或翻译键。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Sourcery 总结

围绕响应式、以 composer 为先的生成工作流，简化已认证的绘图工作台。

改进：
- 重新组织绘图工作台：将提示词、参考图像、错误信息以及主要的生成/编辑操作集中到 composer 中，同时让检查器专注于路由和输出设置。
- 仅在通过页面操作明确打开时，才配置 Drawing MCP；默认情况下将其置于主要工作流之外。
- 更新工作台的视觉设计：采用共享的空状态和徽章组件，统一使用 Hugeicons，改进响应式控件，并简化画布呈现。

测试：
- 添加回归测试，覆盖 composer 所属关系、移动端控件尺寸、装饰网格移除、MCP 折叠与展开行为，以及预览恢复。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

围绕响应式、以合成为优先的生成工作流，简化经过身份验证的绘图工作台。

增强功能：
- 重新组织绘图工作台，使合成器集中处理提示词、参考图像、错误和生成操作，同时将检查器简化为路由和输出设置。
- 将 Drawing MCP 配置移至显式页面操作之后，并在请求前保持折叠状态。
- 使用共享的空状态和徽章组件、统一的 Hugeicons、响应式移动端控件以及更轻量的画布样式，更新工作台的呈现效果。

测试：
- 添加回归测试，涵盖合成器归属、移动端控件尺寸、移除装饰网格、MCP 折叠与展开以及预览恢复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Streamline the authenticated drawing workbench around a responsive, composer-first generation workflow.

Enhancements:
- Reorganize the drawing workbench around a composer that keeps prompting, reference images, errors, and generation actions together while simplifying the inspector to routing and output settings.
- Move Drawing MCP configuration behind an explicit page action and keep it collapsed until requested.
- Refresh the workbench presentation with shared empty-state and badge components, consistent Hugeicons, responsive mobile controls, and a lighter canvas treatment.

Tests:
- Add regressions covering composer ownership, mobile control sizing, decorative grid removal, MCP collapse and expansion, and preview recovery.

</details>

</details>