### PR TITLE
test(go): stabilize HTTP/2 retry fixtures

### DIFF
--- a/apps/api-go/relay/channel/api_request_getbody_test.go
+++ b/apps/api-go/relay/channel/api_request_getbody_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -374,7 +375,11 @@ func awaitH2ServerResult(t *testing.T, resultCh <-chan h2ServerResult) h2ServerR
 // retry-safe reset some proxy/CDN-fronted upstreams send under load or during
 // graceful shutdown, see RFC 9113 section 8.7). When expectRetry is true it
 // serves the retried stream a 200 response; otherwise it stops after the reset.
-func runResetOnFirstStreamServer(ln net.Listener, expectRetry bool) <-chan h2ServerResult {
+func runResetOnFirstStreamServer(
+	ln net.Listener,
+	expectRetry bool,
+	releaseAfterReset <-chan struct{},
+) <-chan h2ServerResult {
 	resCh := make(chan h2ServerResult, 1)
 	go func() {
 		res := h2ServerResult{}
@@ -403,6 +408,9 @@ func runResetOnFirstStreamServer(ln net.Listener, expectRetry bool) <-chan h2Ser
 					return
 				}
 				if !expectRetry {
+					if releaseAfterReset != nil {
+						<-releaseAfterReset
+					}
 					break attempts
 				}
 				continue
@@ -417,43 +425,57 @@ func runResetOnFirstStreamServer(ln net.Listener, expectRetry bool) <-chan h2Ser
 	return resCh
 }
 
-func runGoAwayAfterFirstRequestServer(ln net.Listener) <-chan h2ServerResult {
+func runGoAwayAfterFirstRequestServer(
+	ln net.Listener,
+	releaseConnections <-chan struct{},
+) <-chan h2ServerResult {
 	resCh := make(chan h2ServerResult, 1)
 	go func() {
 		res := h2ServerResult{}
 		defer func() { resCh <- res }()
 
-		for attempt := 0; attempt < 2; attempt++ {
-			conn, framer, err := acceptH2TestConnection(ln)
-			if err != nil {
-				res.err = err
-				return
-			}
-			streamID, body, err := readH2TestRequest(framer)
-			if err != nil {
-				conn.Close()
-				res.err = err
-				return
-			}
-			res.streamCount++
-			res.attemptBodies = append(res.attemptBodies, body)
-
-			if attempt == 0 {
-				err = framer.WriteGoAway(0, http2.ErrCodeNo, nil)
-				conn.Close()
-				if err != nil {
-					res.err = err
-					return
-				}
-				continue
-			}
-
-			err = writeH2TestResponse(framer, streamID)
-			conn.Close()
-			if err != nil {
-				res.err = err
-			}
+		firstConn, firstFramer, err := acceptH2TestConnection(ln)
+		if err != nil {
+			res.err = err
 			return
+		}
+		defer firstConn.Close()
+
+		_, firstBody, err := readH2TestRequest(firstFramer)
+		if err != nil {
+			res.err = err
+			return
+		}
+		res.streamCount++
+		res.attemptBodies = append(res.attemptBodies, firstBody)
+		if err := firstFramer.WriteGoAway(0, http2.ErrCodeNo, nil); err != nil {
+			res.err = err
+			return
+		}
+
+		// Keep the first connection open until the client has processed GOAWAY
+		// and established its retry connection. Closing immediately can race the
+		// control frame and surface a platform-specific TCP reset instead.
+		secondConn, secondFramer, err := acceptH2TestConnection(ln)
+		if err != nil {
+			res.err = err
+			return
+		}
+		defer secondConn.Close()
+
+		streamID, secondBody, err := readH2TestRequest(secondFramer)
+		if err != nil {
+			res.err = err
+			return
+		}
+		res.streamCount++
+		res.attemptBodies = append(res.attemptBodies, secondBody)
+		if err := writeH2TestResponse(secondFramer, streamID); err != nil {
+			res.err = err
+			return
+		}
+		if releaseConnections != nil {
+			<-releaseConnections
 		}
 	}()
 	return resCh
@@ -488,7 +510,7 @@ func TestUpstreamGetBody_HTTP2RetryAfterUpstreamStreamReset(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer ln.Close()
-	resCh := runResetOnFirstStreamServer(ln, true)
+	resCh := runResetOnFirstStreamServer(ln, true, nil)
 
 	client, transport := newH2PriorKnowledgeClient(ln)
 	defer transport.CloseIdleConnections()
@@ -523,7 +545,7 @@ func TestUpstreamGetBody_HTTP2RetryAfterUpstreamStreamReset_PassThrough(t *testi
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer ln.Close()
-	resCh := runResetOnFirstStreamServer(ln, true)
+	resCh := runResetOnFirstStreamServer(ln, true, nil)
 
 	client, transport := newH2PriorKnowledgeClient(ln)
 	defer transport.CloseIdleConnections()
@@ -555,7 +577,13 @@ func TestUpstreamGetBody_HTTP2RetryAfterGracefulGoAway_PassThrough(t *testing.T)
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer ln.Close()
-	resCh := runGoAwayAfterFirstRequestServer(ln)
+	releaseConnections := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseServer := func() {
+		releaseOnce.Do(func() { close(releaseConnections) })
+	}
+	defer releaseServer()
+	resCh := runGoAwayAfterFirstRequestServer(ln, releaseConnections)
 
 	client, transport := newH2PriorKnowledgeClient(ln)
 	defer transport.CloseIdleConnections()
@@ -568,6 +596,7 @@ func TestUpstreamGetBody_HTTP2RetryAfterGracefulGoAway_PassThrough(t *testing.T)
 	require.NotNil(t, req.GetBody)
 
 	resp, err := client.Do(req)
+	releaseServer()
 	require.NoError(t, err, "the transport must retry on a new connection after graceful GOAWAY")
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -589,7 +618,13 @@ func TestUpstreamGetBody_HTTP2CannotRetryWithoutGetBody(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer ln.Close()
-	resCh := runResetOnFirstStreamServer(ln, false)
+	releaseAfterReset := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseServer := func() {
+		releaseOnce.Do(func() { close(releaseAfterReset) })
+	}
+	defer releaseServer()
+	resCh := runResetOnFirstStreamServer(ln, false, releaseAfterReset)
 
 	client, transport := newH2PriorKnowledgeClient(ln)
 	defer transport.CloseIdleConnections()
@@ -604,6 +639,7 @@ func TestUpstreamGetBody_HTTP2CannotRetryWithoutGetBody(t *testing.T) {
 	assert.Nil(t, req.GetBody)
 
 	resp, err := client.Do(req) //nolint:bodyclose // Do fails, no body to close
+	releaseServer()
 	require.Error(t, err)
 	assert.Nil(t, resp)
 	require.ErrorContains(t, err, "cannot retry err")

--- a/apps/api-go/relay/channel/api_request_getbody_test.go
+++ b/apps/api-go/relay/channel/api_request_getbody_test.go
@@ -374,7 +374,8 @@ func awaitH2ServerResult(t *testing.T, resultCh <-chan h2ServerResult) h2ServerR
 // been fully written, and then resets the stream with REFUSED_STREAM (the
 // retry-safe reset some proxy/CDN-fronted upstreams send under load or during
 // graceful shutdown, see RFC 9113 section 8.7). When expectRetry is true it
-// serves the retried stream a 200 response; otherwise it stops after the reset.
+// serves the retried stream a 200 response; otherwise it waits for the release
+// signal after sending the reset before closing the connection and returning.
 func runResetOnFirstStreamServer(
 	ln net.Listener,
 	expectRetry bool,


### PR DESCRIPTION
## Summary

- keep the raw HTTP/2 test connection open until the client has processed a non-retryable RST_STREAM
- keep both GOAWAY connections alive until the transparent retry has completed
- preserve the existing strict retry/error assertions while removing Windows TCP-close races

## Reproduction

On an unmodified Windows checkout, the non-retry test failed 5 of 20 repeated runs:

    GOMAXPROCS=2 go test ./relay/channel -run '^TestUpstreamGetBody_HTTP2CannotRetryWithoutGetBody$' -count=20 -p=1

Instead of the expected HTTP/2 cannot-retry error, net/http intermittently observed wsarecv: An existing connection was forcibly closed by the remote host. Repeating all three HTTP/2 scenarios also exposed the same race in the graceful GOAWAY fixture.

The fixture wrote RST_STREAM or GOAWAY and immediately closed the TCP connection, so Windows could surface the connection close before the client consumed the HTTP/2 control frame.

## Validation

- GOMAXPROCS=2 go test ./relay/channel -run '^TestUpstreamGetBody_HTTP2' -count=100 -p=1
- GOMAXPROCS=2 go test ./relay/channel -count=1 -p=1
- GOMAXPROCS=2 go vet ./relay/channel
- git diff --check

All commands above pass locally.

## Sourcery 摘要

防止 HTTP/2 测试固定装置在客户端处理 reset 和 GOAWAY 帧之前关闭连接，从而消除依赖平台的 TCP 关闭竞争问题。

Bug 修复：
- 通过防止连接过早关闭而掩盖预期的客户端错误，稳定 HTTP/2 重试和非重试测试固定装置。

增强功能：
- 协调固定装置连接生命周期与客户端处理过程，使 reset 和优雅 GOAWAY 场景在不同平台上都能保留严格的重试和错误断言。

测试：
- 加强 HTTP/2 固定装置在重试、直通和无法重试场景下的同步机制。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

消除 HTTP/2 重试 fixture 测试中与平台相关的 TCP 关闭竞态条件。

Bug 修复：
- 通过防止连接在 Windows 上过早关闭而掩盖预期的客户端结果，稳定 HTTP/2 重试和非重试测试 fixture。

增强功能：
- 协调 fixture 连接生命周期与客户端对流重置和优雅 GOAWAY 重试的处理，同时保留严格的重试和错误断言。

测试：
- 改进 HTTP/2 重试、透传、优雅 GOAWAY 以及无法重试测试场景中的同步机制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Eliminate platform-dependent TCP-close races from HTTP/2 retry fixture tests.

Bug Fixes:
- Stabilize HTTP/2 retry and non-retry test fixtures by preventing premature connection closure from masking the expected client outcomes on Windows.

Enhancements:
- Coordinate fixture connection lifetimes with client processing for stream resets and graceful GOAWAY retries while preserving strict retry and error assertions.

Tests:
- Improve synchronization in HTTP/2 retry, pass-through, graceful GOAWAY, and cannot-retry test scenarios.

</details>

</details>