### PR TITLE
fix(web): hide unconfigured OAuth binding actions

### DIFF
--- a/apps/web/src/features/profile/components/tabs/account-bindings-compatibility.test.tsx
+++ b/apps/web/src/features/profile/components/tabs/account-bindings-compatibility.test.tsx
@@ -122,6 +122,27 @@ function customOAuthStatus() {
   }
 }
 
+function misconfiguredOAuthStatus() {
+  return {
+    github_oauth: true,
+    discord_oauth: true,
+    oidc_enabled: true,
+    telegram_oauth: true,
+    linuxdo_oauth: true,
+    custom_oauth_providers: [
+      {
+        id: 43,
+        name: 'Incomplete SSO',
+        slug: 'incomplete-sso',
+        icon: 'link',
+        client_id: '',
+        authorization_endpoint: '',
+        scopes: 'openid',
+      },
+    ],
+  }
+}
+
 const profile: UserProfile = {
   id: 7,
   username: 'compat-user',
@@ -173,6 +194,41 @@ afterEach(() => {
 after(() => domWindow.close())
 
 describe('legacy Go account binding compatibility', () => {
+  test('hides binding actions whose required OAuth configuration is missing', async () => {
+    const status = misconfiguredOAuthStatus()
+    api.get = (async (url) => {
+      if (url === '/api/status') {
+        return { data: { success: true, data: status } }
+      }
+      return { data: { success: true, data: [] } }
+    }) as typeof api.get
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    queryClient.setQueryData(['status', 'anonymous'], status)
+    const { root } = await renderBindings(queryClient)
+
+    for (const provider of [
+      'GitHub',
+      'Discord',
+      'OIDC',
+      'Telegram',
+      'LinuxDO',
+      'Incomplete SSO',
+    ]) {
+      assert.equal(
+        document.body.textContent?.includes(provider),
+        false,
+        `unexpected binding provider: ${provider}`
+      )
+    }
+    assert.equal(buttonsWithText('Bind').length, 0)
+
+    await act(async () => root.unmount())
+    queryClient.clear()
+  })
+
   test('does not render or call built-in unbind from stale capabilities after legacy status', async () => {
     const statusResponse = deferred<{
       data: { success: boolean; data: { github_oauth: boolean } }

--- a/apps/web/src/features/profile/components/tabs/account-bindings-tab.tsx
+++ b/apps/web/src/features/profile/components/tabs/account-bindings-tab.tsx
@@ -37,6 +37,7 @@ import {
   getOAuthSessionStorage,
   markOAuthBindPopup,
 } from '@/features/auth/lib/oauth-callback-mode'
+import { isOAuthProviderConfigured } from '@/features/auth/lib/registration'
 import type { CustomOAuthProviderInfo } from '@/features/auth/types'
 import { useDialogs } from '@/hooks/use-dialog'
 import { useStatus } from '@/hooks/use-status'
@@ -125,9 +126,12 @@ export function AccountBindingsTab({
     []
   )
 
-  const customProviders = status?.custom_oauth_providers as
-    | CustomOAuthProviderInfo[]
-    | undefined
+  const customProviders = (
+    status?.custom_oauth_providers as CustomOAuthProviderInfo[] | undefined
+  )?.filter((provider) =>
+    isOAuthProviderConfigured(status, `custom:${provider.slug}`)
+  )
+  const hasCustomProviders = Boolean(customProviders?.length)
   const customBindingsByProviderId = useMemo(
     () => indexCustomOAuthBindings(customBindings),
     [customBindings]
@@ -135,7 +139,7 @@ export function AccountBindingsTab({
   const canUnbindBuiltInOAuth = getBackendCapabilities(status).self_oauth_unbind
 
   const fetchCustomBindings = useCallback(async () => {
-    if (!customProviders || customProviders.length === 0) return
+    if (!hasCustomProviders) return
     try {
       const res = await getSelfOAuthBindings()
       if (res.success && res.data) {
@@ -144,7 +148,7 @@ export function AccountBindingsTab({
     } catch {
       // ignore
     }
-  }, [customProviders])
+  }, [hasCustomProviders])
 
   useEffect(() => {
     fetchCustomBindings()
@@ -352,7 +356,7 @@ export function AccountBindingsTab({
         isBound: Boolean(
           (profile as unknown as Record<string, unknown>).wechat_id
         ),
-        isEnabled: status?.wechat_login || false,
+        isEnabled: isOAuthProviderConfigured(status, 'wechat'),
         onBind: () => dialogs.open('wechat'),
         onUnbind: canUnbindBuiltInOAuth
           ? () =>
@@ -373,7 +377,7 @@ export function AccountBindingsTab({
         isBound: Boolean(
           (profile as unknown as Record<string, unknown>).github_id
         ),
-        isEnabled: status?.github_oauth || false,
+        isEnabled: isOAuthProviderConfigured(status, 'github'),
         onBind: () => {
           const clientId = status?.github_client_id
           if (clientId) {
@@ -402,7 +406,7 @@ export function AccountBindingsTab({
         isBound: Boolean(
           (profile as unknown as Record<string, unknown>).discord_id
         ),
-        isEnabled: status?.discord_oauth || false,
+        isEnabled: isOAuthProviderConfigured(status, 'discord'),
         onBind: () => {
           const clientId = status?.discord_client_id
           if (clientId) {
@@ -431,7 +435,7 @@ export function AccountBindingsTab({
         isBound: Boolean(
           (profile as unknown as Record<string, unknown>).oidc_id
         ),
-        isEnabled: status?.oidc_enabled || false,
+        isEnabled: isOAuthProviderConfigured(status, 'oidc'),
         onBind: () => {
           const authorizationEndpoint = status?.oidc_authorization_endpoint
           const clientId = status?.oidc_client_id
@@ -461,7 +465,7 @@ export function AccountBindingsTab({
         isBound: Boolean(
           (profile as unknown as Record<string, unknown>).telegram_id
         ),
-        isEnabled: status?.telegram_oauth || false,
+        isEnabled: isOAuthProviderConfigured(status, 'telegram'),
         onBind: () => dialogs.open('telegram'),
         onUnbind: canUnbindBuiltInOAuth
           ? () =>
@@ -482,7 +486,7 @@ export function AccountBindingsTab({
         isBound: Boolean(
           (profile as unknown as Record<string, unknown>).linux_do_id
         ),
-        isEnabled: status?.linuxdo_oauth || false,
+        isEnabled: isOAuthProviderConfigured(status, 'linuxdo'),
         onBind: () => {
           const clientId = status?.linuxdo_client_id
           if (clientId) {


### PR DESCRIPTION
## What changed
- Reuse the shared OAuth configuration predicate when rendering account-binding actions.
- Filter custom OAuth providers and avoid fetching bindings when none are launchable.
- Add a compatibility regression covering enabled flags with missing required credentials.

## Bug evidence
When the live status payload reported github_oauth: true without github_client_id (and equivalent incomplete Discord/OIDC/Telegram/LinuxDO/custom entries), the account bindings page rendered Bind actions that could not initialize. The existing registration flow already treats these providers as unavailable when required configuration is missing.

The new regression test fails on the pre-fix code and passes after the fix.

## Validation
- bunx --bun bun@1.3.14 test apps/web/src/features/profile/components/tabs/account-bindings-compatibility.test.tsx
- bun run --filter @lmm/web typecheck
- bun run --filter @lmm/web lint
- bunx --bun bun@1.3.14 run test:web (217 files)
- oxfmt --check on both changed files

The repository-wide protected-header format check still reports pre-existing issues in seven scripts/*.mjs files; the two changed files pass targeted formatting.

## Sourcery 摘要

防止因配置不完整而无法初始化的 OAuth 提供商显示账户绑定操作。

错误修复：
- 当内置和自定义 OAuth 提供商已启用但缺少必需配置时，隐藏账户绑定操作。
- 当没有可用的已配置自定义提供商时，跳过自定义 OAuth 绑定请求。

改进：
- 在账户绑定可用性检查中复用共享的 OAuth 配置谓词。

测试：
- 添加兼容性回归测试，涵盖配置不完整的内置和自定义 OAuth 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent account-binding actions from appearing for OAuth providers that cannot be initialized due to incomplete configuration.

Bug Fixes:
- Hide built-in and custom OAuth account-binding actions when providers are enabled but missing required configuration.
- Skip custom OAuth binding requests when no configured custom providers are available.

Enhancements:
- Reuse the shared OAuth configuration predicate across account-binding availability checks.

Tests:
- Add a compatibility regression test covering incomplete built-in and custom OAuth configurations.

</details>