### PR TITLE
fix(rust): disable reverse-proxy buffering for SSE relays

### DIFF
--- a/apps/api-rust/src/routes/relay_anthropic_gemini.rs
+++ b/apps/api-rust/src/routes/relay_anthropic_gemini.rs
@@ -13,7 +13,7 @@ use axum::{
     Json, Router,
     body::{Body, to_bytes},
     extract::{Path, Request, State},
-    http::{HeaderValue, StatusCode, header},
+    http::{HeaderName, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
     routing::{MethodRouter, post},
 };
@@ -992,6 +992,17 @@ fn add_compat_headers(response: &mut Response, channel_id: i64, request_id: &str
         && let Ok(value) = HeaderValue::from_str(&channel_id.to_string())
     {
         response.headers_mut().insert(CHANNEL_ID, value);
+    }
+    if response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("text/event-stream"))
+    {
+        response.headers_mut().insert(
+            HeaderName::from_static("x-accel-buffering"),
+            HeaderValue::from_static("no"),
+        );
     }
 }
 

--- a/apps/api-rust/src/routes/relay_anthropic_gemini.rs
+++ b/apps/api-rust/src/routes/relay_anthropic_gemini.rs
@@ -997,7 +997,11 @@ fn add_compat_headers(response: &mut Response, channel_id: i64, request_id: &str
         .headers()
         .get(header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.starts_with("text/event-stream"))
+        .is_some_and(|value| {
+            value.split(';').next().is_some_and(|media_type| {
+                media_type.trim().eq_ignore_ascii_case("text/event-stream")
+            })
+        })
     {
         response.headers_mut().insert(
             HeaderName::from_static("x-accel-buffering"),

--- a/apps/api-rust/src/routes/relay_misc.rs
+++ b/apps/api-rust/src/routes/relay_misc.rs
@@ -672,7 +672,11 @@ pub(super) fn filtered_upstream_response(mut response: Response) -> Response {
         .headers()
         .get(header::CONTENT_TYPE)
         .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.starts_with("text/event-stream"))
+        .is_some_and(|value| {
+            value.split(';').next().is_some_and(|media_type| {
+                media_type.trim().eq_ignore_ascii_case("text/event-stream")
+            })
+        })
     {
         response.headers_mut().insert(
             header::HeaderName::from_static("x-accel-buffering"),
@@ -1343,7 +1347,7 @@ mod tests {
         let mut response = Response::new(Body::empty());
         response.headers_mut().insert(
             header::CONTENT_TYPE,
-            HeaderValue::from_static("text/event-stream; charset=utf-8"),
+            HeaderValue::from_static("Text/Event-Stream; charset=utf-8"),
         );
 
         let response = filtered_upstream_response(response);

--- a/apps/api-rust/src/routes/relay_misc.rs
+++ b/apps/api-rust/src/routes/relay_misc.rs
@@ -668,6 +668,17 @@ pub(super) fn filtered_upstream_response(mut response: Response) -> Response {
             && !is_hop_by_hop(name)
     });
     *response.headers_mut() = headers;
+    if response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("text/event-stream"))
+    {
+        response.headers_mut().insert(
+            header::HeaderName::from_static("x-accel-buffering"),
+            header::HeaderValue::from_static("no"),
+        );
+    }
     response
 }
 
@@ -1325,6 +1336,19 @@ mod tests {
         assert!(response.headers().get("x-provider-hop").is_none());
         assert_eq!(response.headers()[header::CONTENT_TYPE], "application/json");
         assert_eq!(response.headers()["x-upstream-request-id"], "up-1");
+    }
+
+    #[test]
+    fn upstream_sse_response_disables_reverse_proxy_buffering() {
+        let mut response = Response::new(Body::empty());
+        response.headers_mut().insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/event-stream; charset=utf-8"),
+        );
+
+        let response = filtered_upstream_response(response);
+
+        assert_eq!(response.headers()["x-accel-buffering"], "no");
     }
 
     struct LoopbackService {

--- a/apps/api-rust/src/routes/relay_openai.rs
+++ b/apps/api-rust/src/routes/relay_openai.rs
@@ -991,6 +991,10 @@ fn legacy_success(
             response
                 .headers_mut()
                 .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-cache"));
+            response.headers_mut().insert(
+                HeaderName::from_static("x-accel-buffering"),
+                HeaderValue::from_static("no"),
+            );
             response
         }
         OpenAiRelayBody::Upstream { content_type, body } => {
@@ -1014,6 +1018,12 @@ fn legacy_success(
                 response
                     .headers_mut()
                     .insert(header::CONTENT_TYPE, content_type);
+            }
+            if stream {
+                response.headers_mut().insert(
+                    HeaderName::from_static("x-accel-buffering"),
+                    HeaderValue::from_static("no"),
+                );
             }
             response
         }
@@ -1300,6 +1310,7 @@ fn copy_safe_headers(source: &HeaderMap, target: &mut HeaderMap) {
         if !is_hop_by_hop(name)
             && name != header::CONTENT_TYPE
             && name != header::CONTENT_LENGTH
+            && name != "x-accel-buffering"
             && name != "x-new-api-version"
             && name != "x-oneapi-request-id"
         {

--- a/apps/api-rust/tests/relay_anthropic_gemini.rs
+++ b/apps/api-rust/tests/relay_anthropic_gemini.rs
@@ -518,7 +518,7 @@ async fn native_sse_passthrough_preserves_unknown_frames_and_does_not_append_don
             StatusCode::CREATED,
             Body::from(expected.to_vec()),
             Some(HeaderValue::from_static(
-                "text/event-stream; charset=iso-8859-1",
+                "Text/Event-Stream; charset=iso-8859-1",
             )),
         )),
     )));
@@ -538,7 +538,7 @@ async fn native_sse_passthrough_preserves_unknown_frames_and_does_not_append_don
     assert_eq!(response.status(), StatusCode::CREATED);
     assert_eq!(
         response.headers()["content-type"],
-        "text/event-stream; charset=iso-8859-1"
+        "Text/Event-Stream; charset=iso-8859-1"
     );
     assert_eq!(response.headers()["cache-control"], "no-cache");
     assert_eq!(response.headers()["x-accel-buffering"], "no");

--- a/apps/api-rust/tests/relay_anthropic_gemini.rs
+++ b/apps/api-rust/tests/relay_anthropic_gemini.rs
@@ -541,6 +541,7 @@ async fn native_sse_passthrough_preserves_unknown_frames_and_does_not_append_don
         "text/event-stream; charset=iso-8859-1"
     );
     assert_eq!(response.headers()["cache-control"], "no-cache");
+    assert_eq!(response.headers()["x-accel-buffering"], "no");
     let body = to_bytes(response.into_body(), usize::MAX)
         .await
         .expect("response body");

--- a/apps/api-rust/tests/relay_openai.rs
+++ b/apps/api-rust/tests/relay_openai.rs
@@ -254,6 +254,11 @@ async fn responses_route_serializes_typed_stream_as_named_sse_events() {
         response.headers()[header::CONTENT_TYPE],
         "text/event-stream; charset=utf-8"
     );
+    assert_eq!(
+        response.headers()["x-accel-buffering"],
+        "no",
+        "streaming responses must opt out of reverse-proxy buffering"
+    );
     let body = String::from_utf8(
         to_bytes(response.into_body(), usize::MAX)
             .await
@@ -265,6 +270,33 @@ async fn responses_route_serializes_typed_stream_as_named_sse_events() {
     assert!(body.contains("event: response.output_text.delta\n"));
     assert!(body.contains("event: response.completed\n"));
     assert!(body.ends_with("data: [DONE]\n\n"));
+}
+
+#[tokio::test]
+async fn native_openai_sse_sets_reverse_proxy_buffering_header() {
+    let service = service(Ok(OpenAiRelayResult {
+        status: StatusCode::OK,
+        headers: Default::default(),
+        body: OpenAiRelayBody::Upstream {
+            content_type: Some(header::HeaderValue::from_static("text/event-stream")),
+            body: Body::from("data: {\"opaque\":true}\n\ndata: [DONE]\n\n"),
+        },
+    }));
+    let router = openai_relay_router(OpenAiRelayHttpState::new(service, "v0.0.0"));
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"model":"gpt-4o","stream":true}"#))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()["x-accel-buffering"], "no");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Sourcery 摘要

确保中继的服务器发送事件能够在不经过反向代理缓冲的情况下传递。

错误修复：
- 针对 Anthropic/Gemini、OpenAI 以及其他中继路径的服务器发送事件中继响应，禁用反向代理缓冲。

测试：
- 增加测试覆盖，验证 SSE 响应包含退出反向代理缓冲的响应头。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

确保中继的服务器发送事件能够在不经过反向代理缓冲的情况下交付。

错误修复：
- 为 Anthropic/Gemini、OpenAI 以及其他中继路径中的 SSE 响应禁用反向代理缓冲。

测试：
- 增加测试覆盖，验证 SSE 中继响应包含反向代理缓冲禁用标头。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure relayed server-sent events are delivered without reverse-proxy buffering.

Bug Fixes:
- Disable reverse-proxy buffering for SSE responses across Anthropic/Gemini, OpenAI, and miscellaneous relay paths.

Tests:
- Add coverage verifying SSE relay responses include the reverse-proxy buffering opt-out header.

</details>

</details>