### PR TITLE
fix(web): translate common payment audience role

### DIFF
--- a/apps/web/src/features/system-settings/integrations/payment-method-audience.ts
+++ b/apps/web/src/features/system-settings/integrations/payment-method-audience.ts
@@ -1,3 +1,24 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+/*
+Copyright (C) 2026 LIghtJUNction
+*/
 type PaymentMethodAudienceRoleOption = {
   label: string
   value: string

--- a/apps/web/src/features/system-settings/integrations/payment-method-audience.ts
+++ b/apps/web/src/features/system-settings/integrations/payment-method-audience.ts
@@ -1,0 +1,13 @@
+type PaymentMethodAudienceRoleOption = {
+  label: string
+  value: string
+}
+
+export const getPaymentMethodAudienceRoleOptions = (
+  t: (key: string) => string
+): PaymentMethodAudienceRoleOption[] => [
+  { label: t('No role condition'), value: 'none' },
+  { label: t('Common User'), value: 'common' },
+  { label: t('Administrator'), value: 'admin' },
+  { label: t('Root administrator'), value: 'root' },
+]

--- a/apps/web/src/features/system-settings/integrations/payment-method-dialog.test.ts
+++ b/apps/web/src/features/system-settings/integrations/payment-method-dialog.test.ts
@@ -1,0 +1,38 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { describe, test } from 'node:test'
+
+import zhLocale from '@/i18n/locales/zh.json'
+
+import { getPaymentMethodAudienceRoleOptions } from './payment-method-audience'
+
+describe('payment method audience role options', () => {
+  test('uses the translated common-user label', () => {
+    const translations = zhLocale.translation as Record<string, string>
+    const options = getPaymentMethodAudienceRoleOptions(
+      (key) => translations[key] ?? key
+    )
+
+    assert.equal(
+      options.find(({ value }) => value === 'common')?.label,
+      '普通用户'
+    )
+  })
+})

--- a/apps/web/src/features/system-settings/integrations/payment-method-dialog.tsx
+++ b/apps/web/src/features/system-settings/integrations/payment-method-dialog.tsx
@@ -46,6 +46,8 @@ import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { usesDedicatedPaymentPricing } from '@/lib/payment-pricing'
 
+import { getPaymentMethodAudienceRoleOptions } from './payment-method-audience'
+
 const SETTLEMENT_UNIT_PATTERN = /^[A-Za-z0-9._-]{1,16}$/
 const POSITIVE_DECIMAL_PATTERN = /^[0-9]+(?:\.[0-9]+)?$/
 const NON_NEGATIVE_INTEGER_PATTERN = /^(?:0|[1-9][0-9]*)$/
@@ -1117,14 +1119,9 @@ export function PaymentMethodDialog({
                         <FormLabel>{t('Account role condition')}</FormLabel>
                         <FormControl>
                           <Combobox
-                            options={[
-                              { label: t('No role condition'), value: 'none' },
-                              { label: t('Common user'), value: 'common' },
-                              { label: t('Administrator'), value: 'admin' },
-                              { label: t('Root administrator'), value: 'root' },
-                            ]}
+                            options={getPaymentMethodAudienceRoleOptions(t)}
                             value={field.value || 'none'}
-                            onValueChange={(value) =>
+                            onValueChange={(value: string | null) =>
                               value && field.onChange(value)
                             }
                             placeholder={t('Select account role')}


### PR DESCRIPTION
## Root cause
The payment method dialog asks for an account role but looks up `Common user` (lowercase `u`). Supported locale dictionaries define the translated key as `Common User`, so non-English dialogs fall back to the English label while other role selectors use the translated key.

## Reproduction
1. Open System Settings → Integrations → payment methods.
2. Open the audience/account-role condition selector with the Chinese locale enabled.
3. The common-role option is shown as `Common user` instead of `普通用户`.

## Fix
- Reuse the existing `Common User` translation key for the payment audience options.
- Extract the option list into a small helper so the mapping is directly testable without changing the dialog API.
- Add a regression test using the shipped Chinese locale and assert that the `common` option resolves to `普通用户`.

## Validation
- `bun test --timeout 15000 src/features/system-settings/integrations/payment-method-dialog.test.ts` (1 pass)
- `bun run --cwd apps/web lint` (pass)
- `bun run --cwd apps/web format:check` (pass)
- `bun run --cwd apps/web typecheck` (pass)
- `bun run --cwd apps/web test` (222 files passed)
- `git diff --check` (pass)

I searched all-state issues and pull requests for the relevant translation key/payment-audience terms; no existing implementation of this exact fix was found. Existing open PR #198 was inspected and does not modify the payment method dialog or this key.

No documentation or release-note update is needed for this internal label correction.

## Sourcery 摘要

使用共享的翻译标签表示常见支付受众角色，并为本地化对话框添加回归测试。

错误修复：
- 修正支付受众角色查找逻辑，使普通用户选项使用现有的翻译标签 `Common User`。

增强功能：
- 将支付受众角色选项提取为可复用的辅助函数，以便更清晰地进行映射和测试。

测试：
- 添加回归测试，验证中文区域设置下，常见支付受众角色解析为 `普通用户`。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修正支付受众角色的本地化，并为普通用户标签增加覆盖测试。

错误修复：
- 使用现有的 `Common User` 翻译键，确保普通支付受众角色能够正确本地化。

增强功能：
- 将支付受众角色选项提取为可复用的辅助函数，以便更清晰地进行映射和直接测试。

测试：
- 添加回归测试，确认使用随附的中文语言环境时，普通受众角色解析为 `普通用户`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct payment audience role localization and add coverage for the common-user label.

Bug Fixes:
- Use the existing `Common User` translation key so the common payment audience role is localized correctly.

Enhancements:
- Extract payment audience role options into a reusable helper for clearer mapping and direct testing.

Tests:
- Add a regression test confirming the common audience role resolves to `普通用户` with the shipped Chinese locale.

</details>

</details>