### PR TITLE
fix(web): sync table search from URL history

### DIFF
--- a/apps/web/src/hooks/use-table-url-state.test.tsx
+++ b/apps/web/src/hooks/use-table-url-state.test.tsx
@@ -1,0 +1,111 @@
+/*
+Copyright (C) 2023-2026 QuantumNous
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+For commercial licensing, please contact support@quantumnous.com
+*/
+import assert from 'node:assert/strict'
+import { after, test } from 'node:test'
+
+import { Window } from 'happy-dom'
+import type { Root } from 'react-dom/client'
+
+import type { NavigateFn } from './use-table-url-state'
+
+const domWindow = new Window({ url: 'https://console.example.test/users' })
+for (const key of [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'Node',
+  'Element',
+  'Event',
+  'MutationObserver',
+  'localStorage',
+] as const) {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value: domWindow[key],
+  })
+}
+
+const { act, useEffect } = await import('react')
+const { createRoot } = await import('react-dom/client')
+const { useTableUrlState } = await import('./use-table-url-state')
+
+const reactTestGlobals = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean
+}
+reactTestGlobals.IS_REACT_ACT_ENVIRONMENT = true
+
+type HookValue = ReturnType<typeof useTableUrlState>
+let currentHook: HookValue | null = null
+const navigations: Parameters<NavigateFn>[0][] = []
+const navigate: NavigateFn = (options) => {
+  navigations.push(options)
+}
+
+function Harness({ search }: { search: Record<string, unknown> }) {
+  const hook = useTableUrlState({
+    search,
+    navigate,
+    pagination: { defaultPage: 1, defaultPageSize: 20 },
+    globalFilter: { key: 'query' },
+  })
+  useEffect(() => {
+    currentHook = hook
+  }, [hook])
+  return null
+}
+
+async function render(root: Root, search: Record<string, unknown>) {
+  await act(async () => {
+    root.render(<Harness search={search} />)
+  })
+}
+
+after(() => domWindow.close())
+
+test('global filter follows URL history without clobbering a pending local value', async () => {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+
+  try {
+    await render(root, {})
+    assert.equal(currentHook?.globalFilter, '')
+
+    await act(async () => {
+      currentHook?.onGlobalFilterChange?.('  pending  ')
+    })
+    assert.equal(currentHook?.globalFilter, 'pending')
+    assert.equal(navigations.length, 1)
+
+    // An equivalent URL object must not reset local state before navigation
+    // publishes the pending value.
+    await render(root, {})
+    assert.equal(currentHook?.globalFilter, 'pending')
+
+    await render(root, { query: 'from-history' })
+    assert.equal(currentHook?.globalFilter, 'from-history')
+
+    await render(root, {})
+    assert.equal(currentHook?.globalFilter, '')
+  } finally {
+    await act(async () => root.unmount())
+    currentHook = null
+    navigations.length = 0
+  }
+})

--- a/apps/web/src/hooks/use-table-url-state.ts
+++ b/apps/web/src/hooks/use-table-url-state.ts
@@ -183,11 +183,22 @@ export function useTableUrlState(
     })
   }
 
-  const [globalFilter, setGlobalFilter] = useState<string | undefined>(() => {
-    if (!globalFilterEnabled) return undefined
-    const raw = (search as SearchRecord)[globalFilterKey]
-    return typeof raw === 'string' ? raw : ''
-  })
+  const urlGlobalFilter = globalFilterEnabled
+    ? typeof (search as SearchRecord)[globalFilterKey] === 'string'
+      ? ((search as SearchRecord)[globalFilterKey] as string)
+      : ''
+    : undefined
+  const [globalFilter, setGlobalFilter] = useState<string | undefined>(
+    urlGlobalFilter
+  )
+
+  // Keep browser back/forward navigation authoritative without clobbering a
+  // local edit when the parent merely recreates an equivalent search object.
+  useEffect(() => {
+    setGlobalFilter((current) =>
+      current === urlGlobalFilter ? current : urlGlobalFilter
+    )
+  }, [urlGlobalFilter])
 
   const onGlobalFilterChange: OnChangeFn<string> | undefined =
     globalFilterEnabled


### PR DESCRIPTION
## Summary
- keep shared table global filters synchronized with URL history changes
- avoid clobbering pending local input when an equivalent search object is recreated
- add a hook regression test covering local input and back/forward updates

## Verification
- `bun test apps/web/src/hooks/use-table-url-state.test.tsx`
- targeted TypeScript diagnostics and oxlint

## Sourcery 总结

保持共享表格搜索状态与 URL 历史记录同步，同时避免覆盖用户待处理的输入。

错误修复：
- 在重新创建等效搜索状态时，使表格全局筛选条件与 URL 历史记录的变化保持同步，同时保留待处理的本地输入。

测试：
- 增加对本地全局筛选输入以及 URL 后退/前进更新的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Keep shared table search state synchronized with URL history without overwriting pending user input.

Bug Fixes:
- Synchronize table global filters with URL history changes while preserving pending local input when equivalent search state is recreated.

Tests:
- Add regression coverage for local global-filter input and URL back/forward updates.

</details>