### PR TITLE
fix(deploy): keep workspace cleanup idempotent

### DIFF
--- a/.agents/skills/lmm-deploy-safely/scripts/cleanup-owned-workspace.sh
+++ b/.agents/skills/lmm-deploy-safely/scripts/cleanup-owned-workspace.sh
@@ -148,7 +148,7 @@ case "$role" in
     fi
     ;;
   target)
-    [[ -n $root ]] || root='/var/lib/lmm-api/deploy-work'
+    [[ -n $root ]] || root='/var/lib/lmm-api-go-deploy/work'
     ;;
   *) die 'role must be controller or target' ;;
 esac

--- a/.agents/skills/lmm-deploy-safely/scripts/create-workspace.sh
+++ b/.agents/skills/lmm-deploy-safely/scripts/create-workspace.sh
@@ -121,7 +121,7 @@ case "$role" in
     fi
     ;;
   target)
-    [[ -n $root ]] || root='/var/lib/lmm-api/deploy-work'
+    [[ -n $root ]] || root='/var/lib/lmm-api-go-deploy/work'
     ;;
   *)
     die 'role must be controller or target'

--- a/.agents/skills/lmm-deploy-safely/scripts/tests/test-cleanup-owned-workspace.sh
+++ b/.agents/skills/lmm-deploy-safely/scripts/tests/test-cleanup-owned-workspace.sh
@@ -5,6 +5,10 @@ set -euo pipefail
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 readonly script_dir
 readonly cleanup=${script_dir%/scripts/tests}/scripts/cleanup-owned-workspace.sh
+if ! grep -Fq "root='/var/lib/lmm-api-go-deploy/work'" "$cleanup"; then
+  printf 'FAIL: target default root drifted from the production path map\n' >&2
+  exit 1
+fi
 test_base=${XDG_STATE_HOME:-$HOME/.local/state}/lmm-api/skill-tests
 mkdir -p "$test_base"
 test_root=$(mktemp -d -p "$test_base")

--- a/.agents/skills/lmm-deploy-safely/scripts/tests/test-create-workspace.sh
+++ b/.agents/skills/lmm-deploy-safely/scripts/tests/test-create-workspace.sh
@@ -13,6 +13,8 @@ fail() {
   exit 1
 }
 
+grep -Fq "root='/var/lib/lmm-api-go-deploy/work'" "$create_workspace" || fail 'target default root drifted from the production path map'
+
 cleanup() {
   rm -rf -- "$test_base"
 }

--- a/apps/api-go/internal/appcli/deploy_production_cleanup.go
+++ b/apps/api-go/internal/appcli/deploy_production_cleanup.go
@@ -77,7 +77,7 @@ func (runtime *productionRuntime) cleanupWorkspaces(ctx context.Context, options
 			if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
 				continue
 			}
-			workspace, err := runtime.openWorkspace(root)
+			workspace, err := runtime.openWorkspaceForInspection(root)
 			if err != nil {
 				// Unknown or damaged directories are never cleanup targets.
 				result.Entries = append(result.Entries, productionWorkspaceCleanupEntry{

--- a/apps/api-go/internal/appcli/deploy_production_cleanup_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_cleanup_test.go
@@ -129,6 +129,34 @@ func TestProductionWorkspaceCleanupExecuteRemovesOnlyDisposableChildren(t *testi
 			t.Fatalf("audit path %s was removed: %v", path, err)
 		}
 	}
+
+	second, err := runtime.cleanupWorkspaces(context.Background(), productionWorkspaceCleanupOptions{OlderThan: 24 * time.Hour, Execute: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.RemovedBytes != 0 || len(second.Entries) != 1 || second.Entries[0].Phase != "FAILED_PREARM" {
+		t.Fatalf("cleanup was not idempotent after staging removal: %#v", second)
+	}
+}
+
+func TestProductionWorkspaceInspectionDoesNotRequireStaging(t *testing.T) {
+	runtime, now := newCleanupFixture(t)
+	root := addCleanupWorkspace(t, runtime, "go-cleaned", "CONFIRMED", "0.1.0.r299.gdeadbeef0", now.Add(-72*time.Hour))
+	if err := os.RemoveAll(filepath.Join(root, "staging")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.openWorkspaceForInspection(root); err != nil {
+		t.Fatalf("inspect cleaned terminal workspace: %v", err)
+	}
+	if _, err := runtime.openWorkspace(root); err == nil {
+		t.Fatal("mutation path accepted a workspace without staging")
+	}
+	if err := os.Symlink("/etc", filepath.Join(root, "staging")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.openWorkspaceForInspection(root); err == nil {
+		t.Fatal("inspection path accepted an unsafe staging symlink")
+	}
 }
 
 func TestProductionWorkspaceCleanupRefusesInvalidOrActiveLock(t *testing.T) {

--- a/apps/api-go/internal/appcli/deploy_production_state.go
+++ b/apps/api-go/internal/appcli/deploy_production_state.go
@@ -890,7 +890,13 @@ func parseProductionTransactionOptions(action string, args []string, stderr io.W
 }
 
 func (runtime *productionRuntime) executeTransaction(ctx context.Context, options productionTransactionOptions) (productionStatus, error) {
-	workspace, err := runtime.openWorkspace(options.Workspace)
+	var workspace productionWorkspace
+	var err error
+	if options.Action == "status" {
+		workspace, err = runtime.openWorkspaceForInspection(options.Workspace)
+	} else {
+		workspace, err = runtime.openWorkspace(options.Workspace)
+	}
 	if err != nil {
 		return productionStatus{}, err
 	}
@@ -930,6 +936,14 @@ func (runtime *productionRuntime) executeTransaction(ctx context.Context, option
 }
 
 func (runtime *productionRuntime) openWorkspace(root string) (productionWorkspace, error) {
+	return runtime.openWorkspaceWithMode(root, true)
+}
+
+func (runtime *productionRuntime) openWorkspaceForInspection(root string) (productionWorkspace, error) {
+	return runtime.openWorkspaceWithMode(root, false)
+}
+
+func (runtime *productionRuntime) openWorkspaceWithMode(root string, requireStaging bool) (productionWorkspace, error) {
 	if filepath.Dir(root) != filepath.Clean(runtime.paths.WorkRoot) {
 		return productionWorkspace{}, errors.New("workspace must be one direct child of the production work root")
 	}
@@ -964,8 +978,10 @@ func (runtime *productionRuntime) openWorkspace(root string) (productionWorkspac
 		return productionWorkspace{}, errors.New("workspace marker does not own this deployment ID")
 	}
 	stateDir := filepath.Join(root, "state")
-	if err := ensureRealDirectory(stateDir, 0o700); err != nil {
-		return productionWorkspace{}, fmt.Errorf("prepare deployment state: %w", err)
+	if requireStaging {
+		if err := ensureRealDirectory(stateDir, 0o700); err != nil {
+			return productionWorkspace{}, fmt.Errorf("prepare deployment state: %w", err)
+		}
 	}
 	if err := runtime.requireOwnedSafePath(stateDir, true); err != nil {
 		return productionWorkspace{}, errors.New("deployment state must be root-owned and safe")
@@ -978,8 +994,16 @@ func (runtime *productionRuntime) openWorkspace(root string) (productionWorkspac
 		return productionWorkspace{}, errors.New("deployment state must remain root-only")
 	}
 	stagingDir := filepath.Join(root, "staging")
-	if err := runtime.requireOwnedSafePath(stagingDir, true); err != nil {
-		return productionWorkspace{}, fmt.Errorf("validate deployment staging: %w", err)
+	if requireStaging {
+		if err := runtime.requireOwnedSafePath(stagingDir, true); err != nil {
+			return productionWorkspace{}, fmt.Errorf("validate deployment staging: %w", err)
+		}
+	} else if _, err := os.Lstat(stagingDir); err == nil {
+		if err := runtime.requireOwnedSafePath(stagingDir, true); err != nil {
+			return productionWorkspace{}, fmt.Errorf("validate deployment staging: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return productionWorkspace{}, fmt.Errorf("inspect deployment staging: %w", err)
 	}
 	return productionWorkspace{
 		root:          root,


### PR DESCRIPTION
## Summary

- let read-only status and cleanup inspection accept a terminal workspace after its staging directory has been removed
- keep mutation paths strict and reject missing or symlinked staging directories
- align target workspace helper defaults with `/var/lib/lmm-api-go-deploy/work`
- add idempotence, safety, and path-contract regressions

## Validation

- `go test ./internal/appcli`
- `go test ./internal/appcli -run "TestProductionWorkspace(Cleanup|Inspection)" -count=1`
- `go vet ./internal/appcli`
- ShellCheck for the changed lifecycle scripts/tests
- create/cleanup workspace lifecycle tests
- `bash packaging/aur/test-matrix.sh` in a marker-owned workspace

A local full `go test ./...` was also attempted; unrelated loopback SMTP/httptest connections in `common` and `controller` timed out on the workstation. GitHub CI is required as the clean full-suite authority.

## Sourcery 摘要

在不削弱变更路径安全性的前提下，使生产环境中的工作区检查和清理操作具备幂等性。

Bug 修复：
- 在终止状态工作区的暂存目录已被删除后，允许进行工作区状态检查和清理发现，同时继续拒绝不安全的暂存路径。
- 使重复执行清理操作时能够安全地保持幂等。

改进：
- 使目标工作区辅助工具的默认值与生产环境的工作根路径保持一致。
- 添加针对清理幂等性、终止状态工作区检查、变更安全性和路径默认值的回归测试覆盖。

测试：
- 添加涵盖暂存目录缺失和暂存目录为符号链接情况的生命周期与安全性回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make production workspace inspection and cleanup idempotent without weakening mutation-path safety.

Bug Fixes:
- Allow workspace status inspection and cleanup discovery after a terminal workspace’s staging directory has been removed, while continuing to reject unsafe staging paths.
- Make repeated cleanup operations safely idempotent.

Enhancements:
- Align target workspace helper defaults with the production work-root path.
- Add regression coverage for cleanup idempotence, terminal workspace inspection, mutation safety, and path defaults.

Tests:
- Add lifecycle and safety regressions covering missing and symlinked staging directories.

</details>