### PR TITLE
fix(deploy): close release and backup safety gaps

### DIFF
--- a/.agents/skills/lmm-deploy-safely/scripts/create-workspace.sh
+++ b/.agents/skills/lmm-deploy-safely/scripts/create-workspace.sh
@@ -137,7 +137,9 @@ chmod 0700 -- "$root"
 assert_no_symlink_components "$root"
 [[ -d $root && ! -L $root ]] || die 'workspace root is not a real directory'
 [[ $(realpath -e -- "$root") == "$root" ]] || die 'workspace root changed during creation'
-check_state_budget "$(dirname -- "$root")"
+if [[ $role == controller ]]; then
+  check_state_budget "$(dirname -- "$root")"
+fi
 
 workspace="$root/$deployment_id"
 [[ ! -e $workspace && ! -L $workspace ]] || die 'deployment workspace already exists'

--- a/.agents/skills/lmm-deploy-safely/scripts/tests/test-create-workspace.sh
+++ b/.agents/skills/lmm-deploy-safely/scripts/tests/test-create-workspace.sh
@@ -48,4 +48,12 @@ fi
 [[ ! -e $stop_root/blocked ]] || fail 'blocked workspace was partially created'
 grep -Fq 'clean terminal marker-owned workspaces' "$stop_error" || fail 'stop error lacks cleanup guidance'
 
+target_state="$test_base/target/lmm-api-go-deploy"
+target_root="$target_state/work"
+mkdir -p -- "$target_state/backups"
+truncate -s $((513 * 1024 * 1024)) "$target_state/backups/retained-backup.bin"
+target_output=$(bash "$create_workspace" --role target --deployment-id target-budget --root "$target_root")
+[[ -f $target_root/target-budget/.lmm-deploy-workspace ]] || fail 'target workspace was blocked by retained sibling backups'
+grep -Fq "LMM_DEPLOY_WORKSPACE=$target_root/target-budget" <<< "$target_output" || fail 'target output missing workspace path'
+
 printf 'create-workspace tests: PASS\n'

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -295,9 +295,20 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
+          version=${RELEASE_TAG#go-v}
+          expected_names=(
+            "lmm-api-go-${version}-linux-amd64.tar.gz"
+            "lmm-api-go-${version}-linux-amd64.tar.gz.sha256"
+            "lmm-api-go-${version}-linux-amd64.tar.gz.sigstore.json"
+            "lmm-api-go-${version}-linux-arm64.tar.gz"
+            "lmm-api-go-${version}-linux-arm64.tar.gz.sha256"
+            "lmm-api-go-${version}-linux-arm64.tar.gz.sigstore.json"
+          )
           assets=(release-assets/*)
-          (( ${#assets[@]} > 0 )) || {
-            echo 'No signed Go release assets were downloaded.' >&2
+          mapfile -t actual_names < <(printf '%s\n' "${assets[@]##*/}" | sort)
+          mapfile -t expected_names < <(printf '%s\n' "${expected_names[@]}" | sort)
+          [[ "${actual_names[*]}" == "${expected_names[*]}" ]] || {
+            echo 'Signed Go release assets do not match the exact six-file contract.' >&2
             exit 1
           }
           notes="$RUNNER_TEMP/go-release-notes.md"
@@ -305,17 +316,40 @@ jobs:
             'Independent production Go-only backend release.' \
             "$RELEASE_REVISION" "$CONTRACT_REVISION" > "$notes"
 
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-              --verify-tag --target "$RELEASE_REVISION" \
-              --title "LMM Go backend $RELEASE_TAG" \
-              --notes-file "$notes" --latest
-            gh release upload "$RELEASE_TAG" "${assets[@]}" \
-              --repo "$GITHUB_REPOSITORY" --clobber
-          else
-            gh release create "$RELEASE_TAG" "${assets[@]}" \
-              --repo "$GITHUB_REPOSITORY" --verify-tag \
-              --target "$RELEASE_REVISION" \
-              --title "LMM Go backend $RELEASE_TAG" \
-              --notes-file "$notes" --latest
+          verify_release() {
+            local readback=$1 asset name local_digest published_digest published_list
+            [[ $(jq -r '.tagName' <<<"$readback") == "$RELEASE_TAG" ]] || return 1
+            [[ $(jq -r '.targetCommitish' <<<"$readback") == "$RELEASE_REVISION" ]] || return 1
+            [[ $(jq -r '.name' <<<"$readback") == "LMM Go backend $RELEASE_TAG" ]] || return 1
+            [[ $(jq -r '.body' <<<"$readback") == "$(<"$notes")" ]] || return 1
+            [[ $(jq -r '.isDraft, .isPrerelease' <<<"$readback") == $'false\nfalse' ]] || return 1
+            published_list=$(jq -er '.assets | map(.name) | sort | .[]' <<<"$readback") || return 1
+            mapfile -t published_names <<<"$published_list"
+            [[ "${published_names[*]}" == "${expected_names[*]}" ]] || return 1
+            for asset in "${assets[@]}"; do
+              name=${asset##*/}
+              local_digest=$(sha256sum "$asset" | cut -d' ' -f1) || return 1
+              published_digest=$(jq -er --arg name "$name" \
+                '.assets[] | select(.name == $name) | .digest' <<<"$readback") || return 1
+              [[ "$published_digest" == "sha256:$local_digest" ]] || return 1
+            done
+          }
+
+          if readback=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json tagName,targetCommitish,name,body,isDraft,isPrerelease,assets 2>/dev/null); then
+            verify_release "$readback" || {
+              echo "Release $RELEASE_TAG exists but differs; immutable releases cannot be edited or overwritten." >&2
+              exit 1
+            }
+            echo "Release $RELEASE_TAG already exists and exactly matches the immutable contract."
+            exit 0
           fi
+          gh release create "$RELEASE_TAG" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" --verify-tag \
+            --target "$RELEASE_REVISION" \
+            --title "LMM Go backend $RELEASE_TAG" \
+            --notes-file "$notes" --latest
+
+          readback=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json tagName,targetCommitish,name,body,isDraft,isPrerelease,assets)
+          verify_release "$readback"

--- a/.github/workflows/release-web.yml
+++ b/.github/workflows/release-web.yml
@@ -169,9 +169,17 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
+          version=${RELEASE_TAG#web-v}
+          expected_names=(
+            "lmm-api-web-${version}.tar.gz"
+            "lmm-api-web-${version}.tar.gz.sha256"
+            "lmm-api-web-${version}.tar.gz.sigstore.json"
+          )
           assets=(release-web/*)
-          (( ${#assets[@]} > 0 )) || {
-            echo 'No signed web release assets were produced.' >&2
+          mapfile -t actual_names < <(printf '%s\n' "${assets[@]##*/}" | sort)
+          mapfile -t expected_names < <(printf '%s\n' "${expected_names[@]}" | sort)
+          [[ "${actual_names[*]}" == "${expected_names[*]}" ]] || {
+            echo 'Signed web release assets do not match the exact three-file contract.' >&2
             exit 1
           }
           notes="$RUNNER_TEMP/web-release-notes.md"
@@ -179,16 +187,39 @@ jobs:
             'Independent production web frontend release.' \
             "$RELEASE_REVISION" "$CONTRACT_REVISION" > "$notes"
 
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release edit "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
-              --verify-tag --target "$RELEASE_REVISION" \
-              --title "LMM web $RELEASE_TAG" \
-              --notes-file "$notes" --latest=false
-            gh release upload "$RELEASE_TAG" "${assets[@]}" \
-              --repo "$GITHUB_REPOSITORY" --clobber
-          else
-            gh release create "$RELEASE_TAG" "${assets[@]}" \
-              --repo "$GITHUB_REPOSITORY" --verify-tag \
-              --target "$RELEASE_REVISION" --title "LMM web $RELEASE_TAG" \
-              --notes-file "$notes" --latest=false
+          verify_release() {
+            local readback=$1 asset name local_digest published_digest published_list
+            [[ $(jq -r '.tagName' <<<"$readback") == "$RELEASE_TAG" ]] || return 1
+            [[ $(jq -r '.targetCommitish' <<<"$readback") == "$RELEASE_REVISION" ]] || return 1
+            [[ $(jq -r '.name' <<<"$readback") == "LMM web $RELEASE_TAG" ]] || return 1
+            [[ $(jq -r '.body' <<<"$readback") == "$(<"$notes")" ]] || return 1
+            [[ $(jq -r '.isDraft, .isPrerelease' <<<"$readback") == $'false\nfalse' ]] || return 1
+            published_list=$(jq -er '.assets | map(.name) | sort | .[]' <<<"$readback") || return 1
+            mapfile -t published_names <<<"$published_list"
+            [[ "${published_names[*]}" == "${expected_names[*]}" ]] || return 1
+            for asset in "${assets[@]}"; do
+              name=${asset##*/}
+              local_digest=$(sha256sum "$asset" | cut -d' ' -f1) || return 1
+              published_digest=$(jq -er --arg name "$name" \
+                '.assets[] | select(.name == $name) | .digest' <<<"$readback") || return 1
+              [[ "$published_digest" == "sha256:$local_digest" ]] || return 1
+            done
+          }
+
+          if readback=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json tagName,targetCommitish,name,body,isDraft,isPrerelease,assets 2>/dev/null); then
+            verify_release "$readback" || {
+              echo "Release $RELEASE_TAG exists but differs; immutable releases cannot be edited or overwritten." >&2
+              exit 1
+            }
+            echo "Release $RELEASE_TAG already exists and exactly matches the immutable contract."
+            exit 0
           fi
+          gh release create "$RELEASE_TAG" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" --verify-tag \
+            --target "$RELEASE_REVISION" --title "LMM web $RELEASE_TAG" \
+            --notes-file "$notes" --latest=false
+
+          readback=$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
+            --json tagName,targetCommitish,name,body,isDraft,isPrerelease,assets)
+          verify_release "$readback"

--- a/apps/api-go/internal/appcli/deploy_edge_policy.go
+++ b/apps/api-go/internal/appcli/deploy_edge_policy.go
@@ -293,6 +293,51 @@ func legacyPolicyUnitIsEnabled(output []byte) bool {
 	}
 }
 
+func (runtime *productionRuntime) validateEdgePolicyBackup(root, expectedDigest string) error {
+	manifestPath := filepath.Join(root, "manifest.json")
+	manifestBytes, err := readPrivateRegularFile(manifestPath, edgePolicyBackupLimit)
+	if err != nil {
+		return fmt.Errorf("read edge-policy restore manifest: %w", err)
+	}
+	if expectedDigest == "" || fmt.Sprintf("%x", sha256Bytes(manifestBytes)) != expectedDigest {
+		return errors.New("edge-policy restore manifest changed after deployment was armed")
+	}
+	var manifest edgePolicyBackupManifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil || manifest.Format != edgeBackupFormat {
+		return errors.New("edge-policy restore manifest is invalid")
+	}
+	assets := make(map[string]edgePolicyAsset)
+	for _, asset := range runtime.allEdgePolicyAssets() {
+		assets[asset.Key] = asset
+	}
+	if len(manifest.Entries) != len(assets) {
+		return errors.New("edge-policy restore manifest inventory is incomplete")
+	}
+	seen := make(map[string]bool, len(assets))
+	for _, entry := range manifest.Entries {
+		if _, ok := assets[entry.Key]; !ok || seen[entry.Key] || entry.State != "present" && entry.State != "absent" {
+			return errors.New("edge-policy restore manifest contains an unknown or duplicate entry")
+		}
+		seen[entry.Key] = true
+		backupFile := filepath.Join(root, entry.Key)
+		if entry.State == "absent" {
+			if _, err := os.Lstat(backupFile); !errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("edge-policy restore contains unexpected absent-state data: %s", entry.Key)
+			}
+			continue
+		}
+		info, err := os.Lstat(backupFile)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() == 0 || info.Mode().Perm()&0o022 != 0 {
+			return fmt.Errorf("edge-policy restore file is missing or unsafe: %s", entry.Key)
+		}
+		actual, err := sha256File(backupFile)
+		if err != nil || actual != entry.SHA256 {
+			return fmt.Errorf("edge-policy restore checksum mismatch: %s", entry.Key)
+		}
+	}
+	return nil
+}
+
 func (runtime *productionRuntime) restoreEdgePolicyBackup(ctx context.Context, root, expectedDigest string) error {
 	manifestPath := filepath.Join(root, "manifest.json")
 	manifestBytes, err := readPrivateRegularFile(manifestPath, edgePolicyBackupLimit)

--- a/apps/api-go/internal/appcli/deploy_production.go
+++ b/apps/api-go/internal/appcli/deploy_production.go
@@ -105,7 +105,8 @@ func writeProductionDeployUsage(output io.Writer) {
        --web-rollback-package FILE --web-rollback-release-asset FILE --web-rollback-release-bundle FILE \\
        --probe-binary FILE [--operator-binary FILE] [--with-backups --age-recipient-file FILE]
   %s deploy production stage|promote|status|confirm|rollback \\
-       --plan FILE --plan-sha256 HEX --confirm api.lmm.best
+       --plan FILE --plan-sha256 HEX --confirm api.lmm.best \\
+       [--age-identity-file FILE for backup-enabled promote or confirm]
 
 Target-only recovery commands (normally invoked by the controller):
   %s deploy production workspace create --deployment-id ID

--- a/apps/api-go/internal/appcli/deploy_production_backup.go
+++ b/apps/api-go/internal/appcli/deploy_production_backup.go
@@ -92,6 +92,43 @@ func (runtime *productionRuntime) validateStagedFile(workspace productionWorkspa
 	return nil
 }
 
+func (runtime *productionRuntime) validateCandidateEntrypoint(workspace productionWorkspace, provider, expectedSHA256 string) (string, error) {
+	if provider != filepath.Join(workspace.stagingDir, backendGoName) || filepath.Dir(provider) != workspace.stagingDir {
+		return "", errors.New("candidate provider must be the release-scoped staging/lmm-api-go file")
+	}
+	if err := runtime.requireOwnedSafePath(provider, false); err != nil {
+		return "", errors.New("candidate provider target is not a safe root-owned regular file")
+	}
+	providerInfo, err := os.Lstat(provider)
+	if err != nil || providerInfo.Mode().Perm()&0o100 == 0 {
+		return "", errors.New("candidate provider target is not executable")
+	}
+	path := workspace.candidateLink
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return "", errors.New("candidate entrypoint must be a symbolic link")
+	}
+	uid, _, ok := deploymentFileOwnership(info)
+	if !ok || uid != runtime.requiredOwnerUID {
+		return "", errors.New("candidate entrypoint link owner is invalid")
+	}
+	target, err := os.Readlink(path)
+	if err != nil || target != backendGoName {
+		return "", errors.New("candidate entrypoint must be a one-hop relative link to lmm-api-go")
+	}
+	if !productionSHA256Pattern.MatchString(expectedSHA256) {
+		return "", errors.New("candidate entrypoint SHA-256 is invalid")
+	}
+	actual, err := sha256File(provider)
+	if err != nil {
+		return "", fmt.Errorf("hash candidate provider target: %w", err)
+	}
+	if actual != expectedSHA256 {
+		return "", errors.New("candidate provider target SHA-256 mismatch")
+	}
+	return path, nil
+}
+
 func (runtime *productionRuntime) validateBackupSet(ctx context.Context, workspace productionWorkspace, backupDir string) ([]byte, error) {
 	expected := filepath.Join(runtime.paths.BackupRoot, workspace.id)
 	if backupDir != expected {
@@ -99,6 +136,14 @@ func (runtime *productionRuntime) validateBackupSet(ctx context.Context, workspa
 	}
 	if err := requireRealDirectory(backupDir); err != nil {
 		return nil, fmt.Errorf("verified target backup is missing or unsafe: %w", err)
+	}
+	backupInfo, err := os.Lstat(backupDir)
+	if err != nil || backupInfo.Mode().Perm() != 0o700 {
+		return nil, errors.New("verified target backup root must remain private")
+	}
+	backupUID, _, ownershipOK := deploymentFileOwnership(backupInfo)
+	if !ownershipOK || backupUID != runtime.requiredOwnerUID {
+		return nil, errors.New("verified target backup root owner is invalid")
 	}
 	required := []string{
 		"application.archive",
@@ -112,8 +157,27 @@ func (runtime *productionRuntime) validateBackupSet(ctx context.Context, workspa
 	for _, name := range required {
 		path := filepath.Join(backupDir, name)
 		info, err := os.Lstat(path)
-		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() == 0 {
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() == 0 || info.Mode().Perm()&0o077 != 0 {
 			return nil, fmt.Errorf("backup entry %s is missing, empty, or unsafe", name)
+		}
+		uid, linkCount, ownershipOK := deploymentFileOwnership(info)
+		if !ownershipOK || uid != runtime.requiredOwnerUID || linkCount != 1 {
+			return nil, fmt.Errorf("backup entry %s owner or link count is unsafe", name)
+		}
+	}
+	allowed := make(map[string]bool, len(required)+2)
+	for _, name := range required {
+		allowed[name] = true
+	}
+	allowed[productionBackupAttestationFilename] = true
+	allowed[productionBackupConfirmationFilename] = true
+	entries, err := os.ReadDir(backupDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, entry := range entries {
+		if !allowed[entry.Name()] {
+			return nil, fmt.Errorf("backup contains an unexpected member: %s", entry.Name())
 		}
 	}
 	if err := verifyBackupChecksums(backupDir); err != nil {

--- a/apps/api-go/internal/appcli/deploy_production_controller.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -120,7 +122,7 @@ func parseProductionReleaseControllerOptions(action string, args []string, stder
 	flags.StringVar(&options.Plan, "plan", "", "immutable controller release plan")
 	flags.StringVar(&options.PlanSHA256, "plan-sha256", "", "exact immutable release-plan SHA-256")
 	flags.StringVar(&options.Confirm, "confirm", "", "must equal api.lmm.best")
-	if action == "promote" {
+	if action == "promote" || action == "confirm" {
 		flags.StringVar(&options.AgeIdentityFile, "age-identity-file", "", "owner-protected age or SSH private identity for backup verification")
 	}
 	if action == "rollback" {
@@ -217,6 +219,9 @@ func (runtime *productionReleaseRuntime) stage(ctx context.Context, options prod
 			return productionReleaseControllerResult{}, err
 		}
 	}
+	if err := runtime.ensureRemoteCandidateEntrypoint(ctx, plan, state); err != nil {
+		return productionReleaseControllerResult{}, err
+	}
 	if err := runtime.verifyRemoteStagedRelease(ctx, plan, state); err != nil {
 		return productionReleaseControllerResult{}, err
 	}
@@ -303,13 +308,20 @@ func (runtime *productionReleaseRuntime) control(ctx context.Context, action str
 	if err := runtime.assertRemoteHost(ctx, plan.TargetAlias, plan.ExpectedHost); err != nil {
 		return productionReleaseControllerResult{}, err
 	}
+	if action == "confirm" && plan.WithBackups {
+		if options.AgeIdentityFile == "" {
+			return productionReleaseControllerResult{}, errors.New("--age-identity-file is required to reverify backup-enabled confirmation")
+		}
+		if err := runtime.reverifyControllerBackups(ctx, plan, state, options.AgeIdentityFile); err != nil {
+			return productionReleaseControllerResult{}, fmt.Errorf("reverify production backups before confirmation: %w", err)
+		}
+	}
 	if action != "status" {
 		arguments := []string{"deploy", "production", action, "--workspace", state.RemoteWorkspace}
 		if action == "rollback" {
 			arguments = append(arguments, "--reason", options.Reason)
 		}
-		remoteOperator := productionRemoteOperatorPath(plan, state)
-		output, err := runtime.ssh(ctx, plan.TargetAlias, 12*time.Minute, append([]string{remoteOperator}, arguments...)...)
+		output, err := runtime.ssh(ctx, plan.TargetAlias, 12*time.Minute, append([]string{productionOperatorBinary}, arguments...)...)
 		if err != nil {
 			return productionReleaseControllerResult{}, fmt.Errorf("production %s failed or became transport-ambiguous: %w", action, err)
 		}
@@ -328,12 +340,15 @@ func (runtime *productionReleaseRuntime) control(ctx context.Context, action str
 	return releaseControllerResult(plan, state), nil
 }
 
-func productionRemoteOperatorPath(plan productionReleasePlan, state productionReleaseControllerState) string {
-	operator := plan.OperatorBinary.Path
-	if operator == "" {
-		operator = plan.ProbeBinary.Path
+func productionRemoteOperatorPath(state productionReleaseControllerState) string {
+	return filepath.Join(state.RemoteWorkspace, "staging", productionCandidateLinkName)
+}
+
+func (runtime *productionReleaseRuntime) remoteCandidateCommand(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) (string, error) {
+	if err := runtime.verifyRemoteCandidateEntrypoint(ctx, plan, state); err != nil {
+		return "", err
 	}
-	return filepath.Join(state.RemoteWorkspace, "staging", filepath.Base(operator))
+	return productionRemoteOperatorPath(state), nil
 }
 
 func persistRemoteReleaseControllerStatus(plan productionReleasePlan, state *productionReleaseControllerState, status productionStatus, now time.Time) error {
@@ -348,8 +363,8 @@ func persistRemoteReleaseControllerStatus(plan productionReleasePlan, state *pro
 
 func (runtime *productionReleaseRuntime) productionApplyArguments(plan productionReleasePlan, state productionReleaseControllerState) []string {
 	remoteStage := filepath.Join(state.RemoteWorkspace, "staging")
-	remoteOperator := productionRemoteOperatorPath(plan, state)
-	remoteProbe := filepath.Join(remoteStage, filepath.Base(plan.ProbeBinary.Path))
+	remoteOperator := productionRemoteOperatorPath(state)
+	remoteProvider := filepath.Join(remoteStage, backendGoName)
 	arguments := []string{
 		"systemd-run", "--quiet", "--wait", "--collect", "--unit", productionActivationUnit(plan.DeploymentID),
 		"--property=Type=oneshot", "--property=TimeoutStartSec=18min",
@@ -364,9 +379,9 @@ func (runtime *productionReleaseRuntime) productionApplyArguments(plan productio
 		"--web-package-sha256", plan.WebCandidate.PackageSHA256,
 		"--web-rollback-package", filepath.Join(remoteStage, filepath.Base(plan.WebRollback.PackagePath)),
 		"--web-rollback-sha256", plan.WebRollback.PackageSHA256,
-		"--probe-binary", remoteProbe,
+		"--probe-binary", remoteProvider,
 		"--probe-binary-sha256", plan.ProbeBinary.SHA256,
-		"--operator-binary", remoteOperator,
+		"--operator-binary", remoteProvider,
 		"--operator-binary-sha256", plan.OperatorBinary.SHA256,
 		"--expected-version", plan.ExpectedVersion,
 		"--observation-seconds", fmt.Sprintf("%d", plan.ObservationSeconds),
@@ -387,7 +402,10 @@ func (runtime *productionReleaseRuntime) productionApplyArguments(plan productio
 }
 
 func (runtime *productionReleaseRuntime) remoteDispatchEvidence(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) (productionDispatchEvidence, error) {
-	remoteOperator := productionRemoteOperatorPath(plan, state)
+	remoteOperator, err := runtime.remoteCandidateCommand(ctx, plan, state)
+	if err != nil {
+		return productionDispatchEvidence{}, err
+	}
 	output, err := runtime.ssh(ctx, plan.TargetAlias, 30*time.Second,
 		remoteOperator, "deploy", "production", "dispatch-evidence",
 		"--workspace", state.RemoteWorkspace, "--unit", state.ActivationUnit)
@@ -528,9 +546,8 @@ func (runtime *productionReleaseRuntime) waitForDispatchObservation(ctx context.
 }
 
 func (runtime *productionReleaseRuntime) readRemoteReleaseStatus(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) (productionStatus, error) {
-	remoteOperator := productionRemoteOperatorPath(plan, state)
 	output, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute,
-		remoteOperator, "deploy", "production", "status", "--workspace", state.RemoteWorkspace)
+		productionOperatorBinary, "deploy", "production", "status", "--workspace", state.RemoteWorkspace)
 	if err != nil {
 		return productionStatus{}, fmt.Errorf("read production release status: %w", err)
 	}
@@ -629,6 +646,51 @@ func (runtime *productionReleaseRuntime) remoteFileSHA256(ctx context.Context, a
 	return fields[0], nil
 }
 
+func (runtime *productionReleaseRuntime) ensureRemoteCandidateEntrypoint(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) error {
+	link := productionRemoteOperatorPath(state)
+	if output, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "readlink", "--", link); err == nil {
+		if strings.TrimSpace(string(output)) != backendGoName {
+			return errors.New("remote candidate entrypoint has an unexpected target")
+		}
+		return runtime.verifyRemoteCandidateEntrypoint(ctx, plan, state)
+	}
+	if _, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "test", "!", "-e", link); err != nil {
+		return errors.New("remote candidate entrypoint destination is occupied")
+	}
+	if _, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "test", "!", "-L", link); err != nil {
+		return errors.New("remote candidate entrypoint destination is a dangling link")
+	}
+	if _, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "ln", "-s", "--", backendGoName, link); err != nil {
+		return fmt.Errorf("create remote candidate entrypoint: %w", err)
+	}
+	return runtime.verifyRemoteCandidateEntrypoint(ctx, plan, state)
+}
+
+func (runtime *productionReleaseRuntime) verifyRemoteCandidateEntrypoint(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) error {
+	link := productionRemoteOperatorPath(state)
+	target := filepath.Join(state.RemoteWorkspace, "staging", backendGoName)
+	output, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "readlink", "--", link)
+	if err != nil || strings.TrimSpace(string(output)) != backendGoName {
+		return errors.New("remote candidate entrypoint is not a one-hop relative lmm-api link")
+	}
+	metadata, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "stat", "-c", "%u:%a:%h:%F", "--", target)
+	parts := strings.SplitN(strings.TrimSpace(string(metadata)), ":", 4)
+	if err != nil || len(parts) != 4 || parts[0] != "0" || parts[2] != "1" || parts[3] != "regular file" {
+		return errors.New("remote candidate provider target is not a root-owned single-link regular file")
+	}
+	mode, parseErr := strconv.ParseUint(parts[1], 8, 32)
+	if parseErr != nil || mode&0o022 != 0 || mode&0o100 == 0 {
+		return errors.New("remote candidate provider target mode is unsafe")
+	}
+	for _, path := range []string{target, link} {
+		digest, err := runtime.remoteFileSHA256(ctx, plan.TargetAlias, path)
+		if err != nil || digest != plan.GoCandidate.PayloadSHA256 {
+			return errors.New("remote candidate entrypoint target digest mismatch")
+		}
+	}
+	return nil
+}
+
 func (runtime *productionReleaseRuntime) verifyRemoteStagedRelease(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) error {
 	files := []productionReleaseFilePlan{
 		{Path: plan.GoCandidate.PackagePath, SHA256: plan.GoCandidate.PackageSHA256},
@@ -657,7 +719,7 @@ func (runtime *productionReleaseRuntime) verifyRemoteStagedRelease(ctx context.C
 			return fmt.Errorf("remote staged artifact failed digest verification: %s", base)
 		}
 	}
-	return nil
+	return runtime.verifyRemoteCandidateEntrypoint(ctx, plan, state)
 }
 
 type productionPreparedBackups struct {
@@ -671,7 +733,6 @@ func (runtime *productionReleaseRuntime) prepareControllerBackups(ctx context.Co
 		return productionPreparedBackups{}, err
 	}
 	remoteStage := filepath.Join(state.RemoteWorkspace, "staging")
-	remoteProbe := filepath.Join(remoteStage, filepath.Base(plan.ProbeBinary.Path))
 	remoteRollback := filepath.Join(remoteStage, filepath.Base(plan.GoRollback.PackagePath))
 	remoteRecipient := filepath.Join(remoteStage, filepath.Base(plan.AgeRecipient.Path))
 	targetBackup := filepath.Join(defaultProductionPaths().BackupRoot, plan.DeploymentID)
@@ -680,6 +741,10 @@ func (runtime *productionReleaseRuntime) prepareControllerBackups(ctx context.Co
 		return productionPreparedBackups{}, err
 	}
 	if !exists {
+		remoteProbe, err := runtime.remoteCandidateCommand(ctx, plan, state)
+		if err != nil {
+			return productionPreparedBackups{}, err
+		}
 		if _, err := runtime.ssh(ctx, plan.TargetAlias, 12*time.Minute,
 			remoteProbe, "deploy", "production", "backup", "create",
 			"--workspace", state.RemoteWorkspace,
@@ -701,6 +766,10 @@ func (runtime *productionReleaseRuntime) prepareControllerBackups(ctx context.Co
 		}
 		if exists {
 			continue
+		}
+		remoteProbe, err := runtime.remoteCandidateCommand(ctx, plan, state)
+		if err != nil {
+			return productionPreparedBackups{}, err
 		}
 		if _, err := runtime.ssh(ctx, plan.TargetAlias, 12*time.Minute,
 			remoteProbe, "deploy", "production", "backup", "export",
@@ -786,8 +855,17 @@ func (runtime *productionReleaseRuntime) prepareControllerBackups(ctx context.Co
 	if verification.DeploymentID != plan.DeploymentID {
 		return productionPreparedBackups{}, errors.New("verified backup deployment identity mismatch")
 	}
-	if _, err := runtime.ssh(ctx, productionOffhostAlias, 2*time.Minute, "install", "-d", "-m0700", productionOffhostRoot); err != nil {
-		return productionPreparedBackups{}, fmt.Errorf("prepare off-host backup root: %w", err)
+	offhostRootExists, err := runtime.remoteDirectoryExists(ctx, productionOffhostAlias, productionOffhostRoot)
+	if err != nil {
+		return productionPreparedBackups{}, err
+	}
+	if !offhostRootExists {
+		if _, err := runtime.ssh(ctx, productionOffhostAlias, 2*time.Minute, "install", "-d", "-m0700", productionOffhostRoot); err != nil {
+			return productionPreparedBackups{}, fmt.Errorf("prepare off-host backup root: %w", err)
+		}
+		if exists, err := runtime.remoteDirectoryExists(ctx, productionOffhostAlias, productionOffhostRoot); err != nil || !exists {
+			return productionPreparedBackups{}, errors.New("off-host backup root was not created safely")
+		}
 	}
 	offhostBackup := filepath.Join(productionOffhostRoot, plan.DeploymentID)
 	offhostExists, err := runtime.remoteDirectoryExists(ctx, productionOffhostAlias, offhostBackup)
@@ -799,14 +877,16 @@ func (runtime *productionReleaseRuntime) prepareControllerBackups(ctx context.Co
 			return productionPreparedBackups{}, fmt.Errorf("publish off-host backup: %w", err)
 		}
 	}
-	offhostDigestOutput, err := runtime.ssh(ctx, productionOffhostAlias, 2*time.Minute, "sha256sum", filepath.Join(offhostBackup, "SHA256SUMS"))
-	offhostDigestFields := strings.Fields(string(offhostDigestOutput))
-	if err != nil || len(offhostDigestFields) == 0 || offhostDigestFields[0] != verification.OffhostDigest {
-		return productionPreparedBackups{}, errors.New("off-host backup differs from verified controller copy")
+	if err := runtime.verifyRemoteExternalBackupCopy(ctx, productionOffhostAlias, offhostBackup, offhostMirror, "arch", verification.OffhostDigest); err != nil {
+		return productionPreparedBackups{}, fmt.Errorf("verify published off-host backup: %w", err)
+	}
+	remoteProbe, err := runtime.remoteCandidateCommand(ctx, plan, state)
+	if err != nil {
+		return productionPreparedBackups{}, err
 	}
 	if _, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute,
 		remoteProbe, "deploy", "production", "backup", "attest", "--workspace", state.RemoteWorkspace,
-		"--controller-digest", verification.ControllerDigest, "--offhost-digest", verification.OffhostDigest,
+		"--target-digest", verification.TargetDigest, "--controller-digest", verification.ControllerDigest, "--offhost-digest", verification.OffhostDigest,
 	); err != nil {
 		return productionPreparedBackups{}, fmt.Errorf("attest verified external backup copies: %w", err)
 	}
@@ -827,12 +907,125 @@ func validateAgeIdentity(path string) error {
 	return nil
 }
 
+func externalBackupMemberNames() []string {
+	return []string{"application.archive", "configuration.age", "database.age", "frontend.archive", "manifest.env", "rollback.package"}
+}
+
+func (runtime *productionReleaseRuntime) verifyRemoteExternalBackupCopy(ctx context.Context, alias, remoteRoot, localRoot, expectedOwner, expectedChecksumDigest string) error {
+	exists, err := runtime.remoteDirectoryExists(ctx, alias, remoteRoot)
+	if err != nil || !exists {
+		return errors.New("off-host backup directory is missing or unsafe")
+	}
+	rootMetadata, err := runtime.ssh(ctx, alias, 2*time.Minute, "stat", "-c", "%U:%a:%F", "--", remoteRoot)
+	rootParts := strings.SplitN(strings.TrimSpace(string(rootMetadata)), ":", 3)
+	if err != nil || len(rootParts) != 3 || rootParts[0] != expectedOwner || rootParts[1] != "700" || rootParts[2] != "directory" {
+		return errors.New("off-host backup directory ownership or mode is unsafe")
+	}
+	members := externalBackupMemberNames()
+	if err := verifyNamedChecksums(localRoot, members); err != nil {
+		return fmt.Errorf("verify local off-host mirror before remote comparison: %w", err)
+	}
+	localChecksumDigest, err := sha256File(filepath.Join(localRoot, "SHA256SUMS"))
+	if err != nil || localChecksumDigest != expectedChecksumDigest {
+		return errors.New("local off-host checksum manifest digest changed")
+	}
+	listing, err := runtime.ssh(ctx, alias, 2*time.Minute, "find", remoteRoot, "-mindepth", "1", "-maxdepth", "1", "-print")
+	if err != nil {
+		return fmt.Errorf("list off-host backup members: %w", err)
+	}
+	expectedPaths := make([]string, 0, len(members)+1)
+	for _, name := range append(append([]string(nil), members...), "SHA256SUMS") {
+		expectedPaths = append(expectedPaths, filepath.Join(remoteRoot, name))
+	}
+	actualPaths := strings.Fields(string(listing))
+	sort.Strings(expectedPaths)
+	sort.Strings(actualPaths)
+	if strings.Join(actualPaths, "\n") != strings.Join(expectedPaths, "\n") {
+		return errors.New("off-host backup contains a missing or unexpected member")
+	}
+	digests, err := readNamedChecksums(localRoot, members)
+	if err != nil {
+		return err
+	}
+	digests["SHA256SUMS"] = localChecksumDigest
+	for name, expectedDigest := range digests {
+		path := filepath.Join(remoteRoot, name)
+		metadata, err := runtime.ssh(ctx, alias, 2*time.Minute, "stat", "-c", "%U:%a:%h:%s:%F", "--", path)
+		parts := strings.SplitN(strings.TrimSpace(string(metadata)), ":", 5)
+		if err != nil || len(parts) != 5 || parts[0] != expectedOwner || parts[2] != "1" || parts[4] != "regular file" {
+			return fmt.Errorf("off-host backup member is not an owner-controlled regular file: %s", name)
+		}
+		mode, modeErr := strconv.ParseUint(parts[1], 8, 32)
+		size, sizeErr := strconv.ParseInt(parts[3], 10, 64)
+		if modeErr != nil || sizeErr != nil || mode&0o077 != 0 || size <= 0 {
+			return fmt.Errorf("off-host backup member mode or size is unsafe: %s", name)
+		}
+		digest, err := runtime.remoteFileSHA256(ctx, alias, path)
+		if err != nil || digest != expectedDigest {
+			return fmt.Errorf("off-host backup member digest mismatch: %s", name)
+		}
+	}
+	return nil
+}
+
+func (runtime *productionReleaseRuntime) reverifyControllerBackups(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState, ageIdentityFile string) error {
+	if err := validateAgeIdentity(ageIdentityFile); err != nil {
+		return err
+	}
+	if err := runtime.assertRemoteHost(ctx, productionOffhostAlias, productionOffhostExpectedHost); err != nil {
+		return err
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("resolve controller home: %w", err)
+	}
+	targetBackup := filepath.Join(defaultProductionPaths().BackupRoot, plan.DeploymentID)
+	controllerBackup := filepath.Join(home, "backup", "lmm-api", plan.ExpectedHost, plan.DeploymentID)
+	offhostBackup := filepath.Join(productionOffhostRoot, plan.DeploymentID)
+	if state.TargetBackup != targetBackup || state.ControllerBackup != controllerBackup || state.OffhostBackup != offhostBackup {
+		return errors.New("persisted production backup paths do not match the release plan")
+	}
+	targetProof := filepath.Join(plan.ControllerWorkspace, "backups", "target-proof", plan.DeploymentID)
+	offhostMirror := filepath.Join(plan.ControllerWorkspace, "backups", "offhost", plan.DeploymentID)
+	verificationRuntime := &productionRuntime{runner: runtime.runner, now: runtime.now, effectiveUID: os.Geteuid}
+	verification, err := verificationRuntime.verifyExternalBackups(ctx, productionBackupVerifyOptions{
+		Workspace: plan.ControllerWorkspace, Target: targetProof, Controller: controllerBackup,
+		Offhost: offhostMirror, AgeIdentityFile: ageIdentityFile,
+	})
+	if err != nil {
+		return fmt.Errorf("reverify local production backup copies: %w", err)
+	}
+	if verification.DeploymentID != plan.DeploymentID {
+		return errors.New("reverified backup deployment identity mismatch")
+	}
+	if err := runtime.verifyRemoteExternalBackupCopy(ctx, productionOffhostAlias, offhostBackup, offhostMirror, "arch", verification.OffhostDigest); err != nil {
+		return err
+	}
+	remoteOperator, err := runtime.remoteCandidateCommand(ctx, plan, state)
+	if err != nil {
+		return err
+	}
+	if _, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute,
+		remoteOperator, "deploy", "production", "backup", "attest", "--workspace", state.RemoteWorkspace,
+		"--confirmation",
+		"--target-digest", verification.TargetDigest, "--controller-digest", verification.ControllerDigest, "--offhost-digest", verification.OffhostDigest,
+	); err != nil {
+		return fmt.Errorf("revalidate target backup and external attestation: %w", err)
+	}
+	return nil
+}
+
 func (runtime *productionReleaseRuntime) remoteDirectoryExists(ctx context.Context, alias, path string) (bool, error) {
 	if _, err := runtime.ssh(ctx, alias, 2*time.Minute, "test", "-d", path); err == nil {
-		return true, nil
+		if _, err := runtime.ssh(ctx, alias, 2*time.Minute, "test", "!", "-L", path); err == nil {
+			return true, nil
+		}
+		return false, fmt.Errorf("remote directory is a symbolic link: %s", path)
 	}
 	if _, err := runtime.ssh(ctx, alias, 2*time.Minute, "test", "!", "-e", path); err == nil {
-		return false, nil
+		if _, err := runtime.ssh(ctx, alias, 2*time.Minute, "test", "!", "-L", path); err == nil {
+			return false, nil
+		}
 	}
 	return false, fmt.Errorf("remote directory is unsafe or could not be inspected: %s", path)
 }

--- a/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
@@ -14,14 +14,26 @@ import (
 type productionDispatchStatusRunner struct {
 	statuses []productionStatus
 	calls    int
+	payload  string
+	programs []string
 }
 
 func (runner *productionDispatchStatusRunner) Run(_ context.Context, command productionCommand) ([]byte, error) {
-	if command.Name != commandSSH || len(command.Args) < 7 {
+	if command.Name != commandSSH || len(command.Args) < 4 {
 		return nil, errors.New("unexpected status test command")
 	}
 	remote := command.Args[3:]
+	if len(remote) == 3 && remote[0] == "readlink" && remote[1] == "--" {
+		return []byte(backendGoName + "\n"), nil
+	}
+	if len(remote) == 5 && remote[0] == "stat" && remote[1] == "-c" {
+		return []byte("0:700:1:regular file\n"), nil
+	}
+	if len(remote) == 3 && remote[0] == "sha256sum" && remote[1] == "--" {
+		return []byte(runner.payload + "  " + remote[2] + "\n"), nil
+	}
 	if len(remote) >= 4 && remote[1] == "deploy" && remote[2] == "production" && remote[3] == "status" {
+		runner.programs = append(runner.programs, remote[0])
 		index := runner.calls
 		if index >= len(runner.statuses) {
 			index = len(runner.statuses) - 1
@@ -33,14 +45,16 @@ func (runner *productionDispatchStatusRunner) Run(_ context.Context, command pro
 }
 
 type productionDispatchFaultRunner struct {
-	evidence       productionDispatchEvidence
-	statusPhase    string
-	dispatchCalls  int
-	evidenceCalls  int
-	statusCalls    int
-	secondAccepted bool
-	remoteDigests  map[string]string
-	digestCalls    map[string]int
+	evidence         productionDispatchEvidence
+	statusPhase      string
+	dispatchCalls    int
+	evidenceCalls    int
+	statusCalls      int
+	secondAccepted   bool
+	remoteDigests    map[string]string
+	digestCalls      map[string]int
+	dispatchPrograms []string
+	statusPrograms   []string
 }
 
 func (runner *productionDispatchFaultRunner) Run(_ context.Context, command productionCommand) ([]byte, error) {
@@ -48,6 +62,12 @@ func (runner *productionDispatchFaultRunner) Run(_ context.Context, command prod
 		return nil, errors.New("unexpected dispatch test command")
 	}
 	remote := command.Args[3:]
+	if len(remote) == 3 && remote[0] == "readlink" && remote[1] == "--" {
+		return []byte(backendGoName + "\n"), nil
+	}
+	if len(remote) == 5 && remote[0] == "stat" && remote[1] == "-c" {
+		return []byte("0:700:1:regular file\n"), nil
+	}
 	if len(remote) == 3 && remote[0] == "sha256sum" && remote[1] == "--" {
 		path := remote[2]
 		digest, found := runner.remoteDigests[path]
@@ -62,6 +82,9 @@ func (runner *productionDispatchFaultRunner) Run(_ context.Context, command prod
 	}
 	if remote[0] == "systemd-run" {
 		runner.dispatchCalls++
+		if len(remote) > 8 {
+			runner.dispatchPrograms = append(runner.dispatchPrograms, remote[8])
+		}
 		if runner.dispatchCalls == 1 || !runner.secondAccepted {
 			return nil, errors.New("injected SSH transport failure")
 		}
@@ -74,6 +97,7 @@ func (runner *productionDispatchFaultRunner) Run(_ context.Context, command prod
 	}
 	if len(remote) >= 4 && remote[1] == "deploy" && remote[2] == "production" && remote[3] == "status" && runner.statusPhase != "" {
 		runner.statusCalls++
+		runner.statusPrograms = append(runner.statusPrograms, remote[0])
 		return json.Marshal(productionStatus{Phase: runner.statusPhase})
 	}
 	return nil, errors.New("unexpected remote dispatch test command")
@@ -86,12 +110,12 @@ func testProductionDispatchPlan(controllerWorkspace, deploymentID string) produc
 	return productionReleasePlan{
 		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
 		ControllerWorkspace: controllerWorkspace, TargetAlias: productionTargetAlias,
-		GoCandidate:    productionReleasePackagePlan{PackagePath: filepath.Join(controllerWorkspace, "go-candidate.pkg.tar.zst"), PackageSHA256: strings.Repeat("1", 64)},
+		GoCandidate:    productionReleasePackagePlan{PackagePath: filepath.Join(controllerWorkspace, "go-candidate.pkg.tar.zst"), PackageSHA256: strings.Repeat("1", 64), PayloadSHA256: strings.Repeat("5", 64)},
 		GoRollback:     productionReleasePackagePlan{PackagePath: filepath.Join(controllerWorkspace, "go-rollback.pkg.tar.zst"), PackageSHA256: strings.Repeat("2", 64)},
 		WebCandidate:   productionReleasePackagePlan{PackagePath: filepath.Join(controllerWorkspace, "web-candidate.pkg.tar.zst"), PackageSHA256: strings.Repeat("3", 64)},
 		WebRollback:    productionReleasePackagePlan{PackagePath: filepath.Join(controllerWorkspace, "web-rollback.pkg.tar.zst"), PackageSHA256: strings.Repeat("4", 64)},
-		ProbeBinary:    file("probe", strings.Repeat("5", 64)),
-		OperatorBinary: file("operator", strings.Repeat("5", 64)),
+		ProbeBinary:    file(backendGoName, strings.Repeat("5", 64)),
+		OperatorBinary: file(backendGoName, strings.Repeat("5", 64)),
 	}
 }
 
@@ -108,6 +132,7 @@ func productionDispatchRemoteDigests(plan productionReleasePlan, state productio
 	for _, file := range files {
 		digests[filepath.Join(state.RemoteWorkspace, "staging", filepath.Base(file.Path))] = file.SHA256
 	}
+	digests[productionRemoteOperatorPath(state)] = plan.GoCandidate.PayloadSHA256
 	return digests
 }
 
@@ -117,7 +142,9 @@ func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
 	plan := productionReleasePlan{
 		Format: productionReleasePlanFormat, DeploymentID: deploymentID,
 		ControllerWorkspace: controllerWorkspace, TargetAlias: productionTargetAlias,
-		ProbeBinary: productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, "lmm-api")},
+		ProbeBinary:    productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, backendGoName), SHA256: strings.Repeat("5", 64)},
+		OperatorBinary: productionReleaseFilePlan{Path: filepath.Join(controllerWorkspace, backendGoName), SHA256: strings.Repeat("5", 64)},
+		GoCandidate:    productionReleasePackagePlan{PayloadSHA256: strings.Repeat("5", 64)},
 	}
 	state := productionReleaseControllerState{
 		Format: productionReleaseStateFormat, DeploymentID: deploymentID,
@@ -126,7 +153,7 @@ func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
 		ActivationUnit:  productionActivationUnit(deploymentID), DispatchAttempts: 1,
 		UpdatedUTC: time.Date(2026, 8, 24, 11, 58, 0, 0, time.UTC),
 	}
-	runner := &productionDispatchStatusRunner{statuses: []productionStatus{
+	runner := &productionDispatchStatusRunner{payload: strings.Repeat("5", 64), statuses: []productionStatus{
 		{Phase: "PREPARING"},
 		{Phase: "DEPLOYING_GO"},
 		{Phase: "AWAITING_CONFIRMATION"},
@@ -143,6 +170,11 @@ func TestAwaitRemoteReleaseStatusWaitsForTerminalPhase(t *testing.T) {
 	}
 	if status.Phase != "AWAITING_CONFIRMATION" || runner.calls != 3 || waits != 2 {
 		t.Fatalf("status=%#v calls=%d waits=%d", status, runner.calls, waits)
+	}
+	for _, program := range runner.programs {
+		if program != productionOperatorBinary {
+			t.Fatalf("status used non-public CLI: %s", program)
+		}
 	}
 }
 
@@ -202,6 +234,9 @@ func TestAmbiguousDispatchRemoteAbortedPersistsAcrossStatusAndReload(t *testing.
 	}
 	if status.Phase != "ABORTED" || runner.dispatchCalls != 1 || runner.statusCalls != 1 {
 		t.Fatalf("status=%#v dispatches=%d status_calls=%d", status, runner.dispatchCalls, runner.statusCalls)
+	}
+	if len(runner.statusPrograms) != 1 || runner.statusPrograms[0] != productionOperatorBinary {
+		t.Fatalf("status programs=%v", runner.statusPrograms)
 	}
 	if err := persistRemoteReleaseControllerStatus(plan, &state, status, now); err != nil {
 		t.Fatal(err)
@@ -306,9 +341,14 @@ func TestProductionActivationDispatchFaultReconciliation(t *testing.T) {
 			if runner.dispatchCalls != test.wantDispatches || state.DispatchAttempts != test.wantAttempts || state.DispatchObserved != test.wantObserved {
 				t.Fatalf("dispatches=%d attempts=%d observed=%t state=%#v", runner.dispatchCalls, state.DispatchAttempts, state.DispatchObserved, state)
 			}
-			operatorRemote := filepath.Join(state.RemoteWorkspace, "staging", filepath.Base(plan.OperatorBinary.Path))
-			if runner.digestCalls[operatorRemote] != test.wantDispatches {
-				t.Fatalf("operator digest checks=%d want=%d", runner.digestCalls[operatorRemote], test.wantDispatches)
+			operatorRemote := productionRemoteOperatorPath(state)
+			if runner.digestCalls[operatorRemote] < test.wantDispatches {
+				t.Fatalf("operator digest checks=%d want-at-least=%d", runner.digestCalls[operatorRemote], test.wantDispatches)
+			}
+			for _, program := range runner.dispatchPrograms {
+				if program != operatorRemote {
+					t.Fatalf("dispatch executed provider directly: %s", program)
+				}
 			}
 			persisted, exists, err := loadProductionReleaseControllerState(plan, planSHA256)
 			if err != nil || !exists {
@@ -333,8 +373,8 @@ func TestProductionActivationRejectsTamperedRemoteOperatorBeforeDispatch(t *test
 	}
 	runner := &productionDispatchFaultRunner{}
 	runner.remoteDigests = productionDispatchRemoteDigests(plan, state)
-	operatorRemote := filepath.Join(state.RemoteWorkspace, "staging", filepath.Base(plan.OperatorBinary.Path))
-	runner.remoteDigests[operatorRemote] = strings.Repeat("f", 64)
+	providerRemote := filepath.Join(state.RemoteWorkspace, "staging", backendGoName)
+	runner.remoteDigests[providerRemote] = strings.Repeat("f", 64)
 	runtime := &productionReleaseRuntime{runner: runner, now: func() time.Time { return time.Date(2026, 8, 24, 12, 5, 1, 0, time.UTC) }}
 	err := runtime.dispatchProductionActivation(context.Background(), plan, &state)
 	if err == nil || !strings.Contains(err.Error(), "verify staged artifacts immediately before activation dispatch") {

--- a/apps/api-go/internal/appcli/deploy_production_export.go
+++ b/apps/api-go/internal/appcli/deploy_production_export.go
@@ -13,7 +13,10 @@ import (
 	"time"
 )
 
-const productionBackupAttestationFilename = "external-copies.json"
+const (
+	productionBackupAttestationFilename  = "external-copies.json"
+	productionBackupConfirmationFilename = "external-confirmation.json"
+)
 
 type productionBackupExportOptions struct {
 	Workspace        string
@@ -32,8 +35,10 @@ type productionBackupExportResult struct {
 
 type productionBackupAttestOptions struct {
 	Workspace        string
+	TargetDigest     string
 	ControllerDigest string
 	OffhostDigest    string
+	Confirmation     bool
 }
 
 type productionBackupVerifyOptions struct {
@@ -46,6 +51,7 @@ type productionBackupVerifyOptions struct {
 
 type productionBackupVerificationResult struct {
 	DeploymentID     string `json:"deployment_id"`
+	TargetDigest     string `json:"target_digest"`
 	ControllerDigest string `json:"controller_digest"`
 	OffhostDigest    string `json:"offhost_digest"`
 	TargetVerified   bool   `json:"target_verified"`
@@ -55,6 +61,17 @@ type productionBackupVerificationResult struct {
 type productionBackupAttestation struct {
 	Format           int       `json:"format"`
 	DeploymentID     string    `json:"deployment_id"`
+	EvidenceFormat   int       `json:"backup_evidence_format,omitempty"`
+	TargetDigest     string    `json:"target_digest,omitempty"`
+	ControllerDigest string    `json:"controller_digest"`
+	OffhostDigest    string    `json:"offhost_digest"`
+	VerifiedUTC      time.Time `json:"verified_utc"`
+}
+
+type productionBackupConfirmation struct {
+	Format           int       `json:"format"`
+	DeploymentID     string    `json:"deployment_id"`
+	TargetDigest     string    `json:"target_digest"`
 	ControllerDigest string    `json:"controller_digest"`
 	OffhostDigest    string    `json:"offhost_digest"`
 	VerifiedUTC      time.Time `json:"verified_utc"`
@@ -155,8 +172,10 @@ func parseProductionBackupAttestOptions(args []string, stderr io.Writer) (produc
 	flags := flag.NewFlagSet("deploy production backup attest", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	flags.StringVar(&options.Workspace, "workspace", "", "marker-owned target deployment workspace")
+	flags.StringVar(&options.TargetDigest, "target-digest", "", "controller-verified target checksum digest")
 	flags.StringVar(&options.ControllerDigest, "controller-digest", "", "verified controller-copy digest")
 	flags.StringVar(&options.OffhostDigest, "offhost-digest", "", "verified off-host-copy digest")
+	flags.BoolVar(&options.Confirmation, "confirmation", false, "write a fresh controller-verification receipt for backup-enabled confirmation")
 	flags.Usage = func() { writeDeployUsage(stderr) }
 	if err := flags.Parse(args); err != nil {
 		return productionBackupAttestOptions{}, err
@@ -169,8 +188,8 @@ func parseProductionBackupAttestOptions(args []string, stderr io.Writer) (produc
 		return productionBackupAttestOptions{}, fmt.Errorf("invalid --workspace: %w", err)
 	}
 	options.Workspace = workspace
-	if !productionSHA256Pattern.MatchString(options.ControllerDigest) || !productionSHA256Pattern.MatchString(options.OffhostDigest) {
-		return productionBackupAttestOptions{}, errors.New("controller and off-host digests must be lowercase SHA-256 values")
+	if !productionSHA256Pattern.MatchString(options.TargetDigest) || !productionSHA256Pattern.MatchString(options.ControllerDigest) || !productionSHA256Pattern.MatchString(options.OffhostDigest) {
+		return productionBackupAttestOptions{}, errors.New("target, controller, and off-host digests must be lowercase SHA-256 values")
 	}
 	return options, nil
 }
@@ -324,7 +343,7 @@ func (runtime *productionRuntime) attestBackup(ctx context.Context, options prod
 		return productionBackupAttestation{}, err
 	}
 	attestation := productionBackupAttestation{
-		Format: 1, DeploymentID: workspace.id,
+		Format: 1, DeploymentID: workspace.id, EvidenceFormat: 2, TargetDigest: options.TargetDigest,
 		ControllerDigest: options.ControllerDigest, OffhostDigest: options.OffhostDigest,
 		VerifiedUTC: utcSecond(runtime.now()),
 	}
@@ -336,6 +355,13 @@ func (runtime *productionRuntime) attestBackup(ctx context.Context, options prod
 		if _, err := runtime.validateBackupSet(ctx, workspace, backupDir); err != nil {
 			return err
 		}
+		targetDigest, err := sha256File(filepath.Join(backupDir, "SHA256SUMS"))
+		if err != nil {
+			return err
+		}
+		if targetDigest != options.TargetDigest {
+			return errors.New("target backup checksum digest differs from controller-verified evidence")
+		}
 		path := filepath.Join(backupDir, productionBackupAttestationFilename)
 		encoded, err := json.MarshalIndent(attestation, "", "  ")
 		if err != nil {
@@ -343,33 +369,92 @@ func (runtime *productionRuntime) attestBackup(ctx context.Context, options prod
 		}
 		if existing, err := readPrivateRegularFile(path, 64<<10); err == nil {
 			var current productionBackupAttestation
-			if json.Unmarshal(existing, &current) != nil || current.DeploymentID != attestation.DeploymentID ||
+			if json.Unmarshal(existing, &current) != nil || current.Format != 1 || current.EvidenceFormat != 2 || current.DeploymentID != attestation.DeploymentID || current.TargetDigest != attestation.TargetDigest ||
 				current.ControllerDigest != attestation.ControllerDigest || current.OffhostDigest != attestation.OffhostDigest {
 				return errors.New("backup attestation already exists with different evidence")
 			}
 			attestation = current
-			return nil
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return err
+		} else if err := writeAtomicRegularFile(path, append(encoded, '\n'), 0o600); err != nil {
+			return err
 		}
-		return writeAtomicRegularFile(path, append(encoded, '\n'), 0o600)
+		if options.Confirmation {
+			confirmation := productionBackupConfirmation{
+				Format: 1, DeploymentID: workspace.id, TargetDigest: attestation.TargetDigest,
+				ControllerDigest: attestation.ControllerDigest, OffhostDigest: attestation.OffhostDigest,
+				VerifiedUTC: utcSecond(runtime.now()),
+			}
+			confirmationBytes, err := json.MarshalIndent(confirmation, "", "  ")
+			if err != nil {
+				return err
+			}
+			if err := writeAtomicRegularFile(filepath.Join(backupDir, productionBackupConfirmationFilename), append(confirmationBytes, '\n'), 0o600); err != nil {
+				return err
+			}
+		}
+		return nil
 	})
 	return attestation, err
 }
 
-func validateBackupAttestation(backupDir, deploymentID string) error {
-	content, err := readPrivateRegularFile(filepath.Join(backupDir, productionBackupAttestationFilename), 64<<10)
+func readBackupAttestation(backupDir, deploymentID string) (productionBackupAttestation, error) {
+	path := filepath.Join(backupDir, productionBackupAttestationFilename)
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode().Perm()&0o077 != 0 {
+		return productionBackupAttestation{}, errors.New("external backup attestation is missing or not private")
+	}
+	uid, linkCount, ok := deploymentFileOwnership(info)
+	if !ok || int(uid) != os.Geteuid() || linkCount != 1 {
+		return productionBackupAttestation{}, errors.New("external backup attestation owner or link count is unsafe")
+	}
+	content, err := readPrivateRegularFile(path, 64<<10)
 	if err != nil {
-		return fmt.Errorf("external backup attestation is missing or unsafe: %w", err)
+		return productionBackupAttestation{}, fmt.Errorf("external backup attestation is missing or unsafe: %w", err)
 	}
 	var attestation productionBackupAttestation
 	if err := json.Unmarshal(content, &attestation); err != nil {
-		return fmt.Errorf("decode external backup attestation: %w", err)
+		return productionBackupAttestation{}, fmt.Errorf("decode external backup attestation: %w", err)
 	}
-	if attestation.Format != 1 || attestation.DeploymentID != deploymentID ||
+	legacy := attestation.Format == 1 && attestation.EvidenceFormat == 0 && attestation.TargetDigest == ""
+	bound := attestation.Format == 1 && attestation.EvidenceFormat == 2 && productionSHA256Pattern.MatchString(attestation.TargetDigest)
+	if (!legacy && !bound) || attestation.DeploymentID != deploymentID ||
 		!productionSHA256Pattern.MatchString(attestation.ControllerDigest) ||
 		!productionSHA256Pattern.MatchString(attestation.OffhostDigest) || attestation.VerifiedUTC.IsZero() {
-		return errors.New("external backup attestation is incomplete or belongs to another deployment")
+		return productionBackupAttestation{}, errors.New("external backup attestation is incomplete or belongs to another deployment")
+	}
+	return attestation, nil
+}
+
+func validateBackupAttestation(backupDir, deploymentID string) error {
+	_, err := readBackupAttestation(backupDir, deploymentID)
+	return err
+}
+
+func (runtime *productionRuntime) validateBackupConfirmation(backupDir string, manifest productionManifest, now time.Time) error {
+	path := filepath.Join(backupDir, productionBackupConfirmationFilename)
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode().Perm()&0o077 != 0 {
+		return errors.New("fresh external backup confirmation receipt is missing or not private")
+	}
+	uid, linkCount, ok := deploymentFileOwnership(info)
+	if !ok || uid != runtime.requiredOwnerUID || linkCount != 1 {
+		return errors.New("external backup confirmation receipt owner or link count is unsafe")
+	}
+	content, err := readPrivateRegularFile(path, 64<<10)
+	if err != nil {
+		return fmt.Errorf("fresh external backup confirmation receipt is missing or unsafe: %w", err)
+	}
+	var confirmation productionBackupConfirmation
+	if err := json.Unmarshal(content, &confirmation); err != nil {
+		return fmt.Errorf("decode external backup confirmation receipt: %w", err)
+	}
+	verified := confirmation.VerifiedUTC.UTC()
+	current := now.UTC()
+	if confirmation.Format != 1 || confirmation.DeploymentID != manifest.DeploymentID ||
+		confirmation.TargetDigest != manifest.TargetBackupSHA256 || confirmation.ControllerDigest != manifest.ControllerBackupSHA256 ||
+		confirmation.OffhostDigest != manifest.OffhostBackupSHA256 || verified.IsZero() || verified.After(current.Add(30*time.Second)) || current.Sub(verified) > 5*time.Minute {
+		return errors.New("external backup confirmation receipt is stale or differs from immutable manifest evidence")
 	}
 	return nil
 }
@@ -408,7 +493,8 @@ func (runtime *productionRuntime) verifyExternalBackups(ctx context.Context, opt
 		copyDigests[role] = digest
 	}
 	return productionBackupVerificationResult{
-		DeploymentID: deploymentID, ControllerDigest: copyDigests["controller"], OffhostDigest: copyDigests["off-host"],
+		DeploymentID: deploymentID, TargetDigest: targetChecksumDigest,
+		ControllerDigest: copyDigests["controller"], OffhostDigest: copyDigests["off-host"],
 		TargetVerified: true, EncryptedCopies: true,
 	}, nil
 }
@@ -465,9 +551,11 @@ func (runtime *productionRuntime) verifyExternalBackupCopy(
 	role, root, identity, temporaryRoot, deploymentID, targetChecksumDigest string,
 	targetDigests map[string]string,
 ) (string, error) {
-	if err := verifyNamedChecksums(root, []string{
-		"application.archive", "frontend.archive", "rollback.package", "configuration.age", "database.age", "manifest.env",
-	}); err != nil {
+	names := externalBackupMemberNames()
+	if err := runtime.validateExternalBackupInventory(root, names); err != nil {
+		return "", fmt.Errorf("validate %s backup inventory: %w", role, err)
+	}
+	if err := verifyNamedChecksums(root, names); err != nil {
 		return "", fmt.Errorf("verify %s backup checksums: %w", role, err)
 	}
 	manifest, err := readPrivateRegularFile(filepath.Join(root, "manifest.env"), 64<<10)
@@ -504,4 +592,41 @@ func (runtime *productionRuntime) verifyExternalBackupCopy(
 		}
 	}
 	return sha256File(filepath.Join(root, "SHA256SUMS"))
+}
+
+func (runtime *productionRuntime) validateExternalBackupInventory(root string, members []string) error {
+	info, err := os.Lstat(root)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		return errors.New("external backup root is missing, linked, or not private")
+	}
+	owner, _, ok := deploymentFileOwnership(info)
+	if !ok || int(owner) != runtime.effectiveUID() {
+		return errors.New("external backup root owner is invalid")
+	}
+	expected := make(map[string]bool, len(members)+1)
+	for _, name := range append(append([]string(nil), members...), "SHA256SUMS") {
+		if name == "" || filepath.Base(name) != name || expected[name] {
+			return errors.New("external backup inventory contract is invalid")
+		}
+		expected[name] = true
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != len(expected) {
+		return errors.New("external backup contains a missing or unexpected member")
+	}
+	for _, entry := range entries {
+		if !expected[entry.Name()] {
+			return fmt.Errorf("external backup contains an unexpected member: %s", entry.Name())
+		}
+		path := filepath.Join(root, entry.Name())
+		entryInfo, err := os.Lstat(path)
+		if err != nil || entryInfo.Mode()&os.ModeSymlink != 0 || !entryInfo.Mode().IsRegular() || entryInfo.Size() <= 0 || entryInfo.Mode().Perm()&0o077 != 0 {
+			return fmt.Errorf("external backup member is unsafe: %s", entry.Name())
+		}
+		entryOwner, linkCount, ok := deploymentFileOwnership(entryInfo)
+		if !ok || int(entryOwner) != runtime.effectiveUID() || linkCount != 1 {
+			return fmt.Errorf("external backup member owner or link count is unsafe: %s", entry.Name())
+		}
+	}
+	return nil
 }

--- a/apps/api-go/internal/appcli/deploy_production_probe.go
+++ b/apps/api-go/internal/appcli/deploy_production_probe.go
@@ -108,33 +108,48 @@ func (runtime *productionRuntime) probeModels(ctx context.Context, binary, token
 	return nil
 }
 
-func (runtime *productionRuntime) probeBackendLocal(ctx context.Context, manifest productionManifest, version string) error {
-	if _, err := runtime.probeStatus(ctx, manifest.ProbeBinary, runtime.paths.LocalBaseURL, version); err != nil {
+func (runtime *productionRuntime) probeBackendLocal(ctx context.Context, workspace productionWorkspace, manifest productionManifest, version string) error {
+	binary, err := runtime.validateCandidateEntrypoint(workspace, manifest.ProbeBinary, manifest.ProbeBinarySHA256)
+	if err != nil {
+		return err
+	}
+	return runtime.probeBackendLocalWithBinary(ctx, binary, version)
+}
+
+func (runtime *productionRuntime) probeBackendLocalWithBinary(ctx context.Context, binary, version string) error {
+	if _, err := runtime.probeStatus(ctx, binary, runtime.paths.LocalBaseURL, version); err != nil {
 		return fmt.Errorf("local status probe: %w", err)
 	}
-	if err := runtime.probeLive(ctx, manifest.ProbeBinary); err != nil {
+	if err := runtime.probeLive(ctx, binary); err != nil {
 		return fmt.Errorf("local live probe: %w", err)
 	}
 	return nil
 }
 
-func (runtime *productionRuntime) probeRelease(ctx context.Context, manifest productionManifest, version, frontendSHA256 string) error {
+func (runtime *productionRuntime) probeRelease(ctx context.Context, workspace productionWorkspace, manifest productionManifest, version, frontendSHA256 string) error {
+	binary, err := runtime.validateCandidateEntrypoint(workspace, manifest.ProbeBinary, manifest.ProbeBinarySHA256)
+	if err != nil {
+		return err
+	}
+	return runtime.probeReleaseWithBinary(ctx, workspace, binary, version, frontendSHA256)
+}
+
+func (runtime *productionRuntime) probeReleaseWithBinary(ctx context.Context, workspace productionWorkspace, binary, version, frontendSHA256 string) error {
 	attempts := runtime.probeAttempts
 	if attempts < 1 {
 		attempts = 1
 	}
 	var lastError error
 	for attempt := 0; attempt < attempts; attempt++ {
-		if _, err := runtime.probeStatus(ctx, manifest.ProbeBinary, runtime.paths.LocalBaseURL, version); err != nil {
+		if _, err := runtime.probeStatus(ctx, binary, runtime.paths.LocalBaseURL, version); err != nil {
 			lastError = fmt.Errorf("local status probe: %w", err)
-		} else if err := runtime.probeLive(ctx, manifest.ProbeBinary); err != nil {
+		} else if err := runtime.probeLive(ctx, binary); err != nil {
 			lastError = fmt.Errorf("local live probe: %w", err)
-		} else if _, err := runtime.probeStatus(ctx, manifest.ProbeBinary, runtime.paths.PublicBaseURL, version); err != nil {
+		} else if _, err := runtime.probeStatus(ctx, binary, runtime.paths.PublicBaseURL, version); err != nil {
 			lastError = fmt.Errorf("public status probe: %w", err)
-		} else if err := runtime.probeFrontend(ctx, manifest.ProbeBinary, frontendSHA256); err != nil {
+		} else if err := runtime.probeFrontend(ctx, binary, frontendSHA256); err != nil {
 			lastError = fmt.Errorf("public frontend probe: %w", err)
-		} else if err := runtime.probeModels(ctx, manifest.ProbeBinary, filepath.Join(filepath.Dir(manifest.ProbeBinary), "..", "state", productionProbeTokenFilename)); err != nil {
-			// The probe binary is a direct staging child; state is its sibling.
+		} else if err := runtime.probeModels(ctx, binary, workspace.probeToken); err != nil {
 			lastError = fmt.Errorf("authenticated business probe: %w", err)
 		} else {
 			return nil
@@ -360,7 +375,7 @@ func (runtime *productionRuntime) healthCheck(ctx context.Context, workspace pro
 			return err
 		}
 	}
-	if err := runtime.probeRelease(ctx, manifest, manifest.ExpectedVersion, manifest.Frontend.NewIndexSHA256); err != nil {
+	if err := runtime.probeRelease(ctx, workspace, manifest, manifest.ExpectedVersion, manifest.Frontend.NewIndexSHA256); err != nil {
 		return err
 	}
 	if err := runtime.verifyServiceRestartBaseline(ctx, manifest); err != nil {

--- a/apps/api-go/internal/appcli/deploy_production_release.go
+++ b/apps/api-go/internal/appcli/deploy_production_release.go
@@ -154,7 +154,7 @@ func parseProductionReleasePlanOptions(args []string, stderr io.Writer) (product
 	flags.StringVar(&options.WebRollbackReleaseAsset, "web-rollback-release-asset", "", "signed rollback Web release archive")
 	flags.StringVar(&options.WebRollbackReleaseBundle, "web-rollback-release-bundle", "", "rollback Web Sigstore bundle")
 	flags.StringVar(&options.ProbeBinary, "probe-binary", "", "candidate lmm-api binary extracted from the signed Go release")
-	flags.StringVar(&options.OperatorBinary, "operator-binary", "", "signed deployment operator binary staged separately from the candidate probe")
+	flags.StringVar(&options.OperatorBinary, "operator-binary", "", "optional additional candidate operator artifact to verify before normalizing execution to --probe-binary")
 	flags.BoolVar(&options.WithBackups, "with-backups", false, "require verified target, controller, and off-host backups (mandatory for Go changes)")
 	flags.StringVar(&options.AgeRecipientFile, "age-recipient-file", "", "age or SSH public recipient file used when backups are enabled")
 	flags.IntVar(&options.ObservationSeconds, "observation-seconds", options.ObservationSeconds, "stability observation window (120-360)")
@@ -325,7 +325,7 @@ func (runtime *productionReleaseRuntime) createPlan(ctx context.Context, options
 		WebCandidate:        webCandidate,
 		WebRollback:         webRollback,
 		ProbeBinary:         productionReleaseFilePlan{Path: options.ProbeBinary, SHA256: probeSHA256},
-		OperatorBinary:      productionReleaseFilePlan{Path: options.OperatorBinary, SHA256: operatorSHA256},
+		OperatorBinary:      productionReleaseFilePlan{Path: options.ProbeBinary, SHA256: operatorSHA256},
 		GoChanged:           goChanged,
 		WebChanged:          webChanged,
 		ObservationSeconds:  options.ObservationSeconds,
@@ -1276,11 +1276,13 @@ func validateProductionReleasePlan(plan productionReleasePlan) error {
 		return fmt.Errorf("release plan Web pair: %w", err)
 	}
 	probe, err := cleanAbsoluteNonRoot(plan.ProbeBinary.Path)
-	if err != nil || probe != plan.ProbeBinary.Path || !productionSHA256Pattern.MatchString(plan.ProbeBinary.SHA256) || plan.ProbeBinary.SHA256 != plan.GoCandidate.PayloadSHA256 {
+	if err != nil || probe != plan.ProbeBinary.Path || filepath.Base(probe) != backendGoName ||
+		!productionSHA256Pattern.MatchString(plan.ProbeBinary.SHA256) || plan.ProbeBinary.SHA256 != plan.GoCandidate.PayloadSHA256 {
 		return errors.New("release plan probe identity is invalid")
 	}
 	operator, err := cleanAbsoluteNonRoot(plan.OperatorBinary.Path)
-	if err != nil || operator != plan.OperatorBinary.Path || !productionSHA256Pattern.MatchString(plan.OperatorBinary.SHA256) || plan.OperatorBinary.SHA256 != plan.GoCandidate.PayloadSHA256 {
+	if err != nil || operator != plan.OperatorBinary.Path || operator != probe ||
+		plan.OperatorBinary.SHA256 != plan.ProbeBinary.SHA256 {
 		return errors.New("release plan operator identity is invalid")
 	}
 	if plan.WithBackups {
@@ -1355,7 +1357,7 @@ func validateProductionReleasePlanArtifacts(ctx context.Context, runtime *produc
 		}{plan.AgeRecipient.Path, plan.AgeRecipient.SHA256, "age recipient"})
 	}
 	for _, file := range files {
-		executable := file.label == "probe binary"
+		executable := file.label == "probe binary" || file.label == "operator binary"
 		if err := validateControllerArtifact(file.path, file.label, executable); err != nil {
 			return err
 		}

--- a/apps/api-go/internal/appcli/deploy_production_release_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_release_test.go
@@ -49,7 +49,7 @@ func validProductionReleasePlanArguments(root string) []string {
 		"--web-rollback-package", path("web-old.pkg.tar.zst"),
 		"--web-rollback-release-asset", path("web-old.tar.gz"),
 		"--web-rollback-release-bundle", path("web-old.tar.gz.bundle"),
-		"--probe-binary", path("lmm-api"),
+		"--probe-binary", path(backendGoName),
 	}
 }
 
@@ -220,8 +220,8 @@ func testProductionReleasePlan(t *testing.T, root string) productionReleasePlan 
 		GoRollback:          goRollback,
 		WebCandidate:        web,
 		WebRollback:         web,
-		ProbeBinary:         productionReleaseFilePlan{Path: filepath.Join(root, "lmm-api"), SHA256: goCandidate.PayloadSHA256},
-		OperatorBinary:      productionReleaseFilePlan{Path: filepath.Join(root, "lmm-api"), SHA256: goCandidate.PayloadSHA256},
+		ProbeBinary:         productionReleaseFilePlan{Path: filepath.Join(root, backendGoName), SHA256: goCandidate.PayloadSHA256},
+		OperatorBinary:      productionReleaseFilePlan{Path: filepath.Join(root, backendGoName), SHA256: goCandidate.PayloadSHA256},
 		GoChanged:           true,
 		ObservationSeconds:  180,
 		WithBackups:         true,

--- a/apps/api-go/internal/appcli/deploy_production_remote_backup_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_remote_backup_test.go
@@ -1,0 +1,201 @@
+package appcli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type remoteBackupVerificationRunner struct {
+	root       string
+	digests    map[string]string
+	members    []string
+	unsafeName string
+}
+
+func (runner remoteBackupVerificationRunner) Run(_ context.Context, command productionCommand) ([]byte, error) {
+	if command.Name != commandSSH || len(command.Args) < 4 {
+		return nil, errors.New("unexpected remote backup command")
+	}
+	remote := command.Args[3:]
+	switch {
+	case len(remote) == 3 && remote[0] == "test" && remote[1] == "-d":
+		return nil, nil
+	case len(remote) == 4 && remote[0] == "test" && remote[1] == "!" && remote[2] == "-L":
+		return nil, nil
+	case len(remote) == 7 && remote[0] == "find":
+		paths := make([]string, 0, len(runner.members))
+		for _, name := range runner.members {
+			paths = append(paths, filepath.Join(runner.root, name))
+		}
+		return []byte(strings.Join(paths, "\n") + "\n"), nil
+	case len(remote) == 5 && remote[0] == "stat" && remote[1] == "-c":
+		if remote[2] == "%U:%a:%F" {
+			return []byte("arch:700:directory\n"), nil
+		}
+		name := filepath.Base(remote[4])
+		fileType := "regular file"
+		if name == runner.unsafeName {
+			fileType = "symbolic link"
+		}
+		return []byte("arch:600:1:128:" + fileType + "\n"), nil
+	case len(remote) == 3 && remote[0] == "sha256sum" && remote[1] == "--":
+		digest, ok := runner.digests[remote[2]]
+		if !ok {
+			return nil, errors.New("missing remote digest fixture")
+		}
+		return []byte(digest + "  " + remote[2] + "\n"), nil
+	default:
+		return nil, fmt.Errorf("unexpected remote backup command: %v", remote)
+	}
+}
+
+func writeExternalBackupFixture(t *testing.T, root string) (map[string]string, string) {
+	t.Helper()
+	digests := make(map[string]string)
+	var sums strings.Builder
+	for _, name := range externalBackupMemberNames() {
+		path := filepath.Join(root, name)
+		if err := os.WriteFile(path, []byte("fixture-"+name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		digest, err := sha256File(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		digests[name] = digest
+		_, _ = fmt.Fprintf(&sums, "%s  %s\n", digest, name)
+	}
+	checksumPath := filepath.Join(root, "SHA256SUMS")
+	if err := os.WriteFile(checksumPath, []byte(sums.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checksumDigest, err := sha256File(checksumPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digests["SHA256SUMS"] = checksumDigest
+	return digests, checksumDigest
+}
+
+func TestRemoteExternalBackupVerificationChecksEveryMember(t *testing.T) {
+	local := t.TempDir()
+	localDigests, checksumDigest := writeExternalBackupFixture(t, local)
+	remoteRoot := "/home/arch/.local/state/lmm-api-production-backups/deploy-test"
+	remoteDigests := make(map[string]string, len(localDigests))
+	members := append(externalBackupMemberNames(), "SHA256SUMS")
+	for name, digest := range localDigests {
+		remoteDigests[filepath.Join(remoteRoot, name)] = digest
+	}
+	runtime := &productionReleaseRuntime{runner: remoteBackupVerificationRunner{
+		root: remoteRoot, digests: remoteDigests, members: members,
+	}}
+
+	if err := runtime.verifyRemoteExternalBackupCopy(context.Background(), productionOffhostAlias, remoteRoot, local, "arch", checksumDigest); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRemoteExternalBackupVerificationRejectsMissingTamperedOrLinkedMember(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func([]string, map[string]string, string) ([]string, map[string]string, string)
+	}{
+		{
+			name: "missing member",
+			mutate: func(members []string, digests map[string]string, _ string) ([]string, map[string]string, string) {
+				return members[1:], digests, ""
+			},
+		},
+		{
+			name: "tampered member",
+			mutate: func(members []string, digests map[string]string, root string) ([]string, map[string]string, string) {
+				digests[filepath.Join(root, "database.age")] = strings.Repeat("f", 64)
+				return members, digests, ""
+			},
+		},
+		{
+			name: "linked member",
+			mutate: func(members []string, digests map[string]string, _ string) ([]string, map[string]string, string) {
+				return members, digests, "database.age"
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			local := t.TempDir()
+			localDigests, checksumDigest := writeExternalBackupFixture(t, local)
+			remoteRoot := "/home/arch/.local/state/lmm-api-production-backups/deploy-test"
+			remoteDigests := make(map[string]string, len(localDigests))
+			members := append(externalBackupMemberNames(), "SHA256SUMS")
+			for name, digest := range localDigests {
+				remoteDigests[filepath.Join(remoteRoot, name)] = digest
+			}
+			members, remoteDigests, unsafeName := test.mutate(members, remoteDigests, remoteRoot)
+			runtime := &productionReleaseRuntime{runner: remoteBackupVerificationRunner{
+				root: remoteRoot, digests: remoteDigests, members: members, unsafeName: unsafeName,
+			}}
+
+			if err := runtime.verifyRemoteExternalBackupCopy(context.Background(), productionOffhostAlias, remoteRoot, local, "arch", checksumDigest); err == nil {
+				t.Fatal("unsafe remote backup copy was accepted")
+			}
+		})
+	}
+}
+
+func TestLocalExternalBackupInventoryRejectsLinkedOrUnexpectedMembers(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, string)
+	}{
+		{
+			name: "symlink",
+			mutate: func(t *testing.T, root string) {
+				t.Helper()
+				path := filepath.Join(root, "database.age")
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("application.archive", path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "hardlink",
+			mutate: func(t *testing.T, root string) {
+				t.Helper()
+				path := filepath.Join(root, "database.age")
+				if err := os.Remove(path); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Link(filepath.Join(root, "application.archive"), path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "extra member",
+			mutate: func(t *testing.T, root string) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(root, "unexpected"), []byte("unexpected"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			_, _ = writeExternalBackupFixture(t, root)
+			test.mutate(t, root)
+			runtime := &productionRuntime{effectiveUID: os.Geteuid}
+
+			if err := runtime.validateExternalBackupInventory(root, externalBackupMemberNames()); err == nil {
+				t.Fatal("unsafe local external backup inventory was accepted")
+			}
+		})
+	}
+}

--- a/apps/api-go/internal/appcli/deploy_production_snapshot_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_snapshot_test.go
@@ -209,7 +209,8 @@ func TestNativeProductionBackupCapturesRollbackFrontendConfigAndPostgres(t *test
 		t.Fatalf("proof-only verification=%#v want=%#v", proofVerification, verification)
 	}
 	attestation, err := fixture.runtime.attestBackup(context.Background(), productionBackupAttestOptions{
-		Workspace: fixture.workspace.root, ControllerDigest: verification.ControllerDigest, OffhostDigest: verification.OffhostDigest,
+		Workspace: fixture.workspace.root, TargetDigest: verification.TargetDigest,
+		ControllerDigest: verification.ControllerDigest, OffhostDigest: verification.OffhostDigest,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/apps/api-go/internal/appcli/deploy_production_state.go
+++ b/apps/api-go/internal/appcli/deploy_production_state.go
@@ -33,6 +33,7 @@ const (
 	productionFrontendReleaseKeep = 3
 	productionTransactionMarker   = "deployment.env"
 	productionWorkspaceMarker     = ".lmm-deploy-workspace"
+	productionCandidateLinkName   = "lmm-api"
 	productionManifestFilename    = "deployment.json"
 	productionStatusFilename      = "status.json"
 	// pi-lens-ignore: go-hardcoded-secrets
@@ -362,7 +363,11 @@ type productionManifest struct {
 	NewProviderTarget        string                       `json:"new_provider_target,omitempty"`
 	BackupDir                string                       `json:"backup_dir,omitempty"`
 	BackupsEnabled           bool                         `json:"backups_enabled"`
+	BackupEvidenceFormat     int                          `json:"backup_evidence_format,omitempty"`
 	DatabaseBackupSHA256     string                       `json:"database_backup_sha256,omitempty"`
+	TargetBackupSHA256       string                       `json:"target_backup_sha256,omitempty"`
+	ControllerBackupSHA256   string                       `json:"controller_backup_sha256,omitempty"`
+	OffhostBackupSHA256      string                       `json:"offhost_backup_sha256,omitempty"`
 	DatabaseSchema           string                       `json:"database_schema"`
 	ObservationStartedUTC    time.Time                    `json:"observation_started_utc,omitempty"`
 	ObservationSeconds       int64                        `json:"observation_seconds"`
@@ -721,6 +726,7 @@ type productionWorkspace struct {
 	id            string
 	stateDir      string
 	stagingDir    string
+	candidateLink string
 	manifestPath  string
 	statusPath    string
 	probeToken    string
@@ -1010,6 +1016,7 @@ func (runtime *productionRuntime) openWorkspaceWithMode(root string, requireStag
 		id:            id,
 		stateDir:      stateDir,
 		stagingDir:    stagingDir,
+		candidateLink: filepath.Join(stagingDir, productionCandidateLinkName),
 		manifestPath:  filepath.Join(stateDir, productionManifestFilename),
 		statusPath:    filepath.Join(stateDir, productionStatusFilename),
 		probeToken:    filepath.Join(stateDir, productionProbeTokenFilename),
@@ -1091,6 +1098,39 @@ func (runtime *productionRuntime) writeManifest(workspace productionWorkspace, m
 }
 
 func (runtime *productionRuntime) readManifest(workspace productionWorkspace) (productionManifest, error) {
+	manifest, err := runtime.readManifestSchema(workspace)
+	if err != nil {
+		return productionManifest{}, err
+	}
+	if err := runtime.validateManifestArtifacts(workspace, manifest); err != nil {
+		return productionManifest{}, err
+	}
+	return manifest, nil
+}
+
+func (runtime *productionRuntime) readManifestForRollback(workspace productionWorkspace) (productionManifest, error) {
+	manifest, err := runtime.readManifestSchema(workspace)
+	if err != nil {
+		return productionManifest{}, err
+	}
+	for _, file := range []struct {
+		path, digest, label string
+		changed             bool
+	}{
+		{manifest.Go.RollbackPath, manifest.Go.RollbackSHA256, "rollback Go package", manifest.Go.Changed},
+		{manifest.Web.RollbackPath, manifest.Web.RollbackSHA256, "rollback Web package", manifest.Web.Changed},
+	} {
+		if !file.changed {
+			continue
+		}
+		if err := runtime.validateStagedFile(workspace, file.path, file.digest, file.label); err != nil {
+			return productionManifest{}, fmt.Errorf("deployment manifest %s failed validation: %w", file.label, err)
+		}
+	}
+	return manifest, nil
+}
+
+func (runtime *productionRuntime) readManifestSchema(workspace productionWorkspace) (productionManifest, error) {
 	content, err := readPrivateRegularFile(workspace.manifestPath, 256<<10)
 	if err != nil {
 		return productionManifest{}, fmt.Errorf("read deployment manifest: %w", err)
@@ -1102,7 +1142,7 @@ func (runtime *productionRuntime) readManifest(workspace productionWorkspace) (p
 	if manifest.Format != productionTransactionFormat || manifest.DeploymentID != workspace.id {
 		return productionManifest{}, errors.New("deployment manifest identity is invalid")
 	}
-	if err := runtime.validateManifest(workspace, manifest); err != nil {
+	if err := runtime.validateManifestSchema(workspace, manifest); err != nil {
 		return productionManifest{}, err
 	}
 	return manifest, nil
@@ -1120,6 +1160,13 @@ func providerTargetForPackage(name string) (string, error) {
 }
 
 func (runtime *productionRuntime) validateManifest(workspace productionWorkspace, manifest productionManifest) error {
+	if err := runtime.validateManifestSchema(workspace, manifest); err != nil {
+		return err
+	}
+	return runtime.validateManifestArtifacts(workspace, manifest)
+}
+
+func (runtime *productionRuntime) validateManifestSchema(workspace productionWorkspace, manifest productionManifest) error {
 	if !productionVersionPattern.MatchString(manifest.ExpectedVersion) || !productionVersionPattern.MatchString(manifest.OldVersion) ||
 		manifest.OperatorUser != productionOperatorUser {
 		return errors.New("deployment manifest contains invalid release or operator identity")
@@ -1182,11 +1229,9 @@ func (runtime *productionRuntime) validateManifest(workspace productionWorkspace
 			return errors.New("deployment manifest contains an invalid SHA-256")
 		}
 	}
-	if !pathWithinRoot(workspace.stagingDir, manifest.ProbeBinary) || filepath.Dir(manifest.ProbeBinary) != workspace.stagingDir {
-		return errors.New("deployment manifest probe binary escapes staging")
-	}
-	if !pathWithinRoot(workspace.stagingDir, manifest.OperatorBinary) || filepath.Dir(manifest.OperatorBinary) != workspace.stagingDir {
-		return errors.New("deployment manifest operator binary escapes staging")
+	if manifest.ProbeBinary != manifest.OperatorBinary || manifest.ProbeBinarySHA256 != manifest.OperatorBinarySHA256 ||
+		manifest.ProbeBinary != filepath.Join(workspace.stagingDir, backendGoName) {
+		return errors.New("deployment manifest candidate entrypoint is invalid")
 	}
 	if manifest.ConfigRestorePath != workspace.configRestore {
 		return errors.New("deployment manifest configuration rollback path escapes root-only state")
@@ -1195,7 +1240,16 @@ func (runtime *productionRuntime) validateManifest(workspace productionWorkspace
 		if manifest.BackupDir != filepath.Join(runtime.paths.BackupRoot, workspace.id) || !productionSHA256Pattern.MatchString(manifest.DatabaseBackupSHA256) {
 			return errors.New("deployment manifest backup path or digest is not release-scoped")
 		}
-	} else if manifest.BackupDir != "" || manifest.DatabaseBackupSHA256 != "" {
+		boundDigests := productionSHA256Pattern.MatchString(manifest.TargetBackupSHA256) &&
+			productionSHA256Pattern.MatchString(manifest.ControllerBackupSHA256) &&
+			productionSHA256Pattern.MatchString(manifest.OffhostBackupSHA256)
+		legacyDigests := manifest.TargetBackupSHA256 == "" && manifest.ControllerBackupSHA256 == "" && manifest.OffhostBackupSHA256 == ""
+		if (manifest.BackupEvidenceFormat == 2 && !boundDigests) ||
+			(manifest.BackupEvidenceFormat == 0 && !legacyDigests) ||
+			(manifest.BackupEvidenceFormat != 0 && manifest.BackupEvidenceFormat != 2) {
+			return errors.New("deployment manifest external backup digests are incomplete")
+		}
+	} else if manifest.BackupDir != "" || manifest.BackupEvidenceFormat != 0 || manifest.DatabaseBackupSHA256 != "" || manifest.TargetBackupSHA256 != "" || manifest.ControllerBackupSHA256 != "" || manifest.OffhostBackupSHA256 != "" {
 		return errors.New("deployment manifest contains unauthorized optional backup state")
 	}
 	if manifest.ObservationSeconds < 120 || manifest.ObservationSeconds > 360 {
@@ -1216,18 +1270,23 @@ func (runtime *productionRuntime) validateManifest(workspace productionWorkspace
 	if !isDatabaseSchema(manifest.DatabaseSchema) {
 		return errors.New("deployment manifest contains unsafe schema data")
 	}
+	return nil
+}
+
+func (runtime *productionRuntime) validateManifestArtifacts(workspace productionWorkspace, manifest productionManifest) error {
 	staged := []struct{ path, digest, label string }{
 		{manifest.Go.CandidatePath, manifest.Go.CandidateSHA256, "candidate Go package"},
 		{manifest.Go.RollbackPath, manifest.Go.RollbackSHA256, "rollback Go package"},
 		{manifest.Web.CandidatePath, manifest.Web.CandidateSHA256, "candidate Web package"},
 		{manifest.Web.RollbackPath, manifest.Web.RollbackSHA256, "rollback Web package"},
-		{manifest.ProbeBinary, manifest.ProbeBinarySHA256, "probe binary"},
-		{manifest.OperatorBinary, manifest.OperatorBinarySHA256, "operator binary"},
 	}
 	for _, file := range staged {
 		if err := runtime.validateStagedFile(workspace, file.path, file.digest, file.label); err != nil {
 			return fmt.Errorf("deployment manifest %s failed validation: %w", file.label, err)
 		}
+	}
+	if _, err := runtime.validateCandidateEntrypoint(workspace, manifest.ProbeBinary, manifest.ProbeBinarySHA256); err != nil {
+		return fmt.Errorf("deployment manifest candidate entrypoint failed validation: %w", err)
 	}
 	return nil
 }

--- a/apps/api-go/internal/appcli/deploy_production_transaction.go
+++ b/apps/api-go/internal/appcli/deploy_production_transaction.go
@@ -237,14 +237,30 @@ func (runtime *productionRuntime) paruInstall(ctx context.Context, workspace pro
 	return err
 }
 
-func (runtime *productionRuntime) verifyManifestArchives(ctx context.Context, manifest productionManifest) error {
+func (runtime *productionRuntime) verifyManifestArchives(ctx context.Context, workspace productionWorkspace, manifest productionManifest) error {
 	restoredEnvironment, err := readPrivateRegularFile(filepath.Join(manifest.ConfigRestorePath, "lmm-api-go.env"), 1<<20)
 	if err != nil || fmt.Sprintf("%x", sha256Bytes(restoredEnvironment)) != manifest.EnvironmentRestoreSHA256 {
 		return errors.New("configuration rollback snapshot no longer matches the deployment manifest")
 	}
 	if manifest.BackupsEnabled {
-		if err := validateBackupAttestation(manifest.BackupDir, manifest.DeploymentID); err != nil {
+		if _, err := runtime.validateBackupSet(ctx, workspace, manifest.BackupDir); err != nil {
+			return fmt.Errorf("revalidate target production backup: %w", err)
+		}
+		attestation, err := readBackupAttestation(manifest.BackupDir, manifest.DeploymentID)
+		if err != nil {
 			return err
+		}
+		if manifest.BackupEvidenceFormat == 2 {
+			if attestation.Format != 1 || attestation.EvidenceFormat != 2 || attestation.TargetDigest != manifest.TargetBackupSHA256 ||
+				attestation.ControllerDigest != manifest.ControllerBackupSHA256 || attestation.OffhostDigest != manifest.OffhostBackupSHA256 {
+				return errors.New("production backup attestation differs from immutable manifest digests")
+			}
+			targetDigest, err := sha256File(filepath.Join(manifest.BackupDir, "SHA256SUMS"))
+			if err != nil || targetDigest != manifest.TargetBackupSHA256 {
+				return errors.New("target backup checksum manifest differs from immutable deployment evidence")
+			}
+		} else if manifest.BackupEvidenceFormat != 0 || attestation.Format != 1 || attestation.EvidenceFormat != 0 {
+			return errors.New("legacy deployment manifest cannot accept an unbound current backup attestation")
 		}
 		backupDigest, err := sha256File(filepath.Join(manifest.BackupDir, "database.archive"))
 		if err != nil || backupDigest != manifest.DatabaseBackupSHA256 {
@@ -276,6 +292,37 @@ func (runtime *productionRuntime) verifyManifestArchives(ctx context.Context, ma
 	}
 	if pairs[0].candidate.BinarySHA256 != manifest.ProbeBinarySHA256 || pairs[1].candidate.IndexSHA256 != manifest.Frontend.NewIndexSHA256 || pairs[1].rollback.IndexSHA256 != manifest.Frontend.OldIndexSHA256 {
 		return errors.New("manifest binary or frontend hash does not match staged package archives")
+	}
+	return nil
+}
+
+func (runtime *productionRuntime) verifyRollbackManifestArchives(ctx context.Context, manifest productionManifest) error {
+	if manifest.Go.Changed {
+		restoredEnvironment, err := readPrivateRegularFile(filepath.Join(manifest.ConfigRestorePath, "lmm-api-go.env"), 1<<20)
+		if err != nil || fmt.Sprintf("%x", sha256Bytes(restoredEnvironment)) != manifest.EnvironmentRestoreSHA256 {
+			return errors.New("configuration rollback snapshot no longer matches the deployment manifest")
+		}
+	}
+	for _, transition := range []productionPackageTransition{manifest.Go, manifest.Web} {
+		if !transition.Changed {
+			continue
+		}
+		rollback, err := runtime.packageMetadata(ctx, transition.RollbackPath, transition.RollbackPackageName)
+		if err != nil {
+			return err
+		}
+		if rollback.Identity != transition.RollbackIdentity || rollback.GitRevision != transition.RollbackGitRevision ||
+			rollback.ContractRevision != transition.RollbackContractRevision {
+			return fmt.Errorf("%s rollback metadata does not match the staged package archive", transition.RollbackPackageName)
+		}
+		if transition.RollbackPackageName == productionWebPackageName && rollback.IndexSHA256 != manifest.Frontend.OldIndexSHA256 {
+			return errors.New("rollback Web index hash does not match the deployment manifest")
+		}
+	}
+	if manifest.Go.Changed && manifest.NginxEdgeRestoreSHA256 != "" {
+		if err := runtime.validateEdgePolicyBackup(filepath.Join(manifest.ConfigRestorePath, "nginx-edge"), manifest.NginxEdgeRestoreSHA256); err != nil {
+			return fmt.Errorf("validate edge-policy rollback evidence: %w", err)
+		}
 	}
 	return nil
 }
@@ -556,13 +603,19 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	if options.OperatorBinarySHA256 == "" {
 		options.OperatorBinarySHA256 = options.ProbeBinarySHA256
 	}
+	if options.OperatorBinary != options.ProbeBinary || options.OperatorBinarySHA256 != options.ProbeBinarySHA256 {
+		return productionStatus{}, errors.New("candidate probe and operator evidence must identify the same lmm-api-go provider")
+	}
+	candidateEntrypoint, err := runtime.validateCandidateEntrypoint(workspace, options.ProbeBinary, options.ProbeBinarySHA256)
+	if err != nil {
+		return productionStatus{}, err
+	}
 	staged := []productionStagedFile{
 		{options.GoPackage, options.GoPackageSHA256, "candidate Go package", false},
 		{options.GoRollbackPackage, options.GoRollbackSHA256, "rollback Go package", false},
 		{options.WebPackage, options.WebPackageSHA256, "candidate Web package", false},
 		{options.WebRollbackPackage, options.WebRollbackSHA256, "rollback Web package", false},
-		{options.ProbeBinary, options.ProbeBinarySHA256, "probe binary", true},
-		{options.OperatorBinary, options.OperatorBinarySHA256, "operator binary", true},
+		{options.ProbeBinary, options.ProbeBinarySHA256, "candidate provider binary", true},
 	}
 	if err := runtime.validateOperatorWorkspace(ctx, workspace, options.OperatorUser, staged); err != nil {
 		return productionStatus{}, err
@@ -571,6 +624,9 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 		if err := runtime.validateStagedFile(workspace, file.path, file.digest, file.label); err != nil {
 			return productionStatus{}, err
 		}
+	}
+	if candidateEntrypoint, err = runtime.validateCandidateEntrypoint(workspace, options.ProbeBinary, options.ProbeBinarySHA256); err != nil {
+		return productionStatus{}, err
 	}
 	preflightPackages := make([]string, 0, 4)
 	if options.GoChanged {
@@ -590,10 +646,19 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 		return productionStatus{}, err
 	}
 	databaseBackupSHA256 := ""
+	backupAttestation := productionBackupAttestation{}
 	if options.BackupDir != "" {
 		databaseBackupSHA256, err = sha256File(filepath.Join(options.BackupDir, "database.archive"))
 		if err != nil || !productionSHA256Pattern.MatchString(databaseBackupSHA256) {
 			return productionStatus{}, errors.New("authorized database backup is missing or empty")
+		}
+		backupAttestation, err = readBackupAttestation(options.BackupDir, workspace.id)
+		if err != nil || backupAttestation.Format != 1 || backupAttestation.EvidenceFormat != 2 {
+			return productionStatus{}, errors.New("production backup attestation is not bound to all three copy digests")
+		}
+		targetDigest, err := sha256File(filepath.Join(options.BackupDir, "SHA256SUMS"))
+		if err != nil || targetDigest != backupAttestation.TargetDigest {
+			return productionStatus{}, errors.New("target backup changed after controller verification")
 		}
 	}
 	if _, err := runtime.runner.Run(ctx, productionCommand{Name: commandSystemctl, Args: []string{"is-active", "--quiet", runtime.paths.Service}}); err != nil {
@@ -659,18 +724,18 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	if err := runtime.verifyMemoryPackageOwner(ctx, goRollback.Identity); err != nil {
 		return productionStatus{}, err
 	}
-	probeVersion, err := runVerifiedBinary(ctx, runtime.runner, options.ProbeBinary, []string{"version"}, nil, "", productionCommandTimeout, false)
+	probeVersion, err := runVerifiedBinary(ctx, runtime.runner, candidateEntrypoint, []string{"version"}, nil, "", productionCommandTimeout, false)
 	if err != nil || strings.TrimSpace(string(probeVersion)) != options.ExpectedVersion {
 		return productionStatus{}, errors.New("candidate probe binary version mismatch")
 	}
-	oldVersion, err := runtime.probeStatus(ctx, options.ProbeBinary, runtime.paths.LocalBaseURL, "")
+	oldVersion, err := runtime.probeStatus(ctx, candidateEntrypoint, runtime.paths.LocalBaseURL, "")
 	if err != nil {
 		return productionStatus{}, fmt.Errorf("pre-upgrade local status probe failed: %w", err)
 	}
 	if !productionPackageMatches(goRollback.Version, oldVersion) {
 		return productionStatus{}, errors.New("rollback Go package version does not match the running service")
 	}
-	if _, err := runtime.probeStatus(ctx, options.ProbeBinary, runtime.paths.PublicBaseURL, oldVersion); err != nil {
+	if _, err := runtime.probeStatus(ctx, candidateEntrypoint, runtime.paths.PublicBaseURL, oldVersion); err != nil {
 		return productionStatus{}, fmt.Errorf("pre-upgrade public status probe failed: %w", err)
 	}
 	comparisonOutput, err := runtime.runner.Run(ctx, productionCommand{Name: commandVercmp, Args: []string{oldVersion, options.ExpectedVersion}})
@@ -689,7 +754,7 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	if err != nil || oldIndexSHA != webRollback.IndexSHA256 || oldTarget != frontendTargetFor(webRollback) {
 		return productionStatus{}, errors.New("active frontend does not exactly match rollback Web package")
 	}
-	if err := runtime.probeFrontend(ctx, options.ProbeBinary, oldIndexSHA); err != nil {
+	if err := runtime.probeFrontend(ctx, candidateEntrypoint, oldIndexSHA); err != nil {
 		return productionStatus{}, fmt.Errorf("pre-upgrade public frontend probe failed: %w", err)
 	}
 	newTarget := frontendTargetFor(webCandidate)
@@ -711,10 +776,10 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	if err != nil {
 		return productionStatus{}, err
 	}
-	if err := runtime.probeModels(ctx, options.ProbeBinary, workspace.probeToken); err != nil {
+	if err := runtime.probeModels(ctx, candidateEntrypoint, workspace.probeToken); err != nil {
 		return productionStatus{}, fmt.Errorf("pre-upgrade authenticated business probe failed: %w", err)
 	}
-	if err := runtime.probeLive(ctx, options.ProbeBinary); err != nil {
+	if err := runtime.probeLive(ctx, candidateEntrypoint); err != nil {
 		return productionStatus{}, fmt.Errorf("pre-upgrade live probe failed: %w", err)
 	}
 
@@ -738,8 +803,10 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 		OperatorBinary: options.OperatorBinary, OperatorBinarySHA256: options.OperatorBinarySHA256,
 		ExpectedVersion: options.ExpectedVersion, OldVersion: oldVersion,
 		PreviousProviderTarget: previousProviderTarget, NewProviderTarget: backendGoName,
-		BackupDir: options.BackupDir, BackupsEnabled: options.WithBackups,
-		DatabaseBackupSHA256: databaseBackupSHA256, DatabaseSchema: databaseSchema,
+		BackupDir: options.BackupDir, BackupsEnabled: options.WithBackups, BackupEvidenceFormat: backupAttestation.EvidenceFormat,
+		DatabaseBackupSHA256: databaseBackupSHA256, TargetBackupSHA256: backupAttestation.TargetDigest,
+		ControllerBackupSHA256: backupAttestation.ControllerDigest, OffhostBackupSHA256: backupAttestation.OffhostDigest,
+		DatabaseSchema:     databaseSchema,
 		ObservationSeconds: int64(options.ObservationWindow / time.Second), ConfigRestorePath: workspace.configRestore, EnvironmentRestoreSHA256: environmentRestoreSHA256,
 		NginxEdgeRestoreSHA256: nginxEdgeRestoreSHA256, PreserveEdgePolicy: options.PreserveEdgePolicy,
 	}
@@ -756,6 +823,9 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	if err := runtime.prepareOperatorWorkspace(ctx, workspace, options.OperatorUser, staged); err != nil {
 		return productionStatus{}, err
 	}
+	if candidateEntrypoint, err = runtime.validateCandidateEntrypoint(workspace, options.ProbeBinary, options.ProbeBinarySHA256); err != nil {
+		return productionStatus{}, err
+	}
 	if manifest.Go.Changed {
 		if err := runtime.removeLegacyDeployPackageForProviderMigration(ctx, goCandidate); err != nil {
 			return productionStatus{}, err
@@ -766,7 +836,7 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 		if err := runtime.writeStatus(workspace, productionStatus{Phase: "MIGRATING", Version: options.ExpectedVersion, Previous: oldVersion}); err != nil {
 			return productionStatus{}, err
 		}
-		for _, migration := range []migrationRun{{name: "candidate-apply", binary: manifest.ProbeBinary, mode: "apply"}, {name: "candidate-verify", binary: manifest.ProbeBinary, mode: "verify"}, {name: "rollback-verify", binary: runtime.paths.InstalledBinary, mode: "verify"}} {
+		for _, migration := range []migrationRun{{name: "candidate-apply", binary: candidateEntrypoint, mode: "apply"}, {name: "candidate-verify", binary: candidateEntrypoint, mode: "verify"}, {name: "rollback-verify", binary: runtime.paths.InstalledBinary, mode: "verify"}} {
 			if err := runtime.runMigration(ctx, workspace, manifest, migration); err != nil {
 				return productionStatus{}, err
 			}
@@ -844,7 +914,7 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 			return productionStatus{}, err
 		}
 	}
-	if err := runtime.probeBackendLocalEventually(ctx, manifest, options.ExpectedVersion); err != nil {
+	if err := runtime.probeBackendLocalEventually(ctx, workspace, manifest, options.ExpectedVersion); err != nil {
 		return productionStatus{}, fmt.Errorf("candidate local backend health gate failed: %w", err)
 	}
 	if err := runtime.verifyServiceRestartBaseline(ctx, manifest); err != nil {
@@ -870,7 +940,7 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	if err := runtime.verifyServiceRestartBaseline(ctx, manifest); err != nil {
 		return productionStatus{}, fmt.Errorf("candidate release identity verification changed restart baseline: %w", err)
 	}
-	if err := runtime.probeRelease(ctx, manifest, options.ExpectedVersion, manifest.Frontend.NewIndexSHA256); err != nil {
+	if err := runtime.probeRelease(ctx, workspace, manifest, options.ExpectedVersion, manifest.Frontend.NewIndexSHA256); err != nil {
 		return productionStatus{}, fmt.Errorf("candidate release probes failed: %w", err)
 	}
 	if err := runtime.verifyServiceRestartBaseline(ctx, manifest); err != nil {
@@ -889,10 +959,18 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	return awaiting, nil
 }
 
-func (runtime *productionRuntime) probeBackendLocalEventually(ctx context.Context, manifest productionManifest, expectedVersion string) error {
+func (runtime *productionRuntime) probeBackendLocalEventually(ctx context.Context, workspace productionWorkspace, manifest productionManifest, expectedVersion string) error {
+	return runtime.probeBackendLocalEventuallyWithBinary(ctx, workspace, manifest, "", expectedVersion)
+}
+
+func (runtime *productionRuntime) probeBackendLocalEventuallyWithBinary(ctx context.Context, workspace productionWorkspace, manifest productionManifest, binary, expectedVersion string) error {
 	var probeErr error
 	for attempt := 0; attempt < 30; attempt++ {
-		probeErr = runtime.probeBackendLocal(ctx, manifest, expectedVersion)
+		if binary == "" {
+			probeErr = runtime.probeBackendLocal(ctx, workspace, manifest, expectedVersion)
+		} else {
+			probeErr = runtime.probeBackendLocalWithBinary(ctx, binary, expectedVersion)
+		}
 		if probeErr == nil {
 			return nil
 		}
@@ -955,8 +1033,13 @@ func (runtime *productionRuntime) confirmLoaded(ctx context.Context, workspace p
 	if err := runtime.validateTransactionLock(workspace); err != nil {
 		return productionStatus{}, err
 	}
-	if err := runtime.verifyManifestArchives(ctx, manifest); err != nil {
+	if err := runtime.verifyManifestArchives(ctx, workspace, manifest); err != nil {
 		return productionStatus{}, fmt.Errorf("deployment manifest archive verification failed: %w", err)
+	}
+	if manifest.BackupsEnabled && manifest.BackupEvidenceFormat == 2 {
+		if err := runtime.validateBackupConfirmation(manifest.BackupDir, manifest, runtime.now()); err != nil {
+			return productionStatus{}, err
+		}
 	}
 	observationWindow := time.Duration(manifest.ObservationSeconds) * time.Second
 	observationEnd := manifest.ObservationStartedUTC.Add(observationWindow)
@@ -976,8 +1059,13 @@ func (runtime *productionRuntime) confirmLoaded(ctx context.Context, workspace p
 	}
 	// Re-run archive and live identity gates immediately before the terminal
 	// write so confirmation cannot bless changed evidence or a degraded release.
-	if err := runtime.verifyManifestArchives(ctx, manifest); err != nil {
+	if err := runtime.verifyManifestArchives(ctx, workspace, manifest); err != nil {
 		return productionStatus{}, fmt.Errorf("final deployment archive verification failed: %w", err)
+	}
+	if manifest.BackupsEnabled && manifest.BackupEvidenceFormat == 2 {
+		if err := runtime.validateBackupConfirmation(manifest.BackupDir, manifest, runtime.now()); err != nil {
+			return productionStatus{}, err
+		}
 	}
 	if err := runtime.healthCheck(ctx, workspace, manifest); err != nil {
 		return productionStatus{}, fmt.Errorf("final production health and identity recheck failed: %w", err)
@@ -1007,7 +1095,7 @@ func (runtime *productionRuntime) persistRollbackFailure(workspace productionWor
 }
 
 func (runtime *productionRuntime) rollback(ctx context.Context, workspace productionWorkspace, reason string) (productionStatus, error) {
-	manifest, err := runtime.readManifest(workspace)
+	manifest, err := runtime.readManifestForRollback(workspace)
 	if err != nil {
 		return productionStatus{}, err
 	}
@@ -1033,8 +1121,8 @@ func (runtime *productionRuntime) rollback(ctx context.Context, workspace produc
 	fail := func(operationErr error) (productionStatus, error) {
 		return productionStatus{}, runtime.persistRollbackFailure(workspace, rolling, reason, operationErr)
 	}
-	if err := runtime.verifyManifestArchives(ctx, manifest); err != nil {
-		return fail(fmt.Errorf("deployment manifest archive verification failed: %w", err))
+	if err := runtime.verifyRollbackManifestArchives(ctx, manifest); err != nil {
+		return fail(fmt.Errorf("rollback evidence verification failed: %w", err))
 	}
 	if err := runtime.validateTransactionLock(workspace); err != nil {
 		return fail(err)
@@ -1089,7 +1177,7 @@ func (runtime *productionRuntime) rollback(ctx context.Context, workspace produc
 		if _, err := runtime.runner.Run(ctx, productionCommand{Name: commandSystemctl, Args: []string{"enable", "--now", runtime.paths.Service}}); err != nil {
 			return fail(fmt.Errorf("start rolled-back backend service: %w", err))
 		}
-		if err := runtime.probeBackendLocalEventually(ctx, manifest, manifest.OldVersion); err != nil {
+		if err := runtime.probeBackendLocalEventuallyWithBinary(ctx, workspace, manifest, runtime.paths.InstalledBinary, manifest.OldVersion); err != nil {
 			return fail(fmt.Errorf("rolled-back local backend health gate failed: %w", err))
 		}
 	}
@@ -1104,7 +1192,7 @@ func (runtime *productionRuntime) rollback(ctx context.Context, workspace produc
 	if err := verifyFrontendIdentity(runtime.paths.FrontendRoot, manifest.Frontend.OldTarget, manifest.Frontend.OldIndexSHA256); err != nil {
 		return fail(err)
 	}
-	if err := runtime.probeRelease(ctx, manifest, manifest.OldVersion, manifest.Frontend.OldIndexSHA256); err != nil {
+	if err := runtime.probeReleaseWithBinary(ctx, workspace, runtime.paths.InstalledBinary, manifest.OldVersion, manifest.Frontend.OldIndexSHA256); err != nil {
 		return fail(fmt.Errorf("rolled-back release probes failed: %w", err))
 	}
 	rolledBack := productionStatus{Phase: "ROLLED_BACK", Version: manifest.OldVersion, Previous: manifest.ExpectedVersion, Reason: reason}

--- a/apps/api-go/internal/appcli/deploy_production_transaction_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_transaction_test.go
@@ -590,12 +590,15 @@ func newProductionFixture(t *testing.T) productionFixture {
 	goRollback := filepath.Join(staging, "lmm-api-go-bin-old.pkg.tar.zst")
 	webCandidate := filepath.Join(staging, "lmm-api-web-bin-new.pkg.tar.zst")
 	webRollback := filepath.Join(staging, "lmm-api-web-bin-old.pkg.tar.zst")
-	probe := filepath.Join(staging, "lmm-api-go")
-	operator := filepath.Join(staging, "lmm-api-operator")
-	for path, body := range map[string]string{goCandidate: "go-new", goRollback: "go-old", webCandidate: "web-new", webRollback: "web-old", probe: "probe", operator: "operator"} {
+	probeProvider := filepath.Join(staging, backendGoName)
+	probeEntrypoint := filepath.Join(staging, productionCandidateLinkName)
+	for path, body := range map[string]string{goCandidate: "go-new", goRollback: "go-old", webCandidate: "web-new", webRollback: "web-old", probeProvider: "probe"} {
 		if err := os.WriteFile(path, []byte(body), 0o700); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := os.Symlink(backendGoName, probeEntrypoint); err != nil {
+		t.Fatal(err)
 	}
 	environment := []byte("SQL_DSN=postgres://user:password@127.0.0.1/lmm\nSESSION_COOKIE_SECURE=false\n")
 	if err := os.WriteFile(filepath.Join(paths.ConfigDir, "lmm-api-go.env"), environment, 0o600); err != nil {
@@ -619,13 +622,13 @@ func newProductionFixture(t *testing.T) productionFixture {
 		t.Fatal(err)
 	}
 	clockValue := time.Date(2026, 8, 10, 1, 0, 0, 0, time.UTC)
-	runner := &fakeProductionRunner{t: t, goCandidate: goCandidate, goRollback: goRollback, webCandidate: webCandidate, webRollback: webRollback, probeBinary: probe, installedBinary: paths.InstalledBinary, frontendRoot: paths.FrontendRoot, oldWebIndex: filepath.Join(oldFrontend, "index.html"), newWebIndex: filepath.Join(newFrontend, "index.html"), oldVersion: oldVersion, newVersion: newVersion, oldRevision: oldRevision, newRevision: newRevision, contractRevision: contract, installedGoVersion: oldVersion, installedWebVersion: oldVersion, installedGoRevision: oldRevision, installedWebRevision: oldRevision, goRevisionFile: paths.GoRevisionFile, webRevisionFile: paths.WebRevisionFile, goContractFile: paths.GoContractFile, webContractFile: paths.WebContractFile, serviceActive: true, timerDeadline: clockValue.Add(10 * time.Minute)}
+	runner := &fakeProductionRunner{t: t, goCandidate: goCandidate, goRollback: goRollback, webCandidate: webCandidate, webRollback: webRollback, probeBinary: probeEntrypoint, installedBinary: paths.InstalledBinary, frontendRoot: paths.FrontendRoot, oldWebIndex: filepath.Join(oldFrontend, "index.html"), newWebIndex: filepath.Join(newFrontend, "index.html"), oldVersion: oldVersion, newVersion: newVersion, oldRevision: oldRevision, newRevision: newRevision, contractRevision: contract, installedGoVersion: oldVersion, installedWebVersion: oldVersion, installedGoRevision: oldRevision, installedWebRevision: oldRevision, goRevisionFile: paths.GoRevisionFile, webRevisionFile: paths.WebRevisionFile, goContractFile: paths.GoContractFile, webContractFile: paths.WebContractFile, serviceActive: true, timerDeadline: clockValue.Add(10 * time.Minute)}
 	runtime := &productionRuntime{paths: paths, runner: runner, now: func() time.Time { return clockValue }, sleep: func(d time.Duration) { clockValue = clockValue.Add(d) }, effectiveUID: func() int { return 0 }, hostname: func() (string, error) { return productionExpectedHost, nil }, probeAttempts: 1, requiredOwnerUID: uint32(os.Getuid())}
 	workspace, err := runtime.openWorkspace(workspaceRoot)
 	if err != nil {
 		t.Fatal(err)
 	}
-	options := productionTransactionOptions{Action: "apply", Workspace: workspaceRoot, OperatorUser: productionOperatorUser, GoPackage: goCandidate, GoPackageSHA256: mustHashFile(t, goCandidate), GoRollbackPackage: goRollback, GoRollbackSHA256: mustHashFile(t, goRollback), WebPackage: webCandidate, WebPackageSHA256: mustHashFile(t, webCandidate), WebRollbackPackage: webRollback, WebRollbackSHA256: mustHashFile(t, webRollback), GoChanged: true, WebChanged: true, ProbeBinary: probe, ProbeBinarySHA256: mustHashFile(t, probe), OperatorBinary: operator, OperatorBinarySHA256: mustHashFile(t, operator), ExpectedVersion: newVersion, BackupDir: backupDir, WithBackups: true, ObservationWindow: 2 * time.Minute}
+	options := productionTransactionOptions{Action: "apply", Workspace: workspaceRoot, OperatorUser: productionOperatorUser, GoPackage: goCandidate, GoPackageSHA256: mustHashFile(t, goCandidate), GoRollbackPackage: goRollback, GoRollbackSHA256: mustHashFile(t, goRollback), WebPackage: webCandidate, WebPackageSHA256: mustHashFile(t, webCandidate), WebRollbackPackage: webRollback, WebRollbackSHA256: mustHashFile(t, webRollback), GoChanged: true, WebChanged: true, ProbeBinary: probeProvider, ProbeBinarySHA256: mustHashFile(t, probeProvider), OperatorBinary: probeProvider, OperatorBinarySHA256: mustHashFile(t, probeProvider), ExpectedVersion: newVersion, BackupDir: backupDir, WithBackups: true, ObservationWindow: 2 * time.Minute}
 	return productionFixture{runtime: runtime, runner: runner, workspace: workspace, options: options, environment: environment, clock: &clockValue}
 }
 
@@ -658,13 +661,6 @@ func writeTestBackupSet(root string, environment []byte) error {
 	if err := os.WriteFile(filepath.Join(root, "manifest.env"), []byte("format=1\n"), 0o600); err != nil {
 		return fmt.Errorf("write test backup manifest: %w", err)
 	}
-	attestation, err := json.Marshal(productionBackupAttestation{Format: 1, DeploymentID: filepath.Base(root), ControllerDigest: strings.Repeat("c", 64), OffhostDigest: strings.Repeat("d", 64), VerifiedUTC: time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)})
-	if err != nil {
-		return fmt.Errorf("marshal test backup attestation: %w", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, productionBackupAttestationFilename), append(attestation, '\n'), 0o600); err != nil {
-		return fmt.Errorf("write test backup attestation: %w", err)
-	}
 	var sums strings.Builder
 	for _, name := range []string{"application.archive", "frontend.archive", "configuration.archive", "database.archive", "rollback.package"} {
 		digest, err := sha256File(filepath.Join(root, name))
@@ -676,7 +672,48 @@ func writeTestBackupSet(root string, environment []byte) error {
 	if err := os.WriteFile(filepath.Join(root, "SHA256SUMS"), []byte(sums.String()), 0o600); err != nil {
 		return fmt.Errorf("write test backup checksums: %w", err)
 	}
+	targetDigest, err := sha256File(filepath.Join(root, "SHA256SUMS"))
+	if err != nil {
+		return fmt.Errorf("hash test backup checksums: %w", err)
+	}
+	attestation, err := json.Marshal(productionBackupAttestation{Format: 1, DeploymentID: filepath.Base(root), EvidenceFormat: 2, TargetDigest: targetDigest, ControllerDigest: strings.Repeat("c", 64), OffhostDigest: strings.Repeat("d", 64), VerifiedUTC: time.Date(2026, 8, 10, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		return fmt.Errorf("marshal test backup attestation: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, productionBackupAttestationFilename), append(attestation, '\n'), 0o600); err != nil {
+		return fmt.Errorf("write test backup attestation: %w", err)
+	}
 	return nil
+}
+
+func rewriteTestBackupChecksums(t *testing.T, root string) {
+	t.Helper()
+	var sums strings.Builder
+	for _, name := range []string{"application.archive", "frontend.archive", "configuration.archive", "database.archive", "rollback.package"} {
+		digest, err := sha256File(filepath.Join(root, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = fmt.Fprintf(&sums, "%s  %s\n", digest, name)
+	}
+	if err := os.WriteFile(filepath.Join(root, "SHA256SUMS"), []byte(sums.String()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeTestBackupConfirmation(t *testing.T, manifest productionManifest, verifiedUTC time.Time) {
+	t.Helper()
+	receipt, err := json.Marshal(productionBackupConfirmation{
+		Format: 1, DeploymentID: manifest.DeploymentID, TargetDigest: manifest.TargetBackupSHA256,
+		ControllerDigest: manifest.ControllerBackupSHA256, OffhostDigest: manifest.OffhostBackupSHA256,
+		VerifiedUTC: verifiedUTC,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(manifest.BackupDir, productionBackupConfirmationFilename), append(receipt, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func mustHashFile(t *testing.T, path string) string {
@@ -704,7 +741,8 @@ func TestProductionDualPackageApplyUsesParuAndAwaitsExplicitConfirmationWithoutT
 	if manifest.Format != productionTransactionFormat || manifest.OperatorUser != productionOperatorUser || !manifest.Go.Changed || !manifest.Web.Changed ||
 		manifest.Go.CandidatePackageName != productionAURPackageName || manifest.Go.RollbackPackageName != productionAURPackageName ||
 		manifest.Web.CandidatePackageName != productionWebPackageName || manifest.Web.RollbackPackageName != productionWebPackageName ||
-		manifest.Go.CandidateContractRevision != manifest.Web.CandidateContractRevision || manifest.ServiceRestartBaseline != 0 || manifest.ObservationStartedUTC.IsZero() {
+		manifest.Go.CandidateContractRevision != manifest.Web.CandidateContractRevision || manifest.ServiceRestartBaseline != 0 || manifest.ObservationStartedUTC.IsZero() ||
+		!productionSHA256Pattern.MatchString(manifest.TargetBackupSHA256) || !productionSHA256Pattern.MatchString(manifest.ControllerBackupSHA256) || !productionSHA256Pattern.MatchString(manifest.OffhostBackupSHA256) {
 		t.Fatalf("manifest=%#v", manifest)
 	}
 	paruTransactions := 0
@@ -717,6 +755,9 @@ func TestProductionDualPackageApplyUsesParuAndAwaitsExplicitConfirmationWithoutT
 			if got := strings.Join(command.Args, " "); !strings.Contains(got, "-- /usr/bin/paru -U --noconfirm --") {
 				t.Fatalf("paru invocation=%q", got)
 			}
+		}
+		if command.Name == commandRunuser && len(command.Args) >= 4 && command.Args[1] == "root" && command.Args[3] == fixture.options.ProbeBinary {
+			t.Fatalf("candidate provider was executed directly instead of through %s: %#v", fixture.runner.probeBinary, command)
 		}
 	}
 	if paruTransactions != 2 {
@@ -739,6 +780,7 @@ func TestProductionDualPackageApplyUsesParuAndAwaitsExplicitConfirmationWithoutT
 		filepath.Join(fixture.workspace.root, productionWorkspaceMarker): 0o640,
 		fixture.workspace.stateDir:                                       0o700,
 		fixture.options.GoPackage:                                        0o640,
+		fixture.options.ProbeBinary:                                      0o750,
 	} {
 		info, err := os.Lstat(path)
 		if err != nil {
@@ -748,10 +790,78 @@ func TestProductionDualPackageApplyUsesParuAndAwaitsExplicitConfirmationWithoutT
 			t.Fatalf("operator workspace %s mode=%v want=%v", path, info.Mode().Perm(), wantMode)
 		}
 	}
+	if target, err := os.Readlink(fixture.workspace.candidateLink); err != nil || target != backendGoName {
+		t.Fatalf("candidate entrypoint target=%q err=%v", target, err)
+	}
 	for _, command := range fixture.runner.commands {
 		if command.Name == commandSystemctl && len(command.Args) > 2 && (command.Args[0] == "enable" || command.Args[0] == "disable") && strings.HasPrefix(command.Args[2], "lmm-api-go-rollback-") {
 			t.Fatalf("deployment managed a rollback timer/service: %#v", command)
 		}
+	}
+}
+
+func TestCandidateEntrypointRejectsUnsafeLinksAndTargets(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*testing.T, productionFixture)
+	}{
+		{
+			name: "regular generic file",
+			mutate: func(t *testing.T, fixture productionFixture) {
+				t.Helper()
+				if err := os.Remove(fixture.workspace.candidateLink); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(fixture.workspace.candidateLink, []byte("generic"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "absolute target",
+			mutate: func(t *testing.T, fixture productionFixture) {
+				t.Helper()
+				if err := os.Remove(fixture.workspace.candidateLink); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(fixture.options.ProbeBinary, fixture.workspace.candidateLink); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "chained target",
+			mutate: func(t *testing.T, fixture productionFixture) {
+				t.Helper()
+				if err := os.Remove(fixture.workspace.candidateLink); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(backendGoName, filepath.Join(fixture.workspace.stagingDir, "nested-provider")); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink("nested-provider", fixture.workspace.candidateLink); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "writable provider",
+			mutate: func(t *testing.T, fixture productionFixture) {
+				t.Helper()
+				if err := os.Chmod(fixture.options.ProbeBinary, 0o720); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newProductionFixture(t)
+			test.mutate(t, fixture)
+			if _, err := fixture.runtime.validateCandidateEntrypoint(fixture.workspace, fixture.options.ProbeBinary, fixture.options.ProbeBinarySHA256); err == nil {
+				t.Fatal("unsafe candidate entrypoint was accepted")
+			}
+		})
 	}
 }
 
@@ -773,12 +883,131 @@ func TestProductionRollbackRestoresBothPackagesAndFrontend(t *testing.T) {
 	}
 }
 
+func TestProductionRollbackIgnoresAuxiliaryBackupAndCandidateDamage(t *testing.T) {
+	fixture := newProductionFixture(t)
+	fixture.options.WebPackage = fixture.options.WebRollbackPackage
+	fixture.options.WebPackageSHA256 = fixture.options.WebRollbackSHA256
+	fixture.options.WebChanged = false
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture.options.BackupDir, "application.archive"), []byte("damaged-auxiliary-backup"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fixture.workspace.candidateLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fixture.workspace.candidateLink, []byte("invalid-regular-entrypoint"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fixture.options.WebRollbackPackage, []byte("damaged-unused-web-rollback"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := fixture.runtime.rollback(context.Background(), fixture.workspace, "test-necessary-evidence-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Phase != "ROLLED_BACK" || fixture.runner.installedGoVersion != fixture.runner.oldVersion || fixture.runner.installedWebVersion != fixture.runner.oldVersion {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestProductionWebOnlyRollbackIgnoresUnusedGoAndConfigurationEvidence(t *testing.T) {
+	fixture := newProductionFixture(t)
+	fixture.options.GoPackage = fixture.options.GoRollbackPackage
+	fixture.options.GoPackageSHA256 = fixture.options.GoRollbackSHA256
+	fixture.options.GoChanged = false
+	fixture.options.ExpectedVersion = fixture.runner.oldVersion
+	fixture.runner.probeVersion = fixture.runner.oldVersion
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := fixture.runtime.readManifest(fixture.workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fixture.options.GoRollbackPackage, []byte("damaged-unused-go-rollback"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(manifest.ConfigRestorePath, "lmm-api-go.env"), []byte("damaged-unused-configuration"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := fixture.runtime.rollback(context.Background(), fixture.workspace, "test-web-only-necessary-evidence")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Phase != "ROLLED_BACK" || fixture.runner.installedWebVersion != fixture.runner.oldVersion {
+		t.Fatalf("status=%#v", status)
+	}
+}
+
+func TestProductionRollbackRejectsDamagedNecessaryEvidence(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*testing.T, productionFixture, productionManifest)
+	}{
+		{
+			name: "rollback package",
+			mutate: func(t *testing.T, fixture productionFixture, _ productionManifest) {
+				t.Helper()
+				if err := os.WriteFile(fixture.options.GoRollbackPackage, []byte("damaged-rollback-package"), 0o700); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "configuration restore",
+			mutate: func(t *testing.T, _ productionFixture, manifest productionManifest) {
+				t.Helper()
+				if err := os.WriteFile(filepath.Join(manifest.ConfigRestorePath, "lmm-api-go.env"), []byte("damaged-restore-state"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			fixture := newProductionFixture(t)
+			if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+				t.Fatal(err)
+			}
+			manifest, err := fixture.runtime.readManifest(fixture.workspace)
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.mutate(t, fixture, manifest)
+
+			if _, err := fixture.runtime.rollback(context.Background(), fixture.workspace, "test-damaged-rollback-evidence"); err == nil {
+				t.Fatal("rollback accepted damaged necessary evidence")
+			}
+		})
+	}
+}
+
+func TestProductionTargetOnlyConfirmRequiresFreshExternalBackupReceipt(t *testing.T) {
+	fixture := newProductionFixture(t)
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := fixture.runtime.readManifest(fixture.workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.runtime.now = func() time.Time { return manifest.ObservationStartedUTC.Add(3 * time.Minute) }
+
+	if _, err := fixture.runtime.confirmLoaded(context.Background(), fixture.workspace, manifest); err == nil || !strings.Contains(err.Error(), "confirmation receipt") {
+		t.Fatalf("target-only confirmation error=%v", err)
+	}
+}
+
 func TestProductionConfirmRequiresObservationAndExactIdentities(t *testing.T) {
 	fixture := newProductionFixture(t)
 	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
 		t.Fatal(err)
 	}
 	manifest, _ := fixture.runtime.readManifest(fixture.workspace)
+	writeTestBackupConfirmation(t, manifest, manifest.ObservationStartedUTC)
 	*fixture.clock = manifest.ObservationStartedUTC.Add(119 * time.Second)
 	if _, err := fixture.runtime.confirmLoaded(context.Background(), fixture.workspace, manifest); err == nil || !strings.Contains(err.Error(), "120 seconds") {
 		t.Fatalf("early confirm error=%v", err)
@@ -790,6 +1019,47 @@ func TestProductionConfirmRequiresObservationAndExactIdentities(t *testing.T) {
 	}
 	if confirmed.Phase != "CONFIRMED" {
 		t.Fatalf("confirmed=%#v", confirmed)
+	}
+}
+
+func TestProductionConfirmRejectsTamperedTargetBackupMember(t *testing.T) {
+	fixture := newProductionFixture(t)
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := fixture.runtime.readManifest(fixture.workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.runtime.now = func() time.Time { return manifest.ObservationStartedUTC.Add(3 * time.Minute) }
+	if err := os.WriteFile(filepath.Join(fixture.options.BackupDir, "application.archive"), []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rewriteTestBackupChecksums(t, fixture.options.BackupDir)
+
+	if _, err := fixture.runtime.confirmLoaded(context.Background(), fixture.workspace, manifest); err == nil || !strings.Contains(err.Error(), "checksum manifest") {
+		t.Fatalf("tampered target backup confirmation error=%v", err)
+	}
+}
+
+func TestProductionApplyRejectsSelfConsistentTargetBackupTamperBeforeMutation(t *testing.T) {
+	fixture := newProductionFixture(t)
+	if err := os.WriteFile(filepath.Join(fixture.options.BackupDir, "application.archive"), []byte("tampered-before-apply"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rewriteTestBackupChecksums(t, fixture.options.BackupDir)
+
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err == nil || !strings.Contains(err.Error(), "changed after controller verification") {
+		t.Fatalf("pre-mutation target backup tamper error=%v", err)
+	}
+	for _, event := range fixture.runner.events {
+		if event == "systemd-stop" || strings.HasPrefix(event, "paru-") {
+			t.Fatalf("pre-mutation backup tamper changed production state: %v", fixture.runner.events)
+		}
+	}
+	status, err := fixture.runtime.readStatus(fixture.workspace)
+	if err != nil || status.Phase != "FAILED_PREARM" {
+		t.Fatalf("pre-mutation backup tamper status=%#v err=%v", status, err)
 	}
 }
 
@@ -1095,8 +1365,8 @@ func TestProductionManualRollbackNeverRestoresDatabaseAndPreservesOnlineWrites(t
 	}
 	rollbackPackages := make([]string, 0, 2)
 	for _, command := range fixture.runner.commands[commandsBeforeRollback:] {
-		if filepath.Base(command.Name) == "pg_restore" {
-			t.Fatalf("manual rollback invoked pg_restore: %#v", command)
+		if filepath.Base(command.Name) == "pg_restore" && (len(command.Args) != 2 || command.Args[0] != "--list") {
+			t.Fatalf("manual rollback attempted database restoration: %#v", command)
 		}
 		if command.Name == commandRunuser && len(command.Args) == 8 && command.Args[3] == "/usr/bin/paru" && command.Args[4] == "-U" {
 			rollbackPackages = append(rollbackPackages, command.Args[7])

--- a/apps/api-rust/src/deployment.rs
+++ b/apps/api-rust/src/deployment.rs
@@ -30,6 +30,7 @@ pub const RELEASE_STATE_FORMAT: u32 = 3;
 pub const MINIMUM_OBSERVATION_SECONDS: i64 = 120;
 const MAXIMUM_OBSERVATION_SECONDS: i64 = 360;
 const WORK_ROOT: &str = "/var/lib/lmm-api-go-deploy/work";
+const BACKUP_ROOT: &str = "/var/lib/lmm-api-go-deploy/backups";
 const TRANSACTION_LOCK: &str = "/var/lib/lmm-api-go-deploy/transaction.lock";
 const EXPECTED_HOST: &str = "arch-dmit";
 const SERVICE: &str = "lmm-api.service";
@@ -88,7 +89,15 @@ pub struct ProductionManifest {
     pub backup_dir: PathBuf,
     pub backups_enabled: bool,
     #[serde(default)]
+    pub backup_evidence_format: u32,
+    #[serde(default)]
     pub database_backup_sha256: String,
+    #[serde(default)]
+    pub target_backup_sha256: String,
+    #[serde(default)]
+    pub controller_backup_sha256: String,
+    #[serde(default)]
+    pub offhost_backup_sha256: String,
     pub database_schema: String,
     #[serde(default)]
     pub observation_started_utc: Option<DateTime<Utc>>,
@@ -236,8 +245,21 @@ pub struct Workspace {
 
 impl Workspace {
     pub fn open(path: &Path, require_root_owner: bool) -> Result<Self, DeploymentError> {
+        Self::open_under(path, Path::new(WORK_ROOT), require_root_owner, true)
+    }
+
+    fn open_for_inspection(path: &Path, require_root_owner: bool) -> Result<Self, DeploymentError> {
+        Self::open_under(path, Path::new(WORK_ROOT), require_root_owner, false)
+    }
+
+    fn open_under(
+        path: &Path,
+        work_root: &Path,
+        require_root_owner: bool,
+        require_staging: bool,
+    ) -> Result<Self, DeploymentError> {
         let cleaned = clean_absolute(path)?;
-        if cleaned.parent() != Some(Path::new(WORK_ROOT)) {
+        if cleaned.parent() != Some(work_root) {
             return Err(DeploymentError::UnsafePath(
                 "workspace must be one direct child of the production work root".to_owned(),
             ));
@@ -265,7 +287,11 @@ impl Workspace {
         let state = cleaned.join("state");
         let staging = cleaned.join("staging");
         require_real(&state, true, require_root_owner)?;
-        require_real(&staging, true, require_root_owner)?;
+        match fs::symlink_metadata(&staging) {
+            Ok(_) => require_real(&staging, true, require_root_owner)?,
+            Err(error) if !require_staging && error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
         if fs::metadata(&state)?.permissions().mode() & 0o777 != 0o700 {
             return Err(DeploymentError::UnsafePath(
                 "deployment state must remain root-only".to_owned(),
@@ -289,6 +315,17 @@ impl Workspace {
         let bytes = read_private(&self.manifest, 256 * 1024, require_root_owner)?;
         let manifest: ProductionManifest = serde_json::from_slice(&bytes)?;
         validate_manifest(self, &manifest, require_root_owner)?;
+        Ok(manifest)
+    }
+
+    fn read_manifest_for_rollback(
+        &self,
+        require_root_owner: bool,
+    ) -> Result<ProductionManifest, DeploymentError> {
+        let bytes = read_private(&self.manifest, 256 * 1024, require_root_owner)?;
+        let manifest: ProductionManifest = serde_json::from_slice(&bytes)?;
+        validate_manifest_schema(self, &manifest)?;
+        verify_manifest_evidence_for_rollback(&manifest, require_root_owner)?;
         Ok(manifest)
     }
 
@@ -339,12 +376,25 @@ pub fn validate_release_plan(plan: &ReleasePlan) -> Result<(), DeploymentError> 
     }
     for digest in [
         &plan.go_candidate.package_sha256,
+        &plan.go_candidate.payload_sha256,
         &plan.go_rollback.package_sha256,
         &plan.web_candidate.package_sha256,
         &plan.web_rollback.package_sha256,
         &plan.probe_binary.sha256,
     ] {
         require_sha256(digest)?;
+    }
+    let operator = plan.operator_binary.as_ref().ok_or_else(|| {
+        DeploymentError::InvalidSchema("release plan operator identity is missing".to_owned())
+    })?;
+    if plan.probe_binary.path.file_name() != Some(std::ffi::OsStr::new(GO_PROVIDER))
+        || operator.path != plan.probe_binary.path
+        || operator.sha256 != plan.probe_binary.sha256
+        || plan.probe_binary.sha256 != plan.go_candidate.payload_sha256
+    {
+        return Err(DeploymentError::InvalidSchema(
+            "release plan candidate provider evidence is invalid".to_owned(),
+        ));
     }
     if plan.go_changed && !plan.with_backups {
         return Err(DeploymentError::InvalidSchema(
@@ -380,9 +430,8 @@ pub fn load_release_plan(
 }
 
 pub fn target_status(workspace_path: &Path) -> Result<ProductionStatus, DeploymentError> {
-    let workspace = Workspace::open(workspace_path, false)?;
-    let _manifest = workspace.read_manifest(false)?;
-    workspace.read_status(false)
+    let workspace = Workspace::open_for_inspection(workspace_path, true)?;
+    workspace.read_status(true)
 }
 
 pub async fn target_confirm(workspace_path: &Path) -> Result<ProductionStatus, DeploymentError> {
@@ -391,6 +440,9 @@ pub async fn target_confirm(workspace_path: &Path) -> Result<ProductionStatus, D
     validate_transaction_lock(&workspace)?;
     let manifest = workspace.read_manifest(true)?;
     verify_manifest_evidence(&workspace, &manifest, true)?;
+    if manifest.backups_enabled && manifest.backup_evidence_format == 2 {
+        verify_backup_confirmation(&manifest, true)?;
+    }
     let status = workspace.read_status(true)?;
     if status.phase == "CONFIRMED" {
         finalize_transaction(&workspace)?;
@@ -425,6 +477,9 @@ pub async fn target_confirm(workspace_path: &Path) -> Result<ProductionStatus, D
     };
     workspace.write_status(confirming)?;
     verify_manifest_evidence(&workspace, &manifest, true)?;
+    if manifest.backups_enabled && manifest.backup_evidence_format == 2 {
+        verify_backup_confirmation(&manifest, true)?;
+    }
     verify_active_provider(
         &manifest.go.candidate_package_name,
         &manifest.new_provider_target,
@@ -458,8 +513,7 @@ pub async fn target_rollback(
     }
     let workspace = Workspace::open(workspace_path, true)?;
     validate_transaction_lock(&workspace)?;
-    let manifest = workspace.read_manifest(true)?;
-    verify_manifest_evidence(&workspace, &manifest, true)?;
+    let manifest = workspace.read_manifest_for_rollback(true)?;
     let status = workspace.read_status(true)?;
     if status.phase == "CONFIRMED" || status.phase == "ROLLED_BACK" {
         finalize_transaction(&workspace)?;
@@ -785,6 +839,25 @@ fn validate_manifest(
     manifest: &ProductionManifest,
     require_root_owner: bool,
 ) -> Result<(), DeploymentError> {
+    validate_manifest_schema(workspace, manifest)?;
+    for transition in [&manifest.go, &manifest.web] {
+        validate_transition_evidence(workspace, transition, require_root_owner)?;
+    }
+    let candidate_provider = provider_for_package(&manifest.go.candidate_package_name)?;
+    validate_candidate_entrypoint(
+        workspace,
+        &manifest.probe_binary,
+        &manifest.probe_binary_sha256,
+        candidate_provider,
+        require_root_owner,
+    )?;
+    Ok(())
+}
+
+fn validate_manifest_schema(
+    workspace: &Workspace,
+    manifest: &ProductionManifest,
+) -> Result<(), DeploymentError> {
     if manifest.format != MANIFEST_FORMAT
         || manifest.deployment_id != workspace.id
         || manifest.operator_user != "lmm-api-deploy"
@@ -798,7 +871,7 @@ fn validate_manifest(
         ));
     }
     for transition in [&manifest.go, &manifest.web] {
-        validate_transition(workspace, transition, require_root_owner)?;
+        validate_transition_schema(workspace, transition)?;
     }
     let candidate_provider = provider_for_package(&manifest.go.candidate_package_name)?;
     if manifest.new_provider_target != candidate_provider.filename()
@@ -823,6 +896,42 @@ fn validate_manifest(
             "configuration restore path escapes deployment state".to_owned(),
         ));
     }
+    if manifest.backups_enabled {
+        if manifest.backup_dir != Path::new(BACKUP_ROOT).join(&manifest.deployment_id) {
+            return Err(DeploymentError::UnsafePath(
+                "target backup path is not release-scoped".to_owned(),
+            ));
+        }
+        require_sha256(&manifest.database_backup_sha256)?;
+        let bound = [
+            &manifest.target_backup_sha256,
+            &manifest.controller_backup_sha256,
+            &manifest.offhost_backup_sha256,
+        ]
+        .into_iter()
+        .all(|digest| require_sha256(digest).is_ok());
+        let legacy = manifest.target_backup_sha256.is_empty()
+            && manifest.controller_backup_sha256.is_empty()
+            && manifest.offhost_backup_sha256.is_empty();
+        if (manifest.backup_evidence_format == 2 && !bound)
+            || (manifest.backup_evidence_format == 0 && !legacy)
+            || !matches!(manifest.backup_evidence_format, 0 | 2)
+        {
+            return Err(DeploymentError::InvalidSchema(
+                "external backup digest evidence is incomplete".to_owned(),
+            ));
+        }
+    } else if !manifest.backup_dir.as_os_str().is_empty()
+        || manifest.backup_evidence_format != 0
+        || !manifest.database_backup_sha256.is_empty()
+        || !manifest.target_backup_sha256.is_empty()
+        || !manifest.controller_backup_sha256.is_empty()
+        || !manifest.offhost_backup_sha256.is_empty()
+    {
+        return Err(DeploymentError::InvalidSchema(
+            "manifest contains unauthorized backup evidence".to_owned(),
+        ));
+    }
     for digest in [
         &manifest.probe_binary_sha256,
         &manifest.operator_binary_sha256,
@@ -832,25 +941,55 @@ fn validate_manifest(
     ] {
         require_sha256(digest)?;
     }
-    validate_staged(
-        workspace,
-        &manifest.probe_binary,
-        &manifest.probe_binary_sha256,
-        require_root_owner,
-    )?;
-    validate_staged(
-        workspace,
-        &manifest.operator_binary,
-        &manifest.operator_binary_sha256,
-        require_root_owner,
-    )?;
+    if manifest.probe_binary != manifest.operator_binary
+        || manifest.probe_binary_sha256 != manifest.operator_binary_sha256
+    {
+        return Err(DeploymentError::InvalidSchema(
+            "candidate probe and operator evidence differ".to_owned(),
+        ));
+    }
     Ok(())
 }
 
-fn validate_transition(
+fn validate_candidate_entrypoint(
+    workspace: &Workspace,
+    provider_path: &Path,
+    digest: &str,
+    provider: Provider,
+    require_root_owner: bool,
+) -> Result<PathBuf, DeploymentError> {
+    let expected_provider = workspace.staging.join(provider.filename());
+    if provider_path != expected_provider {
+        return Err(DeploymentError::UnsafePath(
+            "candidate provider evidence is not the release-scoped provider file".to_owned(),
+        ));
+    }
+    validate_staged(workspace, provider_path, digest, require_root_owner)?;
+    let provider_metadata = fs::symlink_metadata(provider_path)?;
+    if provider_metadata.permissions().mode() & 0o022 != 0
+        || provider_metadata.permissions().mode() & 0o100 == 0
+        || provider_metadata.nlink() != 1
+    {
+        return Err(DeploymentError::UnsafePath(
+            "candidate provider target mode or link count is unsafe".to_owned(),
+        ));
+    }
+    let entrypoint = workspace.staging.join("lmm-api");
+    let entrypoint_metadata = fs::symlink_metadata(&entrypoint)?;
+    if !entrypoint_metadata.file_type().is_symlink()
+        || (require_root_owner && entrypoint_metadata.uid() != 0)
+        || fs::read_link(&entrypoint)? != Path::new(provider.filename())
+    {
+        return Err(DeploymentError::UnsafePath(
+            "candidate entrypoint is not a one-hop relative provider link".to_owned(),
+        ));
+    }
+    Ok(entrypoint)
+}
+
+fn validate_transition_schema(
     workspace: &Workspace,
     transition: &PackageTransition,
-    require_root_owner: bool,
 ) -> Result<(), DeploymentError> {
     if transition.candidate_package_name.is_empty()
         || transition.rollback_package_name.is_empty()
@@ -869,18 +1008,8 @@ fn validate_transition(
     }
     require_sha256(&transition.candidate_sha256)?;
     require_sha256(&transition.rollback_sha256)?;
-    validate_staged(
-        workspace,
-        &transition.candidate_path,
-        &transition.candidate_sha256,
-        require_root_owner,
-    )?;
-    validate_staged(
-        workspace,
-        &transition.rollback_path,
-        &transition.rollback_sha256,
-        require_root_owner,
-    )?;
+    validate_staged_path(workspace, &transition.candidate_path)?;
+    validate_staged_path(workspace, &transition.rollback_path)?;
     if !transition.changed
         && (transition.candidate_package_name != transition.rollback_package_name
             || transition.candidate_identity != transition.rollback_identity
@@ -893,18 +1022,42 @@ fn validate_transition(
     Ok(())
 }
 
-fn validate_staged(
+fn validate_transition_evidence(
     workspace: &Workspace,
-    path: &Path,
-    digest: &str,
+    transition: &PackageTransition,
     require_root_owner: bool,
 ) -> Result<(), DeploymentError> {
+    validate_staged(
+        workspace,
+        &transition.candidate_path,
+        &transition.candidate_sha256,
+        require_root_owner,
+    )?;
+    validate_staged(
+        workspace,
+        &transition.rollback_path,
+        &transition.rollback_sha256,
+        require_root_owner,
+    )
+}
+
+fn validate_staged_path(workspace: &Workspace, path: &Path) -> Result<PathBuf, DeploymentError> {
     let clean = clean_absolute(path)?;
     if clean.parent() != Some(workspace.staging.as_path()) {
         return Err(DeploymentError::UnsafePath(
             "staged evidence escapes workspace".to_owned(),
         ));
     }
+    Ok(clean)
+}
+
+fn validate_staged(
+    workspace: &Workspace,
+    path: &Path,
+    digest: &str,
+    require_root_owner: bool,
+) -> Result<(), DeploymentError> {
+    let clean = validate_staged_path(workspace, path)?;
     if sha256_file(&clean, require_root_owner)? != digest {
         return Err(DeploymentError::InvalidEvidence(format!(
             "SHA-256 mismatch for {}",
@@ -926,6 +1079,196 @@ fn verify_manifest_evidence(
             "configuration rollback snapshot no longer matches manifest".to_owned(),
         ));
     }
+    verify_target_backup(manifest, require_root_owner)?;
+    Ok(())
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExternalBackupAttestation {
+    format: u32,
+    deployment_id: String,
+    #[serde(default)]
+    backup_evidence_format: u32,
+    #[serde(default)]
+    target_digest: String,
+    controller_digest: String,
+    offhost_digest: String,
+    verified_utc: DateTime<Utc>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExternalBackupConfirmation {
+    format: u32,
+    deployment_id: String,
+    target_digest: String,
+    controller_digest: String,
+    offhost_digest: String,
+    verified_utc: DateTime<Utc>,
+}
+
+fn verify_target_backup(
+    manifest: &ProductionManifest,
+    require_root_owner: bool,
+) -> Result<(), DeploymentError> {
+    if !manifest.backups_enabled {
+        return Ok(());
+    }
+    let root = &manifest.backup_dir;
+    require_real(root, true, require_root_owner)?;
+    let root_metadata = fs::symlink_metadata(root)?;
+    if root_metadata.permissions().mode() & 0o777 != 0o700 {
+        return Err(DeploymentError::UnsafePath(
+            "target backup root must remain private".to_owned(),
+        ));
+    }
+    let checksum_names = [
+        "application.archive",
+        "frontend.archive",
+        "configuration.archive",
+        "database.archive",
+        "rollback.package",
+    ];
+    let checksum_path = root.join("SHA256SUMS");
+    let checksum_bytes = read_private(&checksum_path, 1024 * 1024, require_root_owner)?;
+    let checksum_text = std::str::from_utf8(&checksum_bytes)
+        .map_err(|_| DeploymentError::InvalidSchema("backup checksums are not UTF-8".to_owned()))?;
+    let mut checksums = BTreeMap::new();
+    for line in checksum_text.lines() {
+        let mut fields = line.split_whitespace();
+        let digest = fields.next().unwrap_or_default();
+        let name = fields.next().unwrap_or_default().trim_start_matches('*');
+        if fields.next().is_some()
+            || !checksum_names.contains(&name)
+            || checksums
+                .insert(name.to_owned(), digest.to_owned())
+                .is_some()
+        {
+            return Err(DeploymentError::InvalidSchema(
+                "backup checksum inventory is invalid".to_owned(),
+            ));
+        }
+        require_sha256(digest)?;
+    }
+    if checksums.len() != checksum_names.len() {
+        return Err(DeploymentError::InvalidEvidence(
+            "backup checksum inventory is incomplete".to_owned(),
+        ));
+    }
+    let mut expected_members = vec![
+        "SHA256SUMS",
+        "application.archive",
+        "configuration.archive",
+        "database.archive",
+        "external-copies.json",
+        "frontend.archive",
+        "manifest.env",
+        "rollback.package",
+    ];
+    if root.join("external-confirmation.json").exists() {
+        expected_members.push("external-confirmation.json");
+    }
+    expected_members.sort_unstable();
+    let mut actual_members = fs::read_dir(root)?
+        .map(|entry| {
+            entry
+                .map(|value| value.file_name().to_string_lossy().into_owned())
+                .map_err(DeploymentError::from)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    actual_members.sort();
+    if actual_members != expected_members {
+        return Err(DeploymentError::InvalidEvidence(
+            "target backup contains a missing or unexpected member".to_owned(),
+        ));
+    }
+    for name in &expected_members {
+        let metadata = fs::symlink_metadata(root.join(name))?;
+        if metadata.file_type().is_symlink()
+            || !metadata.is_file()
+            || metadata.len() == 0
+            || metadata.nlink() != 1
+            || metadata.permissions().mode() & 0o077 != 0
+            || (require_root_owner && metadata.uid() != 0)
+        {
+            return Err(DeploymentError::InvalidEvidence(format!(
+                "target backup member is unsafe: {name}"
+            )));
+        }
+    }
+    for (name, expected_digest) in &checksums {
+        let path = root.join(name);
+        if sha256_file(&path, require_root_owner)? != *expected_digest {
+            return Err(DeploymentError::InvalidEvidence(format!(
+                "target backup member is unsafe or mismatched: {name}"
+            )));
+        }
+    }
+    if checksums.get("database.archive") != Some(&manifest.database_backup_sha256) {
+        return Err(DeploymentError::InvalidEvidence(
+            "database backup digest differs from deployment manifest".to_owned(),
+        ));
+    }
+    let checksum_digest = sha256_bytes(&checksum_bytes);
+    let attestation_bytes = read_private(
+        &root.join("external-copies.json"),
+        64 * 1024,
+        require_root_owner,
+    )?;
+    let attestation: ExternalBackupAttestation = serde_json::from_slice(&attestation_bytes)?;
+    if attestation.format != 1
+        || attestation.deployment_id != manifest.deployment_id
+        || attestation.verified_utc.timestamp() <= 0
+        || require_sha256(&attestation.controller_digest).is_err()
+        || require_sha256(&attestation.offhost_digest).is_err()
+    {
+        return Err(DeploymentError::InvalidEvidence(
+            "external backup attestation is invalid".to_owned(),
+        ));
+    }
+    if manifest.backup_evidence_format == 2 {
+        if attestation.backup_evidence_format != 2
+            || attestation.target_digest != manifest.target_backup_sha256
+            || attestation.controller_digest != manifest.controller_backup_sha256
+            || attestation.offhost_digest != manifest.offhost_backup_sha256
+            || checksum_digest != manifest.target_backup_sha256
+        {
+            return Err(DeploymentError::InvalidEvidence(
+                "backup attestation differs from immutable manifest evidence".to_owned(),
+            ));
+        }
+    } else if attestation.backup_evidence_format != 0 || !attestation.target_digest.is_empty() {
+        return Err(DeploymentError::InvalidEvidence(
+            "legacy manifest cannot accept current backup evidence".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn verify_backup_confirmation(
+    manifest: &ProductionManifest,
+    require_root_owner: bool,
+) -> Result<(), DeploymentError> {
+    let bytes = read_private(
+        &manifest.backup_dir.join("external-confirmation.json"),
+        64 * 1024,
+        require_root_owner,
+    )?;
+    let confirmation: ExternalBackupConfirmation = serde_json::from_slice(&bytes)?;
+    let now = Utc::now();
+    if confirmation.format != 1
+        || confirmation.deployment_id != manifest.deployment_id
+        || confirmation.target_digest != manifest.target_backup_sha256
+        || confirmation.controller_digest != manifest.controller_backup_sha256
+        || confirmation.offhost_digest != manifest.offhost_backup_sha256
+        || confirmation.verified_utc > now + chrono::Duration::seconds(30)
+        || now - confirmation.verified_utc > chrono::Duration::minutes(5)
+    {
+        return Err(DeploymentError::InvalidEvidence(
+            "external backup confirmation receipt is stale or mismatched".to_owned(),
+        ));
+    }
     Ok(())
 }
 
@@ -933,12 +1276,24 @@ fn verify_manifest_evidence_for_rollback(
     manifest: &ProductionManifest,
     require_root_owner: bool,
 ) -> Result<(), DeploymentError> {
-    if sha256_file(&manifest.go.rollback_path, require_root_owner)? != manifest.go.rollback_sha256
-        || sha256_file(&manifest.web.rollback_path, require_root_owner)?
+    if manifest.go.changed
+        && (sha256_file(
+            &manifest.config_restore_path.join("lmm-api-go.env"),
+            require_root_owner,
+        )? != manifest.environment_restore_sha256
+            || sha256_file(&manifest.go.rollback_path, require_root_owner)?
+                != manifest.go.rollback_sha256)
+    {
+        return Err(DeploymentError::InvalidEvidence(
+            "Go rollback package or configuration evidence changed during operation".to_owned(),
+        ));
+    }
+    if manifest.web.changed
+        && sha256_file(&manifest.web.rollback_path, require_root_owner)?
             != manifest.web.rollback_sha256
     {
         return Err(DeploymentError::InvalidEvidence(
-            "rollback package evidence changed during operation".to_owned(),
+            "Web rollback package evidence changed during operation".to_owned(),
         ));
     }
     Ok(())
@@ -1079,6 +1434,7 @@ fn require_real(
     if metadata.file_type().is_symlink()
         || directory != metadata.is_dir()
         || (!directory && !metadata.is_file())
+        || metadata.permissions().mode() & 0o022 != 0
         || (require_root_owner && metadata.uid() != 0)
     {
         return Err(DeploymentError::UnsafePath(path.display().to_string()));
@@ -1170,7 +1526,26 @@ fn valid_version(value: &str) -> bool {
 fn valid_identity(identity: &str, package: &str) -> bool {
     identity
         .split_once(' ')
-        .is_some_and(|(name, version)| name == package && valid_version(version))
+        .is_some_and(|(name, full_version)| {
+            name == package
+                && full_version
+                    .rsplit_once('-')
+                    .is_some_and(|(version, release)| {
+                        valid_version(version)
+                            && !release.is_empty()
+                            && release.as_bytes()[0].is_ascii_digit()
+                            && release.split_once('.').map_or_else(
+                                || release.bytes().all(|byte| byte.is_ascii_digit()),
+                                |(major, minor)| {
+                                    !major.is_empty()
+                                        && !minor.is_empty()
+                                        && major.bytes().all(|byte| byte.is_ascii_digit())
+                                        && minor.bytes().all(|byte| byte.is_ascii_digit())
+                                },
+                            )
+                            && !release.starts_with('0')
+                    })
+        })
 }
 
 fn valid_reason(reason: &str) -> bool {
@@ -1184,7 +1559,284 @@ fn valid_reason(reason: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        os::unix::fs::{PermissionsExt, symlink},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
     use super::*;
+
+    static TEST_WORKSPACE_ID: AtomicUsize = AtomicUsize::new(0);
+
+    struct TestWorkspace {
+        base: PathBuf,
+        work_root: PathBuf,
+        workspace: PathBuf,
+    }
+
+    impl TestWorkspace {
+        fn new() -> Self {
+            let sequence = TEST_WORKSPACE_ID.fetch_add(1, Ordering::Relaxed);
+            let base = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("target/deployment-unit-tests")
+                .join(format!("{}-{sequence}", std::process::id()));
+            let work_root = base.join("work");
+            let workspace = work_root.join("cleaned-terminal");
+            let state = workspace.join("state");
+            fs::create_dir_all(&state).expect("create deployment state fixture");
+            fs::set_permissions(&state, fs::Permissions::from_mode(0o700))
+                .expect("protect deployment state fixture");
+            fs::write(
+                workspace.join(".lmm-deploy-workspace"),
+                "format=1\ndeployment_id=cleaned-terminal\nrole=target\n",
+            )
+            .expect("write workspace marker");
+            let status = ProductionStatus {
+                format: STATUS_FORMAT,
+                deployment_id: "cleaned-terminal".to_owned(),
+                phase: "CONFIRMED".to_owned(),
+                version: "0.2.13".to_owned(),
+                previous: "0.2.12".to_owned(),
+                reason: "test".to_owned(),
+                failure: String::new(),
+                updated_utc: Utc::now(),
+                observation_seconds: MINIMUM_OBSERVATION_SECONDS,
+            };
+            fs::write(
+                state.join("status.json"),
+                serde_json::to_vec(&status).expect("encode status fixture"),
+            )
+            .expect("write status fixture");
+            Self {
+                base,
+                work_root,
+                workspace,
+            }
+        }
+
+        fn candidate_entrypoint(&self) -> (PathBuf, String) {
+            let staging = self.workspace.join("staging");
+            fs::create_dir(&staging).expect("create staging fixture");
+            let provider = staging.join(GO_PROVIDER);
+            fs::write(&provider, b"candidate-provider").expect("write provider fixture");
+            fs::set_permissions(&provider, fs::Permissions::from_mode(0o700))
+                .expect("protect provider fixture");
+            symlink(GO_PROVIDER, staging.join("lmm-api"))
+                .expect("create candidate entrypoint fixture");
+            let digest = sha256_file(&provider, false).expect("hash provider fixture");
+            (provider, digest)
+        }
+
+        fn go_rollback_manifest(&self) -> ProductionManifest {
+            let (provider, provider_digest) = self.candidate_entrypoint();
+            let staging = self.workspace.join("staging");
+            let write_package = |name: &str, body: &[u8]| {
+                let path = staging.join(name);
+                fs::write(&path, body).expect("write package fixture");
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+                    .expect("protect package fixture");
+                let digest = sha256_file(&path, false).expect("hash package fixture");
+                (path, digest)
+            };
+            let (go_candidate, go_candidate_digest) =
+                write_package("lmm-api-go-bin-new.pkg.tar.zst", b"go-candidate");
+            let (go_rollback, go_rollback_digest) =
+                write_package("lmm-api-go-bin-old.pkg.tar.zst", b"go-rollback");
+            let (web_candidate, web_candidate_digest) =
+                write_package("lmm-api-web-bin-new.pkg.tar.zst", b"web-candidate");
+            let (web_rollback, _web_rollback_digest) =
+                write_package("lmm-api-web-bin-old.pkg.tar.zst", b"web-candidate");
+            let config_restore = self.workspace.join("state/config-restore");
+            fs::create_dir(&config_restore).expect("create config restore fixture");
+            fs::set_permissions(&config_restore, fs::Permissions::from_mode(0o700))
+                .expect("protect config restore fixture");
+            let environment = config_restore.join("lmm-api-go.env");
+            fs::write(&environment, b"SQL_DSN=postgres://fixture\n")
+                .expect("write environment restore fixture");
+            fs::set_permissions(&environment, fs::Permissions::from_mode(0o600))
+                .expect("protect environment restore fixture");
+            let environment_digest =
+                sha256_file(&environment, false).expect("hash environment restore fixture");
+            let contract = "a".repeat(64);
+            ProductionManifest {
+                format: MANIFEST_FORMAT,
+                deployment_id: "cleaned-terminal".to_owned(),
+                operator_user: "lmm-api-deploy".to_owned(),
+                go: PackageTransition {
+                    candidate_package_name: "lmm-api-go-bin".to_owned(),
+                    rollback_package_name: "lmm-api-go-bin".to_owned(),
+                    changed: true,
+                    candidate_path: go_candidate,
+                    rollback_path: go_rollback,
+                    candidate_identity: "lmm-api-go-bin 0.2.13-1".to_owned(),
+                    rollback_identity: "lmm-api-go-bin 0.2.12-1".to_owned(),
+                    candidate_sha256: go_candidate_digest,
+                    rollback_sha256: go_rollback_digest,
+                    candidate_git_revision: "2".repeat(40),
+                    rollback_git_revision: "1".repeat(40),
+                    candidate_contract_revision: contract.clone(),
+                    rollback_contract_revision: contract.clone(),
+                },
+                web: PackageTransition {
+                    candidate_package_name: "lmm-api-web-bin".to_owned(),
+                    rollback_package_name: "lmm-api-web-bin".to_owned(),
+                    changed: false,
+                    candidate_path: web_candidate,
+                    rollback_path: web_rollback,
+                    candidate_identity: "lmm-api-web-bin 0.1.57-1".to_owned(),
+                    rollback_identity: "lmm-api-web-bin 0.1.57-1".to_owned(),
+                    candidate_sha256: web_candidate_digest.clone(),
+                    rollback_sha256: web_candidate_digest,
+                    candidate_git_revision: "3".repeat(40),
+                    rollback_git_revision: "3".repeat(40),
+                    candidate_contract_revision: contract.clone(),
+                    rollback_contract_revision: contract,
+                },
+                frontend: FrontendTransition {
+                    old_target: "releases/0.1.57-1.g333333333333".to_owned(),
+                    new_target: "releases/0.1.57-1.g333333333333".to_owned(),
+                    old_index_sha256: "4".repeat(64),
+                    new_index_sha256: "4".repeat(64),
+                },
+                probe_binary: provider.clone(),
+                probe_binary_sha256: provider_digest.clone(),
+                operator_binary: provider,
+                operator_binary_sha256: provider_digest,
+                expected_version: "0.2.13".to_owned(),
+                old_version: "0.2.12".to_owned(),
+                previous_provider_target: GO_PROVIDER.to_owned(),
+                new_provider_target: GO_PROVIDER.to_owned(),
+                backup_dir: PathBuf::new(),
+                backups_enabled: false,
+                backup_evidence_format: 0,
+                database_backup_sha256: String::new(),
+                target_backup_sha256: String::new(),
+                controller_backup_sha256: String::new(),
+                offhost_backup_sha256: String::new(),
+                database_schema: "public".to_owned(),
+                observation_started_utc: Some(Utc::now()),
+                observation_seconds: MINIMUM_OBSERVATION_SECONDS,
+                service_restart_baseline: 0,
+                config_restore_path: config_restore,
+                environment_restore_sha256: environment_digest,
+                nginx_edge_restore_sha256: String::new(),
+                preserve_edge_policy: false,
+            }
+        }
+
+        fn bound_backup_manifest(&self) -> ProductionManifest {
+            let backup = self.base.join("backup");
+            fs::create_dir(&backup).expect("create backup fixture");
+            fs::set_permissions(&backup, fs::Permissions::from_mode(0o700))
+                .expect("protect backup fixture");
+            let checksummed = [
+                "application.archive",
+                "frontend.archive",
+                "configuration.archive",
+                "database.archive",
+                "rollback.package",
+            ];
+            let mut checksums = String::new();
+            let mut database_digest = String::new();
+            for name in checksummed {
+                let path = backup.join(name);
+                fs::write(&path, format!("fixture-{name}")).expect("write backup member fixture");
+                fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+                    .expect("protect backup member fixture");
+                let digest = sha256_file(&path, false).expect("hash backup member fixture");
+                if name == "database.archive" {
+                    database_digest.clone_from(&digest);
+                }
+                checksums.push_str(&format!("{digest}  {name}\n"));
+            }
+            let manifest_path = backup.join("manifest.env");
+            fs::write(&manifest_path, "format=1\n").expect("write backup manifest fixture");
+            fs::set_permissions(&manifest_path, fs::Permissions::from_mode(0o600))
+                .expect("protect backup manifest fixture");
+            let checksum_path = backup.join("SHA256SUMS");
+            fs::write(&checksum_path, &checksums).expect("write backup checksums fixture");
+            fs::set_permissions(&checksum_path, fs::Permissions::from_mode(0o600))
+                .expect("protect backup checksums fixture");
+            let target_digest =
+                sha256_file(&checksum_path, false).expect("hash backup checksum fixture");
+            let controller_digest = "c".repeat(64);
+            let offhost_digest = "d".repeat(64);
+            let attestation = serde_json::json!({
+                "format": 1,
+                "deployment_id": "cleaned-terminal",
+                "backup_evidence_format": 2,
+                "target_digest": target_digest,
+                "controller_digest": controller_digest,
+                "offhost_digest": offhost_digest,
+                "verified_utc": Utc::now(),
+            });
+            let attestation_path = backup.join("external-copies.json");
+            fs::write(
+                &attestation_path,
+                serde_json::to_vec(&attestation).expect("encode backup attestation fixture"),
+            )
+            .expect("write backup attestation fixture");
+            fs::set_permissions(&attestation_path, fs::Permissions::from_mode(0o600))
+                .expect("protect backup attestation fixture");
+            let transition = PackageTransition {
+                candidate_package_name: String::new(),
+                rollback_package_name: String::new(),
+                changed: false,
+                candidate_path: PathBuf::new(),
+                rollback_path: PathBuf::new(),
+                candidate_identity: String::new(),
+                rollback_identity: String::new(),
+                candidate_sha256: String::new(),
+                rollback_sha256: String::new(),
+                candidate_git_revision: String::new(),
+                rollback_git_revision: String::new(),
+                candidate_contract_revision: String::new(),
+                rollback_contract_revision: String::new(),
+            };
+            ProductionManifest {
+                format: MANIFEST_FORMAT,
+                deployment_id: "cleaned-terminal".to_owned(),
+                operator_user: String::new(),
+                go: transition.clone(),
+                web: transition,
+                frontend: FrontendTransition {
+                    old_target: String::new(),
+                    new_target: String::new(),
+                    old_index_sha256: String::new(),
+                    new_index_sha256: String::new(),
+                },
+                probe_binary: PathBuf::new(),
+                probe_binary_sha256: String::new(),
+                operator_binary: PathBuf::new(),
+                operator_binary_sha256: String::new(),
+                expected_version: String::new(),
+                old_version: String::new(),
+                previous_provider_target: String::new(),
+                new_provider_target: String::new(),
+                backup_dir: backup,
+                backups_enabled: true,
+                backup_evidence_format: 2,
+                database_backup_sha256: database_digest,
+                target_backup_sha256: target_digest,
+                controller_backup_sha256: controller_digest,
+                offhost_backup_sha256: offhost_digest,
+                database_schema: String::new(),
+                observation_started_utc: None,
+                observation_seconds: MINIMUM_OBSERVATION_SECONDS,
+                service_restart_baseline: 0,
+                config_restore_path: PathBuf::new(),
+                environment_restore_sha256: String::new(),
+                nginx_edge_restore_sha256: String::new(),
+                preserve_edge_policy: false,
+            }
+        }
+    }
+
+    impl Drop for TestWorkspace {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.base);
+        }
+    }
 
     #[test]
     fn formats_match_manual_only_go_contract() {
@@ -1212,5 +1864,227 @@ mod tests {
     fn unsafe_rollback_reason_is_rejected() {
         assert!(!valid_reason("operator request"));
         assert!(valid_reason("operator-request:incident_42"));
+    }
+
+    #[test]
+    fn go_arch_package_identities_include_pkgrel() {
+        assert!(valid_identity("lmm-api-go-bin 0.2.13-1", "lmm-api-go-bin"));
+        assert!(valid_identity(
+            "lmm-api-web-bin 0.1.57-2.1",
+            "lmm-api-web-bin"
+        ));
+        assert!(!valid_identity("lmm-api-go-bin 0.2.13", "lmm-api-go-bin"));
+        assert!(!valid_identity("lmm-api-go-bin 0.2.13-0", "lmm-api-go-bin"));
+    }
+
+    #[test]
+    fn inspection_accepts_terminal_workspace_without_staging() {
+        let fixture = TestWorkspace::new();
+
+        let workspace = Workspace::open_under(&fixture.workspace, &fixture.work_root, false, false)
+            .expect("inspect cleaned terminal workspace");
+
+        assert_eq!(
+            workspace
+                .read_status(false)
+                .expect("read retained terminal status")
+                .phase,
+            "CONFIRMED"
+        );
+    }
+
+    #[test]
+    fn mutation_rejects_terminal_workspace_without_staging() {
+        let fixture = TestWorkspace::new();
+
+        let error = Workspace::open_under(&fixture.workspace, &fixture.work_root, false, true)
+            .expect_err("mutation must require staging");
+
+        assert!(
+            matches!(error, DeploymentError::Io(ref source) if source.kind() == io::ErrorKind::NotFound)
+        );
+    }
+
+    #[test]
+    fn inspection_rejects_symlinked_staging() {
+        let fixture = TestWorkspace::new();
+        symlink("/etc", fixture.workspace.join("staging")).expect("create unsafe staging symlink");
+
+        let error = Workspace::open_under(&fixture.workspace, &fixture.work_root, false, false)
+            .expect_err("inspection must reject symlinked staging");
+
+        assert!(matches!(error, DeploymentError::UnsafePath(_)));
+    }
+
+    #[test]
+    fn candidate_entrypoint_accepts_one_hop_relative_provider_link() {
+        let fixture = TestWorkspace::new();
+        let (provider, digest) = fixture.candidate_entrypoint();
+        let workspace = Workspace::open_under(&fixture.workspace, &fixture.work_root, false, true)
+            .expect("open staged workspace");
+
+        let entrypoint =
+            validate_candidate_entrypoint(&workspace, &provider, &digest, Provider::Go, false)
+                .expect("validate candidate entrypoint");
+
+        assert_eq!(entrypoint, fixture.workspace.join("staging/lmm-api"));
+    }
+
+    #[test]
+    fn candidate_entrypoint_rejects_absolute_or_chained_target() {
+        for target in ["/usr/bin/lmm-api-go", "nested-provider"] {
+            let fixture = TestWorkspace::new();
+            let (provider, digest) = fixture.candidate_entrypoint();
+            let entrypoint = fixture.workspace.join("staging/lmm-api");
+            fs::remove_file(&entrypoint).expect("remove valid entrypoint fixture");
+            symlink(target, &entrypoint).expect("create invalid entrypoint fixture");
+            if target == "nested-provider" {
+                symlink(
+                    GO_PROVIDER,
+                    fixture.workspace.join("staging/nested-provider"),
+                )
+                .expect("create chained provider fixture");
+            }
+            let workspace =
+                Workspace::open_under(&fixture.workspace, &fixture.work_root, false, true)
+                    .expect("open staged workspace");
+
+            assert!(
+                validate_candidate_entrypoint(&workspace, &provider, &digest, Provider::Go, false,)
+                    .is_err(),
+                "unsafe target was accepted: {target}"
+            );
+        }
+    }
+
+    #[test]
+    fn rollback_reader_accepts_go_manifest_and_ignores_candidate_and_backup_evidence() {
+        let fixture = TestWorkspace::new();
+        let mut manifest = fixture.go_rollback_manifest();
+        manifest.backups_enabled = true;
+        manifest.backup_dir = Path::new(BACKUP_ROOT).join(&manifest.deployment_id);
+        manifest.backup_evidence_format = 2;
+        manifest.database_backup_sha256 = "b".repeat(64);
+        manifest.target_backup_sha256 = "c".repeat(64);
+        manifest.controller_backup_sha256 = "d".repeat(64);
+        manifest.offhost_backup_sha256 = "e".repeat(64);
+        fs::write(
+            fixture.workspace.join("state/deployment.json"),
+            serde_json::to_vec(&manifest).expect("encode Go-style deployment manifest"),
+        )
+        .expect("write Go-style deployment manifest");
+        fs::set_permissions(
+            fixture.workspace.join("state/deployment.json"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .expect("protect Go-style deployment manifest");
+        fs::remove_file(fixture.workspace.join("staging/lmm-api"))
+            .expect("remove candidate entrypoint fixture");
+        fs::write(&manifest.probe_binary, b"damaged-candidate-provider")
+            .expect("damage candidate provider fixture");
+        fs::set_permissions(&manifest.probe_binary, fs::Permissions::from_mode(0o700))
+            .expect("protect damaged candidate provider fixture");
+        let workspace = Workspace::open_under(&fixture.workspace, &fixture.work_root, false, true)
+            .expect("open rollback workspace");
+
+        let loaded = workspace
+            .read_manifest_for_rollback(false)
+            .expect("read Go transaction using only rollback evidence");
+
+        assert_eq!(loaded.go.rollback_identity, "lmm-api-go-bin 0.2.12-1");
+        assert!(workspace.read_manifest(false).is_err());
+    }
+
+    #[test]
+    fn rollback_reader_rejects_damaged_package_or_configuration() {
+        for damage_configuration in [false, true] {
+            let fixture = TestWorkspace::new();
+            let manifest = fixture.go_rollback_manifest();
+            fs::write(
+                fixture.workspace.join("state/deployment.json"),
+                serde_json::to_vec(&manifest).expect("encode deployment manifest"),
+            )
+            .expect("write deployment manifest");
+            fs::set_permissions(
+                fixture.workspace.join("state/deployment.json"),
+                fs::Permissions::from_mode(0o600),
+            )
+            .expect("protect deployment manifest");
+            let damaged = if damage_configuration {
+                manifest.config_restore_path.join("lmm-api-go.env")
+            } else {
+                manifest.go.rollback_path.clone()
+            };
+            fs::write(&damaged, b"damaged-rollback-evidence")
+                .expect("damage necessary rollback evidence");
+            fs::set_permissions(&damaged, fs::Permissions::from_mode(0o600))
+                .expect("protect damaged rollback evidence");
+            let workspace =
+                Workspace::open_under(&fixture.workspace, &fixture.work_root, false, true)
+                    .expect("open rollback workspace");
+
+            assert!(workspace.read_manifest_for_rollback(false).is_err());
+        }
+    }
+
+    #[test]
+    fn target_backup_rejects_self_consistent_member_rewrite() {
+        let fixture = TestWorkspace::new();
+        let manifest = fixture.bound_backup_manifest();
+        verify_target_backup(&manifest, false).expect("verify bound target backup");
+        let application = manifest.backup_dir.join("application.archive");
+        fs::write(&application, "tampered-application")
+            .expect("rewrite target backup member fixture");
+        fs::set_permissions(&application, fs::Permissions::from_mode(0o600))
+            .expect("protect rewritten target backup fixture");
+        let replacement = sha256_file(&application, false).expect("hash rewritten member");
+        let checksum_path = manifest.backup_dir.join("SHA256SUMS");
+        let current = fs::read_to_string(&checksum_path).expect("read checksum fixture");
+        let rewritten = current
+            .lines()
+            .map(|line| {
+                if line.ends_with("  application.archive") {
+                    format!("{replacement}  application.archive")
+                } else {
+                    line.to_owned()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        fs::write(&checksum_path, rewritten).expect("rewrite checksum fixture");
+        fs::set_permissions(&checksum_path, fs::Permissions::from_mode(0o600))
+            .expect("protect rewritten checksum fixture");
+
+        assert!(verify_target_backup(&manifest, false).is_err());
+    }
+
+    #[test]
+    fn backup_confirmation_requires_fresh_bound_receipt() {
+        let fixture = TestWorkspace::new();
+        let manifest = fixture.bound_backup_manifest();
+        let receipt_path = manifest.backup_dir.join("external-confirmation.json");
+        let write_receipt = |verified_utc: DateTime<Utc>| {
+            let receipt = serde_json::json!({
+                "format": 1,
+                "deployment_id": manifest.deployment_id.clone(),
+                "target_digest": manifest.target_backup_sha256.clone(),
+                "controller_digest": manifest.controller_backup_sha256.clone(),
+                "offhost_digest": manifest.offhost_backup_sha256.clone(),
+                "verified_utc": verified_utc,
+            });
+            fs::write(
+                &receipt_path,
+                serde_json::to_vec(&receipt).expect("encode backup receipt fixture"),
+            )
+            .expect("write backup receipt fixture");
+            fs::set_permissions(&receipt_path, fs::Permissions::from_mode(0o600))
+                .expect("protect backup receipt fixture");
+        };
+        write_receipt(Utc::now());
+        verify_backup_confirmation(&manifest, false).expect("verify fresh backup receipt");
+        write_receipt(Utc::now() - chrono::Duration::minutes(6));
+
+        assert!(verify_backup_confirmation(&manifest, false).is_err());
     }
 }

--- a/packaging/aur/test-matrix.sh
+++ b/packaging/aur/test-matrix.sh
@@ -156,6 +156,23 @@ fi
 grep -Fq '/usr/bin/lmm-api deploy frontend package-activate --package-version "$1"' \
   "$SHARED/lmm-api-web.install" ||
   die 'future Web release hook does not use the public backend CLI'
+go_release_workflow="$ROOT/.github/workflows/release-go.yml"
+[[ -f $go_release_workflow ]] || die 'Go release workflow is missing'
+# shellcheck disable=SC2016 # Deliberately inspect workflow source literals.
+grep -Fq 'gh release create "$RELEASE_TAG"' "$go_release_workflow" ||
+  die 'Go release workflow does not create a new immutable release'
+grep -Fq 'immutable releases cannot be edited or overwritten' "$go_release_workflow" ||
+  die 'Go release workflow does not fail closed when a release already exists'
+grep -Fq 'already exists and exactly matches the immutable contract' "$go_release_workflow" ||
+  die 'Go release workflow cannot safely resume an exactly matching immutable release'
+grep -Fq '|| return 1' "$go_release_workflow" ||
+  die 'Go release readback checks are not explicit in conditional resume mode'
+if grep -Eq 'gh release (edit|upload)|--clobber' "$go_release_workflow"; then
+  die 'Go release workflow can mutate an existing release'
+fi
+# shellcheck disable=SC2016 # Deliberately inspect the asset digest readback query.
+grep -Fq '.assets[] | select(.name == $name) | .digest' "$go_release_workflow" ||
+  die 'Go release workflow does not read back published asset digests'
 web_release_workflow="$ROOT/.github/workflows/release-web.yml"
 [[ -f $web_release_workflow ]] || die 'web release workflow is missing'
 grep -Fq '  workflow_dispatch:' "$web_release_workflow" ||
@@ -170,6 +187,21 @@ grep -Fq 'cosign sign-blob' "$web_release_workflow" ||
   die 'web release does not sign its immutable artifact'
 grep -Fq 'cosign verify-blob' "$web_release_workflow" ||
   die 'web release does not verify its new signature'
+# shellcheck disable=SC2016 # Deliberately inspect workflow source literals.
+grep -Fq 'gh release create "$RELEASE_TAG"' "$web_release_workflow" ||
+  die 'web release workflow does not create a new immutable release'
+grep -Fq 'immutable releases cannot be edited or overwritten' "$web_release_workflow" ||
+  die 'web release workflow does not fail closed when a release already exists'
+grep -Fq 'already exists and exactly matches the immutable contract' "$web_release_workflow" ||
+  die 'web release workflow cannot safely resume an exactly matching immutable release'
+grep -Fq '|| return 1' "$web_release_workflow" ||
+  die 'web release readback checks are not explicit in conditional resume mode'
+if grep -Eq 'gh release (edit|upload)|--clobber' "$web_release_workflow"; then
+  die 'web release workflow can mutate an existing release'
+fi
+# shellcheck disable=SC2016 # Deliberately inspect the asset digest readback query.
+grep -Fq '.assets[] | select(.name == $name) | .digest' "$web_release_workflow" ||
+  die 'web release workflow does not read back published asset digests'
 
 contains_srcinfo lmm-api-go-git $'\tmakedepends = bun'
 contains_srcinfo lmm-api-go-git $'\tmakedepends = go>=1.25.1'


### PR DESCRIPTION
## Summary

- keep target workspace creation independent from the controller-only 512 MiB state budget
- preserve Go/Rust status parity after terminal staging cleanup while retaining strict mutation checks
- force every staged candidate invocation through a validated one-hop `lmm-api -> lmm-api-go` link
- make Go and Web release publication fail closed instead of editing or clobbering existing releases, then read back exact asset digests
- verify every off-host backup member and reverify target, controller, and archczy copies immediately before confirmation

## Validation so far

- Rust deployment unit tests passed before marker-owned build-cache cleanup
- ShellCheck and workspace lifecycle tests pass
- AUR/release contract matrix passes
- formatting and diff checks pass

Local build caches were cleaned after crossing the controller state budget. Full Go/Rust compilation and integration validation must pass in GitHub Actions before technical reapproval or release.

## Sourcery 总结

通过强制执行经过验证的候选版本、不可变发布以及最终的端到端备份验证，消除部署和发布安全漏洞。

Bug 修复：
- 防止目标工作区创建被仅限控制器的状态预算阻塞。
- 在终端暂存清理后保留部署状态检查，同时严格限制变更路径。
- 确保暂存的生产候选版本只能通过经过验证的单跳 `lmm-api` 到 `lmm-api-go` 入口执行。
- 使 Go 和 Web 发布产物不可变，并验证已发布的元数据、资源和摘要。
- 在确认前立即重新验证目标端、控制器端和异地主机备份副本，包括每个备份成员。

增强功能：
- 围绕发布范围内的 `lmm-api-go` 提供程序统一 Go 探针和操作员证据，并在各部署流程中加强所有权、链接、模式和摘要验证。

测试：
- 增加对工作区预算处理、候选入口安全性、终端工作区检查、备份完整性检查以及不可变发布契约的覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过经过验证的候选执行、不可变发布以及最终的端到端证据验证，消除部署、备份和发布安全方面的漏洞。

Bug 修复：
- 防止仅针对控制器的状态预算检查阻止目标工作区的创建。
- 在保留严格的暂存和变更防护措施的同时，保留对终态部署状态的检查。
- 通过经过验证的单跳 `lmm-api` 到 `lmm-api-go` 入口，执行暂存的生产候选操作。
- 通过在标签已存在时失败，并验证已发布的元数据、资源和摘要，使 Go 和 Web 发布保持不可变。
- 在确认前立即重新验证目标端、控制器端和异地主机备份副本，包括每个备份成员。

增强功能：
- 围绕发布范围内的 `lmm-api-go` 提供方统一 Go 探测和操作员证据，并在各部署流程中加强所有权、链接、模式和摘要验证。

测试：
- 扩展对工作区预算处理、终态工作区检查、候选入口安全性、备份完整性和不可变发布契约的测试覆盖范围。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过经过验证的候选执行、不可变发布以及端到端证据验证，弥补部署、备份和发布安全方面的漏洞。

错误修复：
- 允许创建目标工作区，不再受仅限控制器状态预算的限制。
- 在暂存清理后保留终态部署状态检查，同时继续拒绝不安全的变更路径。
- 所有暂存候选操作均通过经过验证的单跳 lmm-api 到 lmm-api-go 入口进行。
- 通过在标签已存在时失败，并验证已发布的元数据、资产和 SHA-256 摘要，使 Go 和 Web 发布保持不可变。
- 在确认前立即重新验证目标端、控制器端和异地主机备份副本，包括每个备份成员。

增强功能：
- 围绕按发布范围限定的 lmm-api-go 提供程序统一 Go 探针和操作员证据，并在整个部署流程中强制执行所有权、链接、模式和摘要验证。

部署：
- 强化生产部署和备份确认保护措施，以防范被篡改的候选项、不安全的远程路径和过时的备份证据。

测试：
- 扩大对工作区预算处理、终态工作区检查、候选入口验证、备份成员完整性、调度安全性和不可变发布契约的测试覆盖范围。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过经过验证的候选执行、不可变发布以及最终的端到端证据验证，弥补部署、备份和发布安全方面的漏洞。

错误修复：
- 允许创建目标工作区并检查终端状态，而无需应用仅限控制器的状态预算或要求暂存构件。
- 通过经过验证的单跳 `lmm-api` 到 `lmm-api-go` 入口处理暂存的生产候选操作，同时保持严格的所有权、权限和摘要检查。
- 在确认部署前立即重新验证目标端、控制器端和异地主机备份清单及成员摘要。
- 通过拒绝现有标签并验证已发布资源、元数据和摘要的精确匹配，使 Go 和 Web 发布版本不可变。

增强功能：
- 围绕共享的候选提供方和备份证据契约，统一 Go 和 Rust 的部署验证。

部署：
- 加固生产部署、发布版本发布和备份确认，防范被篡改的候选项、不安全路径、过期证据和可变发布版本。

测试：
- 扩展对工作区预算、终端工作区检查、候选入口安全性、备份清单完整性和不可变发布契约的覆盖。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

通过经过验证的候选执行、不可变发布以及最终的端到端证据验证，消除部署、备份和发布流程中的安全漏洞。

错误修复：
- 允许创建目标工作区并检查终端状态，无需应用仅限控制器的状态预算，也无需暂存构件。
- 要求暂存的生产候选版本通过经过验证的单跳 `lmm-api` 到 `lmm-api-go` 入口执行，并确保所有权、权限和摘要匹配。
- 在终端暂存清理后继续执行严格的部署证据检查，并拒绝不安全的候选路径或提供方身份。
- 防止 Go 和 Web 发布工作流编辑或覆盖现有发布版本，强制执行精确的资产契约，并验证已发布的元数据和资产摘要。
- 在确认部署前立即重新验证每个目标、控制器和异地主备份成员，包括所有权、模式、清单、校验和以及最新的证据回执。

增强功能：
- 围绕发布范围内的提供方身份和绑定的三副本备份证据，统一 Go 和 Rust 的部署验证。

部署：
- 加固生产部署、发布版本发布和备份确认流程，防范被篡改的候选版本、不安全的路径、过期证据以及可变发布版本。

测试：
- 扩展对工作区预算处理、终端工作区检查、候选入口安全性、备份清单完整性、确认回执以及不可变发布契约的覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Close deployment, backup, and release safety gaps with validated candidate execution, immutable publication, and final end-to-end evidence verification.

Bug Fixes:
- Allow target workspace creation and terminal status inspection without applying the controller-only state budget or requiring staging artifacts.
- Require staged production candidates to execute through a validated one-hop lmm-api to lmm-api-go entrypoint with matching ownership, permissions, and digests.
- Preserve strict deployment evidence checks after terminal staging cleanup and reject unsafe candidate paths or provider identities.
- Prevent Go and Web release workflows from editing or overwriting existing releases, enforce exact asset contracts, and verify published metadata and asset digests.
- Revalidate every target, controller, and off-host backup member immediately before deployment confirmation, including ownership, modes, inventories, checksums, and fresh evidence receipts.

Enhancements:
- Unify Go and Rust deployment validation around release-scoped provider identity and bound three-copy backup evidence.

Deployment:
- Harden production deployment, release publication, and backup confirmation against tampered candidates, unsafe paths, stale evidence, and mutable releases.

Tests:
- Expand coverage for workspace budget handling, terminal workspace inspection, candidate entrypoint safety, backup inventory integrity, confirmation receipts, and immutable release contracts.

</details>

</details>

</details>

</details>

</details>