### PR TITLE
refactor(web): reuse status-code mapping parser

### DIFF
--- a/apps/web/src/features/channels/lib/status-code-risk-guard.ts
+++ b/apps/web/src/features/channels/lib/status-code-risk-guard.ts
@@ -37,22 +37,28 @@ function parseStatusCodeMappingTarget(rawValue: unknown): number | null {
   return null
 }
 
-export function collectInvalidStatusCodeEntries(
+function parseStatusCodeMapping(
   statusCodeMappingStr: string
-): string[] {
+): [string, unknown][] {
   if (!statusCodeMappingStr?.trim()) return []
 
-  let parsed: Record<string, unknown>
   try {
-    parsed = JSON.parse(statusCodeMappingStr)
+    const parsed: unknown = JSON.parse(statusCodeMappingStr)
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? Object.entries(parsed)
+      : []
   } catch {
     return []
   }
+}
 
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return []
-
+export function collectInvalidStatusCodeEntries(
+  statusCodeMappingStr: string
+): string[] {
   const invalid: string[] = []
-  for (const [rawKey, rawValue] of Object.entries(parsed)) {
+  for (const [rawKey, rawValue] of parseStatusCodeMapping(
+    statusCodeMappingStr
+  )) {
     const fromCode = parseStatusCodeKey(rawKey)
     const toCode = parseStatusCodeMappingTarget(rawValue)
     if (fromCode === null || toCode === null) {
@@ -65,19 +71,8 @@ export function collectInvalidStatusCodeEntries(
 export function collectDisallowedStatusCodeRedirects(
   statusCodeMappingStr: string
 ): string[] {
-  if (!statusCodeMappingStr?.trim()) return []
-
-  let parsed: Record<string, unknown>
-  try {
-    parsed = JSON.parse(statusCodeMappingStr)
-  } catch {
-    return []
-  }
-
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return []
-
   const riskyMappings: string[] = []
-  for (const [rawFrom, rawTo] of Object.entries(parsed)) {
+  for (const [rawFrom, rawTo] of parseStatusCodeMapping(statusCodeMappingStr)) {
     const fromCode = parseStatusCodeKey(rawFrom)
     const toCode = parseStatusCodeMappingTarget(rawTo)
     if (fromCode === null || toCode === null) continue


### PR DESCRIPTION
## Problem

Both status-code risk collectors independently performed the same empty-input, JSON parsing, and object-shape validation. Keeping those paths duplicated makes validation behavior easier to drift.

## Change

Add one private `parseStatusCodeMapping` helper and reuse it from both collectors. Public exports and call sites are unchanged.

## Behavior preservation

Compared before/after outputs for empty and whitespace input, malformed JSON, `null`, arrays, empty objects, invalid keys/targets, self-mappings, and 504/524 risky redirects. Outputs were identical.

## Verification

- `bun run --filter @lmm/web test`: passed, 223 test files
- `bun run --filter @lmm/web typecheck`: passed
- `bun run --filter @lmm/web lint`: passed
- `bun run --filter @lmm/web format:check`: passed
- `bun run --filter @lmm/web build`: passed
- `git diff --check`: passed
- GitHub Actions: 7/8 jobs passed, including the complete web job and all Go/Rust checks. The independent AUR contract job failed because a new upstream Go tag (`go-v0.2.13`) made the existing package pin stale; this change does not touch packaging or release pins.

## Diff and risk

- Additions: 14
- Deletions: 19
- Net: -5 lines

Risk is low: the helper contains the existing parsing and validation steps without changing accepted input shapes or error handling.