### PR TITLE
fix(common): cleanup multipart form temp files after request finishes

### DIFF
--- a/apps/api-go/common/gin.go
+++ b/apps/api-go/common/gin.go
@@ -19,6 +19,7 @@ import (
 
 const KeyRequestBody = "key_request_body"
 const KeyBodyStorage = "key_body_storage"
+const KeyMultipartForms = "key_multipart_forms"
 
 var ErrRequestBodyTooLarge = errors.New("request body too large")
 
@@ -103,6 +104,43 @@ func CleanupBodyStorage(c *gin.Context) {
 		}
 		c.Set(KeyBodyStorage, nil)
 	}
+}
+
+// trackMultipartForm 记录一个已解析的 multipart 表单，以便请求结束时释放它
+// 溢出到磁盘的临时文件。multipart.Reader.ReadForm 会把超过内存上限的分部写入
+// os.CreateTemp，只有 Form.RemoveAll 能删除它们；net/http 仅自动清理
+// Request.MultipartForm，因此没有挂到请求上的表单必须由这里兜底。
+func trackMultipartForm(c *gin.Context, form *multipart.Form) {
+	if c == nil || form == nil {
+		return
+	}
+	tracked, _ := c.Get(KeyMultipartForms)
+	forms, _ := tracked.([]*multipart.Form)
+	c.Set(KeyMultipartForms, append(forms, form))
+}
+
+// CleanupMultipartForms 释放本次请求解析出的所有 multipart 临时文件（应在请求
+// 结束时调用）。Form.RemoveAll 会忽略文件已不存在的情况，因此与调用方自己的
+// RemoveAll 或 net/http 的自动清理重复执行是安全的。
+func CleanupMultipartForms(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	tracked, exists := c.Get(KeyMultipartForms)
+	if !exists || tracked == nil {
+		return
+	}
+	if forms, ok := tracked.([]*multipart.Form); ok {
+		for _, form := range forms {
+			if form == nil {
+				continue
+			}
+			if err := form.RemoveAll(); err != nil {
+				SysLog("failed to remove multipart temporary files: " + err.Error())
+			}
+		}
+	}
+	c.Set(KeyMultipartForms, nil)
 }
 
 func UnmarshalBodyReusable(c *gin.Context, v any) error {
@@ -281,6 +319,9 @@ func ParseMultipartFormReusable(c *gin.Context) (*multipart.Form, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 每次解析都可能新建一批磁盘临时文件；同一请求内允许多次解析，因此逐个登记
+	// 而不是覆盖，确保重复解析产生的副本同样会被释放。
+	trackMultipartForm(c, form)
 
 	// Reset request body
 	if _, seekErr := storage.Seek(0, io.SeekStart); seekErr != nil {

--- a/apps/api-go/common/gin_multipart_cleanup_test.go
+++ b/apps/api-go/common/gin_multipart_cleanup_test.go
@@ -1,0 +1,142 @@
+package common
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LIghtJUNction/api.lmm.best/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMultipartUpload returns a multipart body whose single file part is large
+// enough to force multipart.Reader.ReadForm to spill it to a temporary file.
+func buildMultipartUpload(t *testing.T, fileSize int) (*bytes.Buffer, string) {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "whisper-1"))
+	part, err := writer.CreateFormFile("file", "audio.wav")
+	require.NoError(t, err)
+	_, err = part.Write([]byte(strings.Repeat("a", fileSize)))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return &body, writer.FormDataContentType()
+}
+
+// countTempSpillFiles counts the multipart spill files Go creates in dir.
+func countTempSpillFiles(t *testing.T, dir string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "multipart-*"))
+	require.NoError(t, err)
+	return len(matches)
+}
+
+// newMultipartTestContext wires a gin context over a multipart upload with the
+// multipart memory limit lowered so the file part is guaranteed to spill.
+func newMultipartTestContext(t *testing.T, fileSize int) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	previousLimit := constant.MaxFileDownloadMB
+	constant.MaxFileDownloadMB = 0 // multipartMemoryLimit falls back to 32 MiB
+	t.Cleanup(func() { constant.MaxFileDownloadMB = previousLimit })
+
+	body, contentType := buildMultipartUpload(t, fileSize)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/audio/transcriptions", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	// Release the replayable body storage the same way BodyStorageCleanup does,
+	// so the spill directory has no open handles left when the test tears down.
+	t.Cleanup(func() { CleanupBodyStorage(c) })
+	return c
+}
+
+// TestParseMultipartFormReusableReleasesSpilledTempFiles locks in the fix for
+// the disk-exhaustion leak: a parsed form that is never attached to
+// Request.MultipartForm is still released when the request ends, because
+// net/http only auto-removes the form it owns.
+func TestParseMultipartFormReusableReleasesSpilledTempFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir) // honoured by os.TempDir on unix
+	t.Setenv("TMP", tempDir)    // honoured by os.TempDir on windows
+	t.Setenv("TEMP", tempDir)
+	require.Equal(t, tempDir, os.TempDir(), "the test must control the spill directory")
+
+	// 1 MiB over the 32 MiB fallback memory limit guarantees a disk spill.
+	c := newMultipartTestContext(t, (32<<20)+(1<<20))
+
+	form, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NotNil(t, form)
+	require.Len(t, form.File["file"], 1)
+	require.Equal(t, 1, countTempSpillFiles(t, tempDir), "the oversized part must spill to disk")
+
+	// The vulnerable code path never assigns the form to the request, so the
+	// standard library cleanup in (*response).finishRequest cannot see it.
+	require.Nil(t, c.Request.MultipartForm)
+
+	CleanupMultipartForms(c)
+	assert.Equal(t, 0, countTempSpillFiles(t, tempDir), "request teardown must remove multipart spill files")
+}
+
+// TestParseMultipartFormReusableReleasesEveryParsePass covers the audio relay
+// shape, where one request parses the same body more than once and each pass
+// creates an independent spill file.
+func TestParseMultipartFormReusableReleasesEveryParsePass(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	t.Setenv("TMP", tempDir)
+	t.Setenv("TEMP", tempDir)
+	require.Equal(t, tempDir, os.TempDir(), "the test must control the spill directory")
+
+	c := newMultipartTestContext(t, (32<<20)+(1<<20))
+
+	first, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	second, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, 2, countTempSpillFiles(t, tempDir), "each parse pass spills its own copy")
+
+	CleanupMultipartForms(c)
+	assert.Equal(t, 0, countTempSpillFiles(t, tempDir), "no spill file may survive the request")
+}
+
+// TestCleanupMultipartFormsIsIdempotent guards the call sites that already run
+// their own RemoveAll, or that attach the form so net/http removes it too.
+func TestCleanupMultipartFormsIsIdempotent(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	t.Setenv("TMP", tempDir)
+	t.Setenv("TEMP", tempDir)
+	require.Equal(t, tempDir, os.TempDir(), "the test must control the spill directory")
+
+	c := newMultipartTestContext(t, (32<<20)+(1<<20))
+
+	form, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NoError(t, form.RemoveAll(), "a caller may release the form itself")
+
+	CleanupMultipartForms(c)
+	CleanupMultipartForms(c)
+	assert.Equal(t, 0, countTempSpillFiles(t, tempDir))
+}
+
+// TestCleanupMultipartFormsWithoutParsedForm keeps the middleware cheap and
+// safe on the majority of requests, which never parse a multipart body.
+func TestCleanupMultipartFormsWithoutParsedForm(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{}`))
+
+	assert.NotPanics(t, func() { CleanupMultipartForms(c) })
+	assert.NotPanics(t, func() { CleanupMultipartForms(nil) })
+}

--- a/apps/api-go/middleware/body_cleanup.go
+++ b/apps/api-go/middleware/body_cleanup.go
@@ -16,6 +16,9 @@ func BodyStorageCleanup() gin.HandlerFunc {
 		// 请求结束后清理存储
 		common.CleanupBodyStorage(c)
 
+		// 清理 multipart 解析溢出到磁盘的临时文件
+		common.CleanupMultipartForms(c)
+
 		// 清理文件缓存（URL 下载的文件等）
 		service.CleanupFileSources(c)
 	}


### PR DESCRIPTION
# LMM API Pull Request

> LMM Forge 的 Go 服务保留上游兼容层。请说明本次变更对悬赏协作、交付跟踪或兼容行为的影响，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

大文件上传触发 multipart 落盘后，可复用解析得到的表单未交给标准库管理，临时文件会随请求积累。本 PR 登记每轮解析结果，在请求结束时统一释放，保留上传接口、重复解析和重试行为。

**完整代码修正版：#212。** 已保留原作者提交，并完成 panic 清理修复、磁盘请求体流式解析、失败路径回归和分配基准。#212 位于本仓库分支，可直接审查代码及运行 CI。本 PR 保持打开、保留原提交；无需手动拼装此前补丁。

按维护者重开要求，使用现有 exempt 标签豁免自动启发式筛选；代码 CI 与待修意见保留。修正版由 Codex 协助实现并复验。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: 针对本仓库 #205 修复；未移植上游提交，未核实上游当前状态。

## 关联 Issue / Related issue

Closes #205

同题 PR #206、#208 均已关闭且未合并。本次继续维护 #207。

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

Go 1.25.1 / Linux，以下命令均在 apps/api-go 执行：

```text
command: GOMAXPROCS=2 go test -p 2 ./common ./middleware -count=1
result: 原提交 bdf21ded PASS（common 1.410s / middleware 0.085s）。
```

新增生命周期测试在原实现中 return、abort 通过，panic 失败：两份 multipart 文件残留且 BodyStorage 未关闭；修复后全部通过。原有测试通过不代表 panic 路径已修复。

完整修正版 #212 的 5 个相关包测试、go vet、gofmt、git diff --check 已通过；16 MiB 请求的每次总分配减少约 79.8%。完整命令、对照结果与未执行的全仓库检查均列于 #212。

## 截图或日志 / Screenshots or logs

无界面、协议或配置变化。回归结果见上；[原关闭日志](https://github.com/LIghtJUNction/api.lmm.best/actions/runs/34040493361/job/101506237153) 记录启发式筛选失败，模板检查实际跳过。

## 提交检查 / Checklist

- [ ] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

首项因存在同题 PR 保留未勾选，查重结果已披露。无需迁移或更新配置、多语言文案。
