### PR TITLE
fix(go): clean multipart files on panic and stream stored uploads

### DIFF
--- a/apps/api-go/common/gin.go
+++ b/apps/api-go/common/gin.go
@@ -19,6 +19,7 @@ import (
 
 const KeyRequestBody = "key_request_body"
 const KeyBodyStorage = "key_body_storage"
+const KeyMultipartForms = "key_multipart_forms"
 
 var ErrRequestBodyTooLarge = errors.New("request body too large")
 
@@ -103,6 +104,43 @@ func CleanupBodyStorage(c *gin.Context) {
 		}
 		c.Set(KeyBodyStorage, nil)
 	}
+}
+
+// trackMultipartForm 记录一个已解析的 multipart 表单，以便请求结束时释放它
+// 溢出到磁盘的临时文件。multipart.Reader.ReadForm 会把超过内存上限的分部写入
+// os.CreateTemp，只有 Form.RemoveAll 能删除它们；net/http 仅自动清理
+// Request.MultipartForm，因此没有挂到请求上的表单必须由这里兜底。
+func trackMultipartForm(c *gin.Context, form *multipart.Form) {
+	if c == nil || form == nil {
+		return
+	}
+	tracked, _ := c.Get(KeyMultipartForms)
+	forms, _ := tracked.([]*multipart.Form)
+	c.Set(KeyMultipartForms, append(forms, form))
+}
+
+// CleanupMultipartForms 释放本次请求解析出的所有 multipart 临时文件（应在请求
+// 结束时调用）。Form.RemoveAll 会忽略文件已不存在的情况，因此与调用方自己的
+// RemoveAll 或 net/http 的自动清理重复执行是安全的。
+func CleanupMultipartForms(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	tracked, exists := c.Get(KeyMultipartForms)
+	if !exists || tracked == nil {
+		return
+	}
+	if forms, ok := tracked.([]*multipart.Form); ok {
+		for _, form := range forms {
+			if form == nil {
+				continue
+			}
+			if err := form.RemoveAll(); err != nil {
+				SysLog("failed to remove multipart temporary files: " + err.Error())
+			}
+		}
+	}
+	c.Set(KeyMultipartForms, nil)
 }
 
 func UnmarshalBodyReusable(c *gin.Context, v any) error {
@@ -281,6 +319,9 @@ func ParseMultipartFormReusable(c *gin.Context) (*multipart.Form, error) {
 	if err != nil {
 		return nil, err
 	}
+	// 每次解析都可能新建一批磁盘临时文件；同一请求内允许多次解析，因此逐个登记
+	// 而不是覆盖，确保重复解析产生的副本同样会被释放。
+	trackMultipartForm(c, form)
 
 	// Reset request body
 	if _, seekErr := storage.Seek(0, io.SeekStart); seekErr != nil {

--- a/apps/api-go/common/gin_multipart_cleanup_test.go
+++ b/apps/api-go/common/gin_multipart_cleanup_test.go
@@ -1,0 +1,142 @@
+package common
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/LIghtJUNction/api.lmm.best/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildMultipartUpload returns a multipart body whose single file part is large
+// enough to force multipart.Reader.ReadForm to spill it to a temporary file.
+func buildMultipartUpload(t *testing.T, fileSize int) (*bytes.Buffer, string) {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", "whisper-1"))
+	part, err := writer.CreateFormFile("file", "audio.wav")
+	require.NoError(t, err)
+	_, err = part.Write([]byte(strings.Repeat("a", fileSize)))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+	return &body, writer.FormDataContentType()
+}
+
+// countTempSpillFiles counts the multipart spill files Go creates in dir.
+func countTempSpillFiles(t *testing.T, dir string) int {
+	t.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "multipart-*"))
+	require.NoError(t, err)
+	return len(matches)
+}
+
+// newMultipartTestContext wires a gin context over a multipart upload with the
+// multipart memory limit lowered so the file part is guaranteed to spill.
+func newMultipartTestContext(t *testing.T, fileSize int) *gin.Context {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	previousLimit := constant.MaxFileDownloadMB
+	constant.MaxFileDownloadMB = 0 // multipartMemoryLimit falls back to 32 MiB
+	t.Cleanup(func() { constant.MaxFileDownloadMB = previousLimit })
+
+	body, contentType := buildMultipartUpload(t, fileSize)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/audio/transcriptions", body)
+	c.Request.Header.Set("Content-Type", contentType)
+	// Release the replayable body storage the same way BodyStorageCleanup does,
+	// so the spill directory has no open handles left when the test tears down.
+	t.Cleanup(func() { CleanupBodyStorage(c) })
+	return c
+}
+
+// TestParseMultipartFormReusableReleasesSpilledTempFiles locks in the fix for
+// the disk-exhaustion leak: a parsed form that is never attached to
+// Request.MultipartForm is still released when the request ends, because
+// net/http only auto-removes the form it owns.
+func TestParseMultipartFormReusableReleasesSpilledTempFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir) // honoured by os.TempDir on unix
+	t.Setenv("TMP", tempDir)    // honoured by os.TempDir on windows
+	t.Setenv("TEMP", tempDir)
+	require.Equal(t, tempDir, os.TempDir(), "the test must control the spill directory")
+
+	// 1 MiB over the 32 MiB fallback memory limit guarantees a disk spill.
+	c := newMultipartTestContext(t, (32<<20)+(1<<20))
+
+	form, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NotNil(t, form)
+	require.Len(t, form.File["file"], 1)
+	require.Equal(t, 1, countTempSpillFiles(t, tempDir), "the oversized part must spill to disk")
+
+	// The vulnerable code path never assigns the form to the request, so the
+	// standard library cleanup in (*response).finishRequest cannot see it.
+	require.Nil(t, c.Request.MultipartForm)
+
+	CleanupMultipartForms(c)
+	assert.Equal(t, 0, countTempSpillFiles(t, tempDir), "request teardown must remove multipart spill files")
+}
+
+// TestParseMultipartFormReusableReleasesEveryParsePass covers the audio relay
+// shape, where one request parses the same body more than once and each pass
+// creates an independent spill file.
+func TestParseMultipartFormReusableReleasesEveryParsePass(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	t.Setenv("TMP", tempDir)
+	t.Setenv("TEMP", tempDir)
+	require.Equal(t, tempDir, os.TempDir(), "the test must control the spill directory")
+
+	c := newMultipartTestContext(t, (32<<20)+(1<<20))
+
+	first, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	second, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, 2, countTempSpillFiles(t, tempDir), "each parse pass spills its own copy")
+
+	CleanupMultipartForms(c)
+	assert.Equal(t, 0, countTempSpillFiles(t, tempDir), "no spill file may survive the request")
+}
+
+// TestCleanupMultipartFormsIsIdempotent guards the call sites that already run
+// their own RemoveAll, or that attach the form so net/http removes it too.
+func TestCleanupMultipartFormsIsIdempotent(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	t.Setenv("TMP", tempDir)
+	t.Setenv("TEMP", tempDir)
+	require.Equal(t, tempDir, os.TempDir(), "the test must control the spill directory")
+
+	c := newMultipartTestContext(t, (32<<20)+(1<<20))
+
+	form, err := ParseMultipartFormReusable(c)
+	require.NoError(t, err)
+	require.NoError(t, form.RemoveAll(), "a caller may release the form itself")
+
+	CleanupMultipartForms(c)
+	CleanupMultipartForms(c)
+	assert.Equal(t, 0, countTempSpillFiles(t, tempDir))
+}
+
+// TestCleanupMultipartFormsWithoutParsedForm keeps the middleware cheap and
+// safe on the majority of requests, which never parse a multipart body.
+func TestCleanupMultipartFormsWithoutParsedForm(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{}`))
+
+	assert.NotPanics(t, func() { CleanupMultipartForms(c) })
+	assert.NotPanics(t, func() { CleanupMultipartForms(nil) })
+}

--- a/apps/api-go/middleware/body_cleanup.go
+++ b/apps/api-go/middleware/body_cleanup.go
@@ -16,6 +16,9 @@ func BodyStorageCleanup() gin.HandlerFunc {
 		// 请求结束后清理存储
 		common.CleanupBodyStorage(c)
 
+		// 清理 multipart 解析溢出到磁盘的临时文件
+		common.CleanupMultipartForms(c)
+
 		// 清理文件缓存（URL 下载的文件等）
 		service.CleanupFileSources(c)
 	}


### PR DESCRIPTION
# LMM API Pull Request

> LMM Forge 的 Go 服务保留上游兼容层。请说明本次变更对悬赏协作、交付跟踪或兼容行为的影响，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

接续 #207 的 multipart 临时文件修复，完成代码审查后的修改。原作者 wawavd13 的提交 bdf21ded 保留在分支历史中。本 PR 基于 main 628f027f 验证，仅改变清理和解析实现，上传接口与重复读取行为保持兼容。

- 每轮解析都登记表单，在请求结束时释放全部落盘文件。
- 使用 defer 清理请求体、multipart 和文件缓存，保持原顺序，并覆盖下游 panic。
- 直接读取 BodyStorage，消除磁盘请求体再次完整载入内存的副本。
- 补齐正常返回、Abort、panic、最终 Seek 失败、重复清理及重新解析回归；测试样本由 33 MiB 减至 2 MiB，并保留可复现基准。

当前连接器无法写入 #207 的源 fork，因此按维护者要求在本仓库分支交付完整修正版。代码与验证由 Codex 协助完成。

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: 本仓库 #205、#207；未移植上游提交，未核实上游当前状态。

## 关联 Issue / Related issue

Closes #205

接续 #207；#206、#208 为已关闭的同题实现。#207 保持打开，并关联本修正版，避免要求贡献者手动拼装补丁。

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [x] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

Go 1.25.1 / Linux，在 apps/api-go 执行：

```text
command: GOMAXPROCS=2 go test -p 2 ./common ./middleware ./relay/helper ./relay/channel/openai ./relay/channel/task/sora -count=1
result: 5 个包全部 PASS。

command: GOMAXPROCS=2 go vet -p 2 ./common ./middleware ./relay/helper ./relay/channel/openai ./relay/channel/task/sora
result: PASS。

command: GOMAXPROCS=2 go test -p 2 ./common -run '^$' -bench '^BenchmarkParseMultipartFormReusableDisk$' -benchtime=10x -count=1 -benchmem
result: 16 MiB 磁盘请求、1 MiB multipart 上限；每次总分配由 21,021,778 B 降至 4,239,608 B，减少约 79.8%。
```

原实现的 panic 回归失败，修复后通过。将登记移到 Seek 后或删掉登记清空操作，新增测试分别失败。基准比较相同测试的完整物化与流式实现，结果表示总分配量，不代表峰值内存。

gofmt、git diff --check 通过。未运行全仓库 just format/lint/test/build/check：本次限于 Go 解析与清理，其他语言、部署和全仓库验证交由 CI。

## 截图或日志 / Screenshots or logs

无界面、响应格式或配置变化。测试与可复现基准见上。

## 提交检查 / Checklist

- [ ] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

首项因接续现有 PR 保留未勾选，原因已披露。无需迁移或新增配置文案。
