### PR TITLE
fix: recover reviewed payment and translation PRs after false closures

### DIFF
--- a/apps/api-go/controller/payment_webhook_availability.go
+++ b/apps/api-go/controller/payment_webhook_availability.go
@@ -39,7 +39,14 @@ func isStripeWebhookConfigured() bool {
 }
 
 func isStripeWebhookEnabled() bool {
-	return isStripeTopUpEnabled()
+	// Wallet and subscription checkouts share one Stripe webhook. Subscription
+	// plans carry their own Price ID, so requiring the global wallet product
+	// rejects paid subscription fulfillments on subscription-only deploys.
+	// Keep the endpoint available whenever signed webhook credentials exist,
+	// matching Waffo Pancake: pending orders must still complete after the
+	// wallet product is absent or rotated.
+	return isStripeWebhookConfigured() &&
+		(isStripeTopUpEnabled() || isStripeSubscriptionPaymentEnabled())
 }
 
 func isCreemTopUpEnabled() bool {
@@ -67,7 +74,11 @@ func isCreemWebhookConfigured() bool {
 }
 
 func isCreemWebhookEnabled() bool {
-	return isCreemTopUpEnabled() && isCreemWebhookConfigured()
+	// Creem subscription products live on each plan. The global wallet
+	// catalog must not gate signed webhooks, or subscription-only sites
+	// charge users and never grant access.
+	return isCreemWebhookConfigured() &&
+		(isCreemTopUpEnabled() || isCreemSubscriptionPaymentEnabled())
 }
 
 func isWaffoTopUpEnabled() bool {

--- a/apps/api-go/controller/payment_webhook_availability_test.go
+++ b/apps/api-go/controller/payment_webhook_availability_test.go
@@ -54,8 +54,31 @@ func TestStripeWebhookEnabledRequiresTopUpAndWebhookConfig(t *testing.T) {
 	setting.StripeWebhookSecret = "whsec_test"
 	require.True(t, isStripeWebhookEnabled())
 
+	// Subscription-only sites leave the wallet price empty on purpose.
 	setting.StripePriceId = ""
+	require.True(t, isStripeWebhookEnabled())
+
+	setting.StripeApiSecret = ""
 	require.False(t, isStripeWebhookEnabled())
+}
+
+func TestStripeWebhookEnabledForSubscriptionOnlyCredentials(t *testing.T) {
+	confirmPaymentComplianceForTest(t)
+	originalAPISecret := setting.StripeApiSecret
+	originalWebhookSecret := setting.StripeWebhookSecret
+	originalPriceID := setting.StripePriceId
+	t.Cleanup(func() {
+		setting.StripeApiSecret = originalAPISecret
+		setting.StripeWebhookSecret = originalWebhookSecret
+		setting.StripePriceId = originalPriceID
+	})
+
+	setting.StripeApiSecret = "sk_test_subscription" // gitleaks:allow
+	setting.StripeWebhookSecret = "whsec_subscription"
+	setting.StripePriceId = ""
+	require.True(t, isStripeSubscriptionPaymentEnabled())
+	require.False(t, isStripeTopUpEnabled())
+	require.True(t, isStripeWebhookEnabled())
 }
 
 func TestCreemWebhookEnabledRequiresTopUpAndWebhookConfig(t *testing.T) {
@@ -77,8 +100,31 @@ func TestCreemWebhookEnabledRequiresTopUpAndWebhookConfig(t *testing.T) {
 	setting.CreemWebhookSecret = "creem_secret"
 	require.True(t, isCreemWebhookEnabled())
 
+	// Subscription-only sites do not populate the wallet product catalog.
 	setting.CreemProducts = "[]"
+	require.True(t, isCreemWebhookEnabled())
+
+	setting.CreemApiKey = ""
 	require.False(t, isCreemWebhookEnabled())
+}
+
+func TestCreemWebhookEnabledForSubscriptionOnlyCredentials(t *testing.T) {
+	confirmPaymentComplianceForTest(t)
+	originalAPIKey := setting.CreemApiKey
+	originalProducts := setting.CreemProducts
+	originalWebhookSecret := setting.CreemWebhookSecret
+	t.Cleanup(func() {
+		setting.CreemApiKey = originalAPIKey
+		setting.CreemProducts = originalProducts
+		setting.CreemWebhookSecret = originalWebhookSecret
+	})
+
+	setting.CreemApiKey = "creem_api_key"
+	setting.CreemWebhookSecret = "creem_secret"
+	setting.CreemProducts = "[]"
+	require.True(t, isCreemSubscriptionPaymentEnabled())
+	require.False(t, isCreemTopUpEnabled())
+	require.True(t, isCreemWebhookEnabled())
 }
 
 func TestWaffoWebhookEnabledRequiresTopUpAndWebhookConfig(t *testing.T) {

--- a/apps/api-go/controller/topup.go
+++ b/apps/api-go/controller/topup.go
@@ -1342,8 +1342,8 @@ func validateEpayCallback(topUp *model.TopUp, verifyInfo *epay.VerifyRes) (bool,
 	if topUp.PaymentMethod != verifyInfo.Type {
 		return false, fmt.Errorf("payment method mismatch")
 	}
-	if topUp.ExpectedAmountMicros <= 0 || topUp.CreditedQuota <= 0 || !strings.EqualFold(strings.TrimSpace(topUp.SettlementCurrency), "CNY") {
-		return false, fmt.Errorf("Epay order has no immutable CNY settlement snapshot")
+	if !model.EpayHasImmutableSettlementSnapshot(topUp) {
+		return false, fmt.Errorf("Epay order has no immutable settlement snapshot")
 	}
 	callbackMoneyMicros, err := monetaryStringToMicros(verifyInfo.Money)
 	if err != nil || callbackMoneyMicros <= 0 {

--- a/apps/api-go/controller/topup_channel_pricing_test.go
+++ b/apps/api-go/controller/topup_channel_pricing_test.go
@@ -425,3 +425,35 @@ func TestValidateEpayCallbackRejectsSignedTypeOrMoneyMismatchAndIsIdempotent(t *
 	require.NoError(t, err)
 	require.False(t, shouldCredit)
 }
+
+func TestValidateEpayCallbackAcceptsNonCNYImmutableSnapshot(t *testing.T) {
+	pending := &model.TopUp{
+		PaymentMethod:        "epay",
+		PaymentProvider:      model.PaymentProviderEpay,
+		Money:                5,
+		ExpectedAmountMicros: 5_000_000,
+		CreditedQuota:        2 * int64(common.QuotaPerUnit),
+		SettlementCurrency:   "LDC",
+		Status:               common.TopUpStatusPending,
+	}
+
+	shouldCredit, err := validateEpayCallback(pending, &epay.VerifyRes{Type: "epay", Money: "5.00"})
+	require.NoError(t, err)
+	require.True(t, shouldCredit)
+
+	usd := *pending
+	usd.SettlementCurrency = "USD"
+	usd.ExpectedAmountMicros = 10_000_000
+	usd.Money = 10
+	shouldCredit, err = validateEpayCallback(&usd, &epay.VerifyRes{Type: "epay", Money: "10.00"})
+	require.NoError(t, err)
+	require.True(t, shouldCredit)
+
+	legacy := *pending
+	legacy.ExpectedAmountMicros = 0
+	legacy.CreditedQuota = 0
+	legacy.SettlementCurrency = ""
+	shouldCredit, err = validateEpayCallback(&legacy, &epay.VerifyRes{Type: "epay", Money: "5.00"})
+	require.Error(t, err)
+	require.False(t, shouldCredit)
+}

--- a/apps/api-go/controller/topup_stripe_test.go
+++ b/apps/api-go/controller/topup_stripe_test.go
@@ -76,6 +76,63 @@ func TestStripeWebhookRetriesWhenLocalSettlementCannotPersist(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, response.Code)
 }
 
+func TestStripeWebhookAcceptsSubscriptionOnlyCredentials(t *testing.T) {
+	setupTokenControllerTestDB(t)
+	confirmPaymentComplianceForTest(t)
+
+	originalAPISecret := setting.StripeApiSecret
+	originalWebhookSecret := setting.StripeWebhookSecret
+	originalPriceID := setting.StripePriceId
+	t.Cleanup(func() {
+		setting.StripeApiSecret = originalAPISecret
+		setting.StripeWebhookSecret = originalWebhookSecret
+		setting.StripePriceId = originalPriceID
+	})
+	setting.StripeApiSecret = "sk_test_subscription_only" // gitleaks:allow
+	setting.StripeWebhookSecret = "whsec_subscription_only"
+	setting.StripePriceId = ""
+
+	payload := []byte(`{
+		"id":"evt_subscription_only",
+		"object":"event",
+		"type":"checkout.session.completed",
+		"data":{"object":{
+			"id":"cs_subscription_only",
+			"object":"checkout.session",
+			"client_reference_id":"missing-local-order",
+			"status":"complete",
+			"payment_status":"paid",
+			"amount_total":"100",
+			"amount_subtotal":"100",
+			"currency":"usd"
+		}}
+	}`)
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload:   payload,
+		Secret:    setting.StripeWebhookSecret,
+		Timestamp: time.Now(),
+	})
+
+	disabled := httptest.NewRecorder()
+	disabledCtx, _ := gin.CreateTestContext(disabled)
+	disabledCtx.Request = httptest.NewRequest(http.MethodPost, "/api/stripe/webhook", http.NoBody)
+	disabledCtx.Request.Body = io.NopCloser(bytes.NewReader(payload))
+	setting.StripeWebhookSecret = ""
+	StripeWebhook(disabledCtx)
+	require.Equal(t, http.StatusForbidden, disabled.Code)
+
+	setting.StripeWebhookSecret = "whsec_subscription_only"
+	accepted := httptest.NewRecorder()
+	acceptedCtx, _ := gin.CreateTestContext(accepted)
+	acceptedRequest := httptest.NewRequest(http.MethodPost, "/api/stripe/webhook", http.NoBody)
+	acceptedRequest.Body = io.NopCloser(bytes.NewReader(payload))
+	acceptedRequest.Header.Set("Stripe-Signature", signed.Header)
+	acceptedCtx.Request = acceptedRequest
+	StripeWebhook(acceptedCtx)
+	require.NotEqual(t, http.StatusForbidden, accepted.Code)
+	require.Equal(t, http.StatusInternalServerError, accepted.Code)
+}
+
 func TestStripeWebhookRetriesOnlyPersistableFailures(t *testing.T) {
 	require.True(t, stripeWebhookRetryable(errors.New("database unavailable")))
 	for _, err := range []error{

--- a/apps/api-go/controller/topup_waffo_pancake.go
+++ b/apps/api-go/controller/topup_waffo_pancake.go
@@ -1159,28 +1159,22 @@ func validateWaffoPancakeSubscriptionRefundEvent(event *service.WaffoPancakeWebh
 	actualProduct, productMetadataPresent := event.Data.OrderMetadata[service.WaffoPancakeOrderMetadataProductID]
 	actualPlan, planMetadataPresent := event.Data.OrderMetadata[service.WaffoPancakeOrderMetadataPlanID]
 	metadataPresent := productMetadataPresent || planMetadataPresent
+	// Checkout snapshots are authoritative. The live store/product/currency on
+	// the plan can change after purchase (CNY list price vs USD Pancake
+	// settlement, product recreation, store rotation) and must not strand a
+	// signed refund against a still-active entitlement.
+	expectedStore := strings.TrimSpace(order.ProviderStoreId)
+	if expectedStore == "" {
+		expectedStore = strings.TrimSpace(setting.WaffoPancakeStoreID)
+	}
 	// Older refund payloads (and orders created before checkout metadata was
 	// introduced) do not carry StoreID or OrderMetadata. Keep those payloads
 	// processable, but never ignore a contradictory value when the provider
 	// does send one. New payloads with either binding field are validated below.
-	if expectedStore := strings.TrimSpace(setting.WaffoPancakeStoreID); expectedStore != "" &&
-		(actualStore != "" || metadataPresent) && actualStore != expectedStore {
-		return fmt.Errorf("subscription refund store mismatch: expected=%q actual=%q", expectedStore, strings.TrimSpace(event.StoreID))
+	if expectedStore != "" && (actualStore != "" || metadataPresent) && actualStore != expectedStore {
+		return fmt.Errorf("subscription refund store mismatch: expected=%q actual=%q", expectedStore, actualStore)
 	}
-	plan, err := model.GetSubscriptionPlanById(order.PlanId)
-	if err != nil || plan == nil {
-		if metadataPresent && err != nil {
-			return fmt.Errorf("subscription refund plan could not be loaded: %w", err)
-		}
-		if metadataPresent {
-			return fmt.Errorf("subscription refund plan could not be loaded")
-		}
-		// The plan may have been removed after a legacy order was settled. The
-		// trade number and (when supplied) buyer identity were already bound by
-		// ResolveWaffoPancakeRefundSubscriptionTradeNo, so retain compatibility.
-		return nil
-	}
-	expectedCurrency := strings.ToUpper(strings.TrimSpace(plan.Currency))
+	expectedCurrency := strings.ToUpper(strings.TrimSpace(order.SettlementCurrency))
 	if expectedCurrency == "" {
 		expectedCurrency = "USD"
 	}
@@ -1194,7 +1188,17 @@ func validateWaffoPancakeSubscriptionRefundEvent(event *service.WaffoPancakeWebh
 	if actualCurrency == "" {
 		return fmt.Errorf("subscription refund currency mismatch: expected=%q actual=%q", expectedCurrency, actualCurrency)
 	}
-	expectedProduct := strings.TrimSpace(plan.WaffoPancakeProductId)
+	expectedProduct := strings.TrimSpace(order.ProviderProductId)
+	if expectedProduct == "" {
+		plan, err := model.GetSubscriptionPlanById(order.PlanId)
+		if err != nil || plan == nil {
+			if err != nil {
+				return fmt.Errorf("subscription refund plan could not be loaded: %w", err)
+			}
+			return fmt.Errorf("subscription refund plan could not be loaded")
+		}
+		expectedProduct = strings.TrimSpace(plan.WaffoPancakeProductId)
+	}
 	if expectedProduct == "" {
 		return fmt.Errorf("subscription refund product is not configured")
 	}
@@ -1203,7 +1207,7 @@ func validateWaffoPancakeSubscriptionRefundEvent(event *service.WaffoPancakeWebh
 		return fmt.Errorf("subscription refund product metadata mismatch: expected=%q actual=%q", expectedProduct, actualProduct)
 	}
 	actualPlan = strings.TrimSpace(actualPlan)
-	if expectedPlan := strconv.Itoa(plan.Id); !planMetadataPresent || actualPlan != expectedPlan {
+	if expectedPlan := strconv.Itoa(order.PlanId); !planMetadataPresent || actualPlan != expectedPlan {
 		return fmt.Errorf("subscription refund plan metadata mismatch: expected=%q actual=%q", expectedPlan, actualPlan)
 	}
 	return nil

--- a/apps/api-go/controller/topup_waffo_pancake_refund_test.go
+++ b/apps/api-go/controller/topup_waffo_pancake_refund_test.go
@@ -183,6 +183,74 @@ func TestHandleWaffoPancakeSubscriptionRefundIsLedgerIdempotent(t *testing.T) {
 	require.Len(t, logs, 1)
 }
 
+func TestHandleWaffoPancakeSubscriptionRefundUsesCheckoutSnapshotNotLivePlan(t *testing.T) {
+	originalStoreID := setting.WaffoPancakeStoreID
+	setting.WaffoPancakeStoreID = "store-rotated"
+	t.Cleanup(func() { setting.WaffoPancakeStoreID = originalStoreID })
+
+	db := setupTokenControllerTestDB(t)
+	require.NoError(t, db.AutoMigrate(&model.User{}, &model.SubscriptionPlan{}, &model.SubscriptionOrder{}, &model.Log{}, &model.FinanceLedgerEntry{}))
+	user := model.User{
+		Username: "pancake-subscription-refund-snapshot",
+		Password: "password",
+		Status:   common.UserStatusEnabled,
+	}
+	require.NoError(t, db.Create(&user).Error)
+	plan := model.SubscriptionPlan{
+		Id:                    987656,
+		Title:                 "CNY list price plan",
+		PriceAmount:           6.8,
+		Currency:              "CNY",
+		WaffoPancakeProductId: "product-rotated",
+		Enabled:               true,
+	}
+	require.NoError(t, db.Create(&plan).Error)
+	tradeNo := "WAFFO_PANCAKE_SUB-refund-snapshot"
+	require.NoError(t, db.Create(&model.SubscriptionOrder{
+		UserId:               user.Id,
+		PlanId:               plan.Id,
+		TradeNo:              tradeNo,
+		PaymentMethod:        model.PaymentMethodWaffoPancake,
+		PaymentProvider:      model.PaymentProviderWaffoPancake,
+		Status:               common.TopUpStatusSuccess,
+		Money:                plan.PriceAmount,
+		ExpectedAmountMicros: 1_000_000,
+		SettlementCurrency:   "USD",
+		ProviderProductId:    "product-checkout",
+		ProviderStoreId:      "store-checkout",
+	}).Error)
+
+	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+	event := &service.WaffoPancakeWebhookEvent{
+		ID:        "evt-subscription-refund-snapshot",
+		EventType: "refund.succeeded",
+		StoreID:   "store-checkout",
+		Data: service.WaffoPancakeWebhookData{
+			OrderMerchantExternalID:        tradeNo,
+			RefundTicketMerchantExternalID: "refund-subscription-snapshot",
+			Amount:                         "1.00",
+			Currency:                       "USD",
+			OrderMetadata: map[string]string{
+				service.WaffoPancakeOrderMetadataProductID: "product-checkout",
+				service.WaffoPancakeOrderMetadataPlanID:    strconv.Itoa(plan.Id),
+			},
+		},
+	}
+
+	require.NoError(t, handleWaffoPancakeRefundEvent(ctx, event))
+
+	var entries []model.FinanceLedgerEntry
+	require.NoError(t, db.Where("source_type = ? AND source_id = ?", model.FinanceSourceRefund, event.ID).Find(&entries).Error)
+	require.Len(t, entries, 1)
+	require.Equal(t, int64(1_000_000), entries[0].AmountMicros)
+	require.Equal(t, "USD", entries[0].Currency)
+
+	var stored model.SubscriptionOrder
+	require.NoError(t, db.Where("trade_no = ?", tradeNo).First(&stored).Error)
+	require.Equal(t, int64(1_000_000), stored.RefundedAmountMicros)
+}
+
 func TestHandleWaffoPancakeSubscriptionRefundRejectsMismatchedMetadata(t *testing.T) {
 	originalStoreID := setting.WaffoPancakeStoreID
 	setting.WaffoPancakeStoreID = "store-subscription-refund"

--- a/apps/api-go/model/payment_method_guard_test.go
+++ b/apps/api-go/model/payment_method_guard_test.go
@@ -266,6 +266,40 @@ func TestRechargeEpayRejectsLegacyOrderWithoutImmutableCNYSnapshot(t *testing.T)
 	assert.Equal(t, 0, getUserQuotaForPaymentGuardTest(t, user.Id))
 }
 
+func TestRechargeEpayCreditsLinuxDOCreditSnapshotWithoutRewritingCurrency(t *testing.T) {
+	truncateTables(t)
+	oldQuotaPerUnit := common.QuotaPerUnit
+	common.QuotaPerUnit = 500000
+	t.Cleanup(func() { common.QuotaPerUnit = oldQuotaPerUnit })
+
+	user := insertUserForPaymentGuardTest(t, 502, 0)
+	order := TopUp{
+		UserId:               user.Id,
+		Amount:               2,
+		CreditedQuota:        int64(common.QuotaPerUnit * 2),
+		Money:                5,
+		ExpectedAmountMicros: 5_000_000,
+		SettlementCurrency:   "LDC",
+		TradeNo:              "EPAYLDCSNAPSHOT",
+		PaymentMethod:        PaymentProviderEpay,
+		PaymentProvider:      PaymentProviderEpay,
+		CreateTime:           common.GetTimestamp(),
+		Status:               common.TopUpStatusPending,
+	}
+	require.NoError(t, DB.Create(&order).Error)
+
+	alreadyDone, err := RechargeEpay(order.TradeNo, PaymentProviderEpay, "127.0.0.1")
+	require.NoError(t, err)
+	assert.False(t, alreadyDone)
+	assert.Equal(t, 2*500000, getUserQuotaForPaymentGuardTest(t, user.Id))
+
+	reloaded := GetTopUpByTradeNo(order.TradeNo)
+	require.NotNil(t, reloaded)
+	assert.Equal(t, common.TopUpStatusSuccess, reloaded.Status)
+	assert.Equal(t, "LDC", reloaded.SettlementCurrency)
+	assert.EqualValues(t, 5_000_000, reloaded.SettledAmountMicros)
+}
+
 func TestRechargeEpayCreditsQuotaExactlyOnce(t *testing.T) {
 	truncateTables(t)
 

--- a/apps/api-go/model/payment_refund.go
+++ b/apps/api-go/model/payment_refund.go
@@ -167,7 +167,8 @@ func ApplyPaymentRefund(
 			if ledgerExists && !refundLedgerBindsRequest(&ledger, tradeNo, providerEventID, paymentMethod, paymentProvider, currency, result.UserID) {
 				return ErrPaymentRefundOrderConflict
 			}
-			alreadyApplied := ledgerExists && order.RefundedAmountMicros > 0
+			alreadyApplied := ledgerExists && (order.RefundedAmountMicros > 0 ||
+				subscriptionRefundAlreadyConsumedInPriorPeriod(&order, &ledger))
 			paidMicros := order.ExpectedAmountMicros
 			if paidMicros <= 0 {
 				// Legacy fallback only. New subscription orders snapshot the real
@@ -294,6 +295,18 @@ func refundNoteContainsTradeNo(note, tradeNo string) bool {
 		}
 	}
 	return false
+}
+
+// subscriptionRefundAlreadyConsumedInPriorPeriod reports that a ledger row
+// belongs to an earlier billing cycle. Recurring renewal resets the order's
+// cumulative refund counters so the new period can accept its own refunds;
+// a provider retry of the previous cycle must not look like a legacy
+// backfill and shrink the freshly restored grant.
+func subscriptionRefundAlreadyConsumedInPriorPeriod(order *SubscriptionOrder, ledger *FinanceLedgerEntry) bool {
+	if order == nil || ledger == nil {
+		return false
+	}
+	return order.CurrentPeriodStart > 0 && ledger.OccurredAt > 0 && ledger.OccurredAt < order.CurrentPeriodStart
 }
 
 func refundLedgerBindsRequest(

--- a/apps/api-go/model/payment_refund_test.go
+++ b/apps/api-go/model/payment_refund_test.go
@@ -220,6 +220,102 @@ func TestApplyWaffoPancakeRefundBindsProviderEventToOriginalOrder(t *testing.T) 
 	assert.Contains(t, entries[0].Note, "refund_trade_no="+firstOrder.TradeNo)
 }
 
+func TestSubscriptionRenewalRestoresPurchasedQuotaAndIgnoresPriorRefundRetries(t *testing.T) {
+	db := setupConsoleActivationTestDB(t)
+	require.NoError(t, db.AutoMigrate(
+		&SubscriptionPlan{}, &SubscriptionOrder{}, &UserSubscription{},
+		&SubscriptionPaymentEvent{}, &FinanceLedgerEntry{}, &TopUp{}, &Log{},
+	))
+
+	user := User{
+		Username: "refund-renewal-owner", Password: "password",
+		Status: common.UserStatusEnabled, Group: "default", AffCode: "refund-renewal-owner",
+	}
+	require.NoError(t, db.Create(&user).Error)
+	plan := SubscriptionPlan{
+		Title: "Refund renewal plan", PriceAmount: 10, Currency: "USD",
+		DurationUnit: SubscriptionDurationMonth, DurationValue: 1,
+		Enabled: true, TotalAmount: 100_000,
+	}
+	require.NoError(t, db.Create(&plan).Error)
+	tradeNo := "refund-renewal-subscription"
+	order := SubscriptionOrder{
+		UserId: user.Id, PlanId: plan.Id, Money: plan.PriceAmount, TradeNo: tradeNo,
+		PaymentMethod: PaymentMethodWaffoPancake, PaymentProvider: PaymentProviderWaffoPancake,
+		Status: common.TopUpStatusPending, CreateTime: common.GetTimestamp(),
+		PlanSnapshot: common.GetJsonString(plan), ExpectedAmountMicros: 1_000_000,
+		SettlementCurrency: "USD", ProviderProductId: "PROD_refund_renewal",
+	}
+	require.NoError(t, db.Create(&order).Error)
+	require.NoError(t, CompleteSubscriptionOrder(tradeNo, `{}`, PaymentProviderWaffoPancake, ""))
+
+	now := common.GetTimestamp()
+	firstStart := now - 60
+	firstEnd := now + 30*24*60*60
+	require.NoError(t, ApplySubscriptionPaymentEvent(tradeNo, &SubscriptionPaymentEvent{
+		PaymentProvider: PaymentProviderWaffoPancake, ProviderEventId: "EVT_refund_renewal_initial",
+		ProviderTransactionId: "PAY_refund_renewal_initial", SettlementCurrency: "USD",
+		SettlementAmountMicros: 1_000_000, PeriodStart: firstStart, PeriodEnd: firstEnd,
+	}, "ORD_refund_renewal", "active"))
+
+	result, err := ApplyWaffoPancakeRefund(
+		tradeNo, true, 500_000, FinanceCurrencyUSD,
+		"EVT_refund_renewal_partial", PaymentMethodWaffoPancake, PaymentProviderWaffoPancake,
+		"period-1 refund", user.Id,
+	)
+	require.NoError(t, err)
+	assert.True(t, result.Created)
+	assert.Equal(t, int64(50_000), result.QuotaDebited)
+
+	storedOrder := GetSubscriptionOrderByTradeNo(tradeNo)
+	require.NotNil(t, storedOrder)
+	var subscription UserSubscription
+	require.NoError(t, db.First(&subscription, storedOrder.UserSubscriptionId).Error)
+	assert.Equal(t, int64(50_000), subscription.AmountTotal)
+
+	secondEnd := firstEnd + 31*24*60*60
+	require.NoError(t, ApplySubscriptionPaymentEvent(tradeNo, &SubscriptionPaymentEvent{
+		PaymentProvider: PaymentProviderWaffoPancake, ProviderEventId: "EVT_refund_renewal_cycle_2",
+		ProviderTransactionId: "PAY_refund_renewal_cycle_2", SettlementCurrency: "USD",
+		SettlementAmountMicros: 1_000_000, PeriodStart: firstEnd, PeriodEnd: secondEnd,
+	}, "ORD_refund_renewal", "active"))
+
+	require.NoError(t, db.First(&subscription, storedOrder.UserSubscriptionId).Error)
+	assert.Equal(t, int64(100_000), subscription.AmountTotal, "paid renewal must restore the purchased quota grant")
+	assert.Equal(t, "active", subscription.Status)
+	storedOrder = GetSubscriptionOrderByTradeNo(tradeNo)
+	require.NotNil(t, storedOrder)
+	assert.Zero(t, storedOrder.RefundedAmountMicros)
+	assert.Zero(t, storedOrder.RefundedQuota)
+
+	result, err = ApplyWaffoPancakeRefund(
+		tradeNo, true, 500_000, FinanceCurrencyUSD,
+		"EVT_refund_renewal_partial", PaymentMethodWaffoPancake, PaymentProviderWaffoPancake,
+		"period-1 refund retry", user.Id,
+	)
+	require.NoError(t, err)
+	assert.False(t, result.Created)
+	assert.Zero(t, result.QuotaDebited)
+	require.NoError(t, db.First(&subscription, storedOrder.UserSubscriptionId).Error)
+	assert.Equal(t, int64(100_000), subscription.AmountTotal, "prior-period refund retry must not shrink the new grant")
+	storedOrder = GetSubscriptionOrderByTradeNo(tradeNo)
+	require.NotNil(t, storedOrder)
+	assert.Zero(t, storedOrder.RefundedAmountMicros)
+}
+
+func TestSubscriptionRefundAlreadyConsumedInPriorPeriod(t *testing.T) {
+	assert.False(t, subscriptionRefundAlreadyConsumedInPriorPeriod(nil, &FinanceLedgerEntry{OccurredAt: 10}))
+	assert.False(t, subscriptionRefundAlreadyConsumedInPriorPeriod(&SubscriptionOrder{CurrentPeriodStart: 20}, nil))
+	assert.False(t, subscriptionRefundAlreadyConsumedInPriorPeriod(
+		&SubscriptionOrder{CurrentPeriodStart: 20},
+		&FinanceLedgerEntry{OccurredAt: 20},
+	))
+	assert.True(t, subscriptionRefundAlreadyConsumedInPriorPeriod(
+		&SubscriptionOrder{CurrentPeriodStart: 20},
+		&FinanceLedgerEntry{OccurredAt: 19},
+	))
+}
+
 func getUserQuotaForRefundTest(t *testing.T, db *gorm.DB, userID int) int {
 	t.Helper()
 	var quota int

--- a/apps/api-go/model/subscription.go
+++ b/apps/api-go/model/subscription.go
@@ -1054,9 +1054,17 @@ func ApplySubscriptionPaymentEvent(tradeNo string, paymentEvent *SubscriptionPay
 		subscription.EndTime = paymentEvent.PeriodEnd
 		isRenewal = priorCount > 0
 		if isRenewal {
+			// A paid renewal starts a new grant. Refunds permanently shrink
+			// AmountTotal for the period they belong to; carrying that reduced
+			// cap into the next paid cycle would keep charging full price for
+			// leftover quota. Restore the purchased snapshot when it is a
+			// finite grant (0 means unlimited and is not reduced by refunds).
 			order.RefundedAmountMicros = 0
 			order.RefundedQuota = 0
 			subscription.AmountUsed = 0
+			if renewalPlan.TotalAmount > 0 {
+				subscription.AmountTotal = renewalPlan.TotalAmount
+			}
 			subscription.Status = "active"
 			subscription.LastResetTime = paymentEvent.PeriodStart
 			subscription.NextResetTime = calcNextResetTime(time.Unix(paymentEvent.PeriodStart, 0), &renewalPlan, subscription.EndTime)

--- a/apps/api-go/model/topup.go
+++ b/apps/api-go/model/topup.go
@@ -380,12 +380,13 @@ func completeExternalTopUpOnDB(db *gorm.DB, settlement ExternalTopUpSettlement) 
 			if completed.PaymentProvider == PaymentProviderCreem && strings.TrimSpace(completed.SettlementCurrency) == "" {
 				return ErrPaymentEvidenceConflict
 			}
-			if completed.PaymentProvider == PaymentProviderEpay &&
-				(completed.ExpectedAmountMicros <= 0 || completed.CreditedQuota <= 0 || !strings.EqualFold(strings.TrimSpace(completed.SettlementCurrency), "CNY")) {
+			if completed.PaymentProvider == PaymentProviderEpay && !epayHasImmutableSettlementSnapshot(&completed) {
 				// Historical Epay rows stored only an ambiguous float Money value.
 				// They may represent either already-converted USD or CNY and cannot
 				// be settled safely. Require manual reconciliation instead of
 				// guessing and crediting at today's exchange configuration.
+				// Virtual units such as LDC are valid when the order snapshotted
+				// amount, quota, and currency before the user paid.
 				return ErrPaymentEvidenceConflict
 			}
 
@@ -802,11 +803,11 @@ func normalizedTopUpCreditedQuota(topUp *TopUp) int64 {
 	if topUp == nil {
 		return 0
 	}
+	if topUp.CreditedQuota > 0 && (knownExternalTopUpSource(topUp) || epayHasImmutableSettlementSnapshot(topUp)) {
+		return topUp.CreditedQuota
+	}
 	if !knownExternalTopUpSource(topUp) {
 		return 0
-	}
-	if topUp.CreditedQuota > 0 {
-		return topUp.CreditedQuota
 	}
 	switch {
 	case topUp.PaymentProvider == PaymentProviderCreem || topUp.PaymentMethod == PaymentMethodCreem:
@@ -855,6 +856,24 @@ func isLegacyLinuxDOCreditTopUp(topUp *TopUp) bool {
 	}
 	return !strings.EqualFold(strings.TrimSpace(topUp.SettlementCurrency), "CNY") ||
 		(topUp.ExpectedAmountMicros <= 0 && topUp.SettledAmountMicros <= 0)
+}
+
+// EpayHasImmutableSettlementSnapshot reports whether an Epay order recorded
+// amount, credited quota, and settlement unit before redirecting to the
+// gateway. Historical rows stored only an ambiguous float Money value and
+// cannot be settled safely. Virtual units such as LDC are valid snapshots;
+// requiring CNY here would take payment and then refuse to credit.
+func EpayHasImmutableSettlementSnapshot(topUp *TopUp) bool {
+	return epayHasImmutableSettlementSnapshot(topUp)
+}
+
+func epayHasImmutableSettlementSnapshot(topUp *TopUp) bool {
+	if topUp == nil {
+		return false
+	}
+	return topUp.ExpectedAmountMicros > 0 &&
+		topUp.CreditedQuota > 0 &&
+		strings.TrimSpace(topUp.SettlementCurrency) != ""
 }
 
 func knownExternalTopUpSource(topUp *TopUp) bool {
@@ -952,7 +971,7 @@ func RechargeEpay(tradeNo string, actualPaymentMethod string, callerIp string) (
 		if actualPaymentMethod != "" && topUp.PaymentMethod != actualPaymentMethod {
 			topUp.PaymentMethod = actualPaymentMethod
 		}
-		if topUp.ExpectedAmountMicros <= 0 || topUp.CreditedQuota <= 0 || !strings.EqualFold(strings.TrimSpace(topUp.SettlementCurrency), "CNY") {
+		if !epayHasImmutableSettlementSnapshot(topUp) {
 			return ErrPaymentEvidenceConflict
 		}
 		quotaToAdd = int(topUp.CreditedQuota)
@@ -960,7 +979,6 @@ func RechargeEpay(tradeNo string, actualPaymentMethod string, callerIp string) (
 			return ErrInvalidTopUpQuota
 		}
 		topUp.SettledAmountMicros = topUp.ExpectedAmountMicros
-		topUp.SettlementCurrency = "CNY"
 		topUp.CompleteTime = common.GetTimestamp()
 		topUp.Status = common.TopUpStatusSuccess
 		if err := tx.Save(topUp).Error; err != nil {

--- a/apps/api-go/model/topup_settlement_test.go
+++ b/apps/api-go/model/topup_settlement_test.go
@@ -430,6 +430,62 @@ func TestCompleteExternalTopUpIndependentHandlesCreditExactlyOnce(t *testing.T) 
 	assert.Equal(t, 100+1_234, reloadedUser.Quota)
 }
 
+func TestCompleteExternalTopUpCreditsEpayNonCNYSnapshot(t *testing.T) {
+	db := setupExternalTopUpSettlementDB(t, 1)
+	user, topUp, settlement := createSettlementFixture(t, db, "epay-ldc")
+	require.NoError(t, db.Model(&topUp).Updates(map[string]any{
+		"payment_provider":       PaymentProviderEpay,
+		"payment_method":         PaymentProviderEpay,
+		"settlement_currency":    "LDC",
+		"provider_product_id":    "",
+		"provider_store_id":      "",
+		"expected_amount_micros": 5_000_000,
+		"credited_quota":         2_000,
+	}).Error)
+	settlement.PaymentProvider = PaymentProviderEpay
+	settlement.PaymentMethod = PaymentProviderEpay
+	settlement.SettlementCurrency = "LDC"
+	settlement.SettledAmountMicros = 5_000_000
+	settlement.ProviderQuotedAmountMicros = 0
+	settlement.ProviderProductId = ""
+	settlement.ProviderStoreId = ""
+
+	completed, err := CompleteExternalTopUp(settlement)
+	require.NoError(t, err)
+	require.NotNil(t, completed)
+	assert.Equal(t, common.TopUpStatusSuccess, completed.Status)
+	assert.Equal(t, "LDC", completed.SettlementCurrency)
+	assert.EqualValues(t, 5_000_000, completed.SettledAmountMicros)
+	assert.EqualValues(t, 2_000, completed.CreditedQuota)
+
+	var reloadedUser User
+	require.NoError(t, db.First(&reloadedUser, user.Id).Error)
+	assert.Equal(t, 100+2_000, reloadedUser.Quota)
+}
+
+func TestCompleteExternalTopUpRejectsEpayWithoutImmutableSnapshot(t *testing.T) {
+	db := setupExternalTopUpSettlementDB(t, 1)
+	_, topUp, settlement := createSettlementFixture(t, db, "epay-legacy")
+	require.NoError(t, db.Model(&topUp).Updates(map[string]any{
+		"payment_provider":       PaymentProviderEpay,
+		"payment_method":         "alipay",
+		"settlement_currency":    "",
+		"expected_amount_micros": 0,
+		"credited_quota":         0,
+		"provider_product_id":    "",
+		"provider_store_id":      "",
+	}).Error)
+	settlement.PaymentProvider = PaymentProviderEpay
+	settlement.PaymentMethod = "alipay"
+	settlement.SettlementCurrency = "CNY"
+	settlement.ProviderQuotedAmountMicros = 0
+	settlement.ProviderProductId = ""
+	settlement.ProviderStoreId = ""
+
+	_, err := CompleteExternalTopUp(settlement)
+	require.ErrorIs(t, err, ErrPaymentEvidenceConflict)
+}
+
 func TestCompleteExternalTopUpRejectsExpectedMoneyOrCurrencyMismatch(t *testing.T) {
 	db := setupExternalTopUpSettlementDB(t, 1)
 	_, topUp, settlement := createSettlementFixture(t, db, "money-mismatch")

--- a/apps/web/src/i18n/locales/fr.json
+++ b/apps/web/src/i18n/locales/fr.json
@@ -3033,7 +3033,7 @@
     "footer.columns.related.links.midjourney": "MjProxy",
     "footer.columns.related.title": "Projets liés",
     "footer.defaultCopyright": "Tous droits réservés.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Tous droits réservés. Conçu et développé par les contributeurs du projet.",
+    "footer.newapi.projectAttributionSuffix": "Tous droits réservés. Conçu et développé par les contributeurs du projet.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Pour les canaux ajoutés après le 10 mai 2025, pas besoin de supprimer \".\" des noms de modèles lors du déploiement",
     "For example, a reliable OpenAI-compatible endpoint": "Par exemple : un point d’accès OpenAI compatible fiable",
     "For example: 12, 34, 56": "Par exemple : 12, 34, 56",
@@ -8026,6 +8026,10 @@
     "Zero retention": "Aucune rétention",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Zoom"
+    "Zoom": "Zoom",
+    "Automatically sign out sessions after one week": "Déconnecter automatiquement les sessions après une semaine",
+    "Enabled by default. Sessions are signed out one week after login, even if they are still active, including this device.": "Activé par défaut. Les sessions sont déconnectées une semaine après la connexion, même si elles sont encore actives, y compris sur cet appareil.",
+    "Failed to update login session settings": "Échec de la mise à jour des paramètres de session de connexion",
+    "Login session settings updated": "Paramètres de session de connexion mis à jour"
   }
 }

--- a/apps/web/src/i18n/locales/ja.json
+++ b/apps/web/src/i18n/locales/ja.json
@@ -8026,6 +8026,10 @@
     "Zero retention": "データ保持なし",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V 4",
-    "Zoom": "ズーム"
+    "Zoom": "ズーム",
+    "Automatically sign out sessions after one week": "1 週間後にセッションを自動でサインアウトする",
+    "Enabled by default. Sessions are signed out one week after login, even if they are still active, including this device.": "デフォルトで有効。ログインから 1 週間経過したセッションは、利用中であってもこのデバイスを含めて自動的にサインアウトされます。",
+    "Failed to update login session settings": "ログインセッション設定の更新に失敗しました",
+    "Login session settings updated": "ログインセッション設定を更新しました"
   }
 }

--- a/apps/web/src/i18n/locales/ru.json
+++ b/apps/web/src/i18n/locales/ru.json
@@ -8026,6 +8026,10 @@
     "Zero retention": "Без хранения данных",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Масштаб"
+    "Zoom": "Масштаб",
+    "Automatically sign out sessions after one week": "Автоматически завершать сеансы через неделю",
+    "Enabled by default. Sessions are signed out one week after login, even if they are still active, including this device.": "Включено по умолчанию. Сеансы завершаются через неделю после входа, даже если они всё ещё активны, включая это устройство.",
+    "Failed to update login session settings": "Не удалось обновить настройки сеанса входа",
+    "Login session settings updated": "Настройки сеанса входа обновлены"
   }
 }

--- a/apps/web/src/i18n/locales/vi.json
+++ b/apps/web/src/i18n/locales/vi.json
@@ -3033,7 +3033,7 @@
     "footer.columns.related.links.midjourney": "MjProxy",
     "footer.columns.related.title": "Các Dự Án Liên Quan",
     "footer.defaultCopyright": "Bản quyền được bảo lưu.",
-    "footer.new\u0061pi.projectAttributionSuffix": "Bản quyền được bảo lưu. Được thiết kế và phát triển bởi các cộng tác viên dự án.",
+    "footer.newapi.projectAttributionSuffix": "Bản quyền được bảo lưu. Được thiết kế và phát triển bởi các cộng tác viên dự án.",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "Đối với các kênh được thêm sau ngày 10 tháng 5 năm 2025, không cần loại bỏ \".\" khỏi tên mô hình trong quá trình triển khai",
     "For example, a reliable OpenAI-compatible endpoint": "Ví dụ: một endpoint tương thích OpenAI đáng tin cậy",
     "For example: 12, 34, 56": "Ví dụ: 12, 34, 56",
@@ -8026,6 +8026,10 @@
     "Zero retention": "Không lưu dữ liệu",
     "Zhipu": "Zhipu",
     "Zhipu V4": "Zhipu V4",
-    "Zoom": "Thu phóng"
+    "Zoom": "Thu phóng",
+    "Automatically sign out sessions after one week": "Tự động đăng xuất phiên sau một tuần",
+    "Enabled by default. Sessions are signed out one week after login, even if they are still active, including this device.": "Bật theo mặc định. Các phiên sẽ được đăng xuất một tuần sau khi đăng nhập, ngay cả khi vẫn đang hoạt động, bao gồm cả thiết bị này.",
+    "Failed to update login session settings": "Cập nhật cài đặt phiên đăng nhập thất bại",
+    "Login session settings updated": "Đã cập nhật cài đặt phiên đăng nhập"
   }
 }

--- a/apps/web/src/i18n/locales/zh-TW.json
+++ b/apps/web/src/i18n/locales/zh-TW.json
@@ -3033,7 +3033,7 @@
     "footer.columns.related.links.midjourney": "MjProxy",
     "footer.columns.related.title": "相關項目",
     "footer.defaultCopyright": "版權所有。",
-    "footer.new\u0061pi.projectAttributionSuffix": "版權所有，由項目貢獻者設計與開發。",
+    "footer.newapi.projectAttributionSuffix": "版權所有，由項目貢獻者設計與開發。",
     "For channels added after May 10, 2025, no need to remove \".\" from model names during deployment": "對於 2025 年 5 月 10 日之後新增的渠道，在部署時無需從模型名稱中移除 \".\"",
     "For example, a reliable OpenAI-compatible endpoint": "例如：穩定的 OpenAI 相容介面",
     "For example: 12, 34, 56": "例如：12, 34, 56",
@@ -8026,6 +8026,10 @@
     "Zero retention": "零數據保留",
     "Zhipu": "智譜",
     "Zhipu V4": "智譜 V4",
-    "Zoom": "縮放"
+    "Zoom": "縮放",
+    "Automatically sign out sessions after one week": "登入超過一週後自動登出工作階段",
+    "Enabled by default. Sessions are signed out one week after login, even if they are still active, including this device.": "預設為啟用。工作階段自登入起算一週後將自動登出，即使仍在使用中亦然，包括本裝置。",
+    "Failed to update login session settings": "更新登入工作階段設定失敗",
+    "Login session settings updated": "登入工作階段設定已更新"
   }
 }


### PR DESCRIPTION
# LMM API Pull Request

> LMM Forge 的 Go 服务保留上游兼容层。请说明本次变更对悬赏协作、交付跟踪或兼容行为的影响，并确保 PR 只包含当前任务所需的改动。

## 变更说明 / Summary

Recover valid fixes from automatically closed PRs #165, #168, #188, #196 and #214, preserving all five original heads as merge parents. This integration is needed because contributor forks cannot be updated through the available connection.

- #165: settle snapshotted non-CNY Epay orders; additionally restrict the fallback to Epay providers so unknown/internal orders cannot bypass quota-source validation.
- #168: allow signed Stripe/Creem subscription webhooks without wallet products.
- #188: validate refunds against checkout snapshots; add wrong-binding, deleted-plan and entitlement revocation coverage.
- #196: restore purchased renewal quota; use actual local renewal receipt time to prevent delayed/same-second refund replay while preserving append-only ledger records.
- #214: add the four login-session strings to five missing locales, preserving existing translations and protected footer serialization.

#206/#208 are already covered by merged #212 and are intentionally excluded. The automated-closure policy was fixed separately in #215.

## 与上游的关系 / Upstream relationship

<!-- 请选择一项，并补充相关上游 Issue、PR 或 commit 链接。 -->

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: Existing contribution PRs linked above.

## 关联 Issue / Related issue

Closes #213

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

<!-- 列出实际执行的命令、结果，以及必要的手动验证步骤。未执行的项目请写明原因。 -->

```text
command: cd apps/api-go && go test ./controller ./model -count=1 -timeout 180s
result: controller passed (5.616s); model passed (13.388s)
command: cd apps/api-go && go vet ./controller ./model
result: passed
command: node --test scripts/pr-quality.test.mjs scripts/check-i18n.test.mjs
result: 15 tests passed
command: node scripts/check-i18n.mjs --base origin/main
result: passed
command: git diff --check
result: passed
```

## 截图或日志 / Screenshots or logs

Locale JSON validation: exactly four additions per affected locale, no duplicate keys, all existing translations preserved. The Epay regression fails on the original #165 and passes with provider binding. Refund tests cover delayed callbacks, same-second renewal, current-cycle retries and legacy ledger-only backfill.

Compatibility limit: an old ledger-only refund recorded in exactly the renewal second is conservatively treated as the previous cycle. Normal atomic refunds are unaffected. No schema changes or historic ledger rewrites. Full CI runs on the combined tree before merge.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Sourcery 总结

恢复此前已关闭的拉取请求中的有效支付、退款、续订、Webhook 和翻译变更，同时保留其原有行为与兼容性保护措施。

错误修复：
- 恢复对有效非 CNY Epay 支付的处理，同时拒绝缺少不可变结算凭证的旧版或无法识别提供商订单。
- 即使未配置钱包产品，也允许已签名的 Stripe 和 Creem 订阅 Webhook 正常运行。
- 根据结账时的支付快照验证订阅退款，包括支持在实时套餐被移除或提供商设置发生变化后进行退款。
- 恢复付费订阅续订时的已购配额发放，并防止延迟或重复退款影响后续计费周期。
- 补充五种语言环境中缺失的登录会话翻译。

增强功能：
- 保留仅追加的财务账本记录，同时在订阅续订过渡期间安全处理旧版退款条目。

测试：
- 增加针对 Epay 结算验证、仅订阅支付 Webhook、基于快照的退款、续订配额恢复以及旧版退款重放处理的回归测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Recover valid payment, refund, renewal, webhook, and translation changes from previously closed pull requests while preserving their original behavior and compatibility safeguards.

Bug Fixes:
- Restore processing for valid non-CNY Epay payments while rejecting legacy or unrecognized-provider orders without immutable settlement evidence.
- Allow signed Stripe and Creem subscription webhooks to operate when wallet products are not configured.
- Validate subscription refunds against checkout-time payment snapshots, including support for refunds after live plans are removed or provider settings change.
- Restore the purchased quota grant on paid subscription renewals and prevent delayed or repeated refunds from affecting a subsequent billing cycle.
- Add missing login-session translations across five locales.

Enhancements:
- Preserve append-only financial ledger records while safely handling legacy refund entries during subscription renewal transitions.

Tests:
- Add regression coverage for Epay settlement validation, subscription-only payment webhooks, snapshot-bound refunds, renewal quota restoration, and legacy refund replay handling.

</details>