### PR TITLE
feat(deploy): verify controller-only production backup receipts

### DIFF
--- a/apps/api-go/go.mod
+++ b/apps/api-go/go.mod
@@ -4,6 +4,7 @@ module github.com/LIghtJUNction/api.lmm.best
 go 1.25.1
 
 require (
+	filippo.io/edwards25519 v1.1.0
 	github.com/Calcium-Ion/go-epay v0.0.4
 	github.com/abema/go-mp4 v1.4.1
 	github.com/andybalholm/brotli v1.1.1

--- a/apps/api-go/go.sum
+++ b/apps/api-go/go.sum
@@ -597,6 +597,8 @@ cloud.google.com/go/workflows v1.9.0/go.mod h1:ZGkj1aFIOd9c8Gerkjjq7OW7I5+l6cSvT
 cloud.google.com/go/workflows v1.10.0/go.mod h1:fZ8LmRmZQWacon9UCX1r/g/DfAXx5VcPALq2CxzdePw=
 dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 gioui.org v0.0.0-20210308172011-57750fc8a0a6/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 git.sr.ht/~sbinet/gg v0.3.1/go.mod h1:KGYtlADtqsqANL9ueOFkWymvzUvLMQllU5Ixo+8v3pc=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=

--- a/apps/api-go/internal/appcli/deploy.go
+++ b/apps/api-go/internal/appcli/deploy.go
@@ -73,12 +73,12 @@ func writeDeployUsage(output io.Writer) {
        --go-rollback-package FILE --go-rollback-release-asset FILE --go-rollback-release-bundle FILE \
        --web-package FILE --web-release-asset FILE --web-release-bundle FILE \
        --web-rollback-package FILE --web-rollback-release-asset FILE --web-rollback-release-bundle FILE \
-       --probe-binary FILE [--with-backups --age-recipient-file FILE]
+       --probe-binary FILE [--with-backups --controller-backup-dir DIR]
   %s deploy production stage|promote|status|confirm|rollback \
        --plan FILE --plan-sha256 HEX --confirm api.lmm.best
 
-Production Go changes require --with-backups and the verified target, controller, and off-host copies.
-Web-only releases may omit backups.
+Backups are optional for Go-only, Web-only, and combined releases.
+Selected backups are imported and decrypted only on the controller; only signed verification receipts reach production.
 Target-only recovery commands are listed by the production command's usage.
 `, ProgramName, ProgramName, ProgramName, ProgramName, ProgramName, ProgramName, ProgramName, ProgramName, ProgramName)
 }

--- a/apps/api-go/internal/appcli/deploy_production.go
+++ b/apps/api-go/internal/appcli/deploy_production.go
@@ -103,7 +103,7 @@ func writeProductionDeployUsage(output io.Writer) {
        --go-rollback-package FILE --go-rollback-release-asset FILE --go-rollback-release-bundle FILE \\
        --web-package FILE --web-release-asset FILE --web-release-bundle FILE \\
        --web-rollback-package FILE --web-rollback-release-asset FILE --web-rollback-release-bundle FILE \\
-       --probe-binary FILE [--operator-binary FILE] [--with-backups --age-recipient-file FILE]
+       --probe-binary FILE [--operator-binary FILE] [--with-backups --controller-backup-dir DIR]
   %s deploy production stage|promote|status|confirm|rollback \\
        --plan FILE --plan-sha256 HEX --confirm api.lmm.best \\
        [--age-identity-file FILE for backup-enabled promote or confirm]
@@ -114,11 +114,15 @@ Target-only recovery commands (normally invoked by the controller):
        --go-package FILE --go-package-sha256 HEX --go-rollback-package FILE --go-rollback-sha256 HEX \\
        --web-package FILE --web-package-sha256 HEX --web-rollback-package FILE --web-rollback-sha256 HEX \\
        --probe-binary FILE --probe-binary-sha256 HEX --operator-binary FILE --operator-binary-sha256 HEX \\
-       --expected-version VERSION [--go-changed] [--web-changed] [--with-backups --backup-dir DIR]
+       --expected-version VERSION [--go-changed] [--web-changed]
+       [--with-backups --controller-backup-public-key HEX --release-plan-sha256 HEX
+        --controller-backup-receipt FILE --controller-backup-receipt-sha256 HEX]
   %s deploy production status|confirm|rollback --workspace DIR
 
-Production Go changes require --with-backups and the verified target, controller, and off-host copies.
-Web-only releases may omit backups.
+Backups are optional for Go-only, Web-only, and combined releases.
+New plans import controller-only encrypted backup sets; no full target or off-host copy is created.
+Selected backups require the local age identity at promote and confirm. Only signed metadata reaches production.
+Legacy format-5 plans and --with-backups --backup-dir transactions remain readable for recovery.
 `, ProgramName, ProgramName, ProgramName, ProgramName, ProgramName)
 }
 

--- a/apps/api-go/internal/appcli/deploy_production_controller.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller.go
@@ -32,19 +32,20 @@ type productionReleaseControllerOptions struct {
 }
 
 type productionReleaseControllerState struct {
-	Format           int       `json:"format"`
-	DeploymentID     string    `json:"deployment_id"`
-	PlanSHA256       string    `json:"plan_sha256"`
-	Phase            string    `json:"phase"`
-	RemoteWorkspace  string    `json:"remote_workspace"`
-	TargetBackup     string    `json:"target_backup,omitempty"`
-	ControllerBackup string    `json:"controller_backup,omitempty"`
-	OffhostBackup    string    `json:"offhost_backup,omitempty"`
-	Version          string    `json:"version,omitempty"`
-	ActivationUnit   string    `json:"activation_unit,omitempty"`
-	DispatchAttempts int       `json:"dispatch_attempts,omitempty"`
-	DispatchObserved bool      `json:"dispatch_observed,omitempty"`
-	UpdatedUTC       time.Time `json:"updated_utc"`
+	Format                  int       `json:"format"`
+	DeploymentID            string    `json:"deployment_id"`
+	PlanSHA256              string    `json:"plan_sha256"`
+	Phase                   string    `json:"phase"`
+	RemoteWorkspace         string    `json:"remote_workspace"`
+	TargetBackup            string    `json:"target_backup,omitempty"`
+	ControllerBackup        string    `json:"controller_backup,omitempty"`
+	ControllerReceiptSHA256 string    `json:"controller_receipt_sha256,omitempty"`
+	OffhostBackup           string    `json:"offhost_backup,omitempty"`
+	Version                 string    `json:"version,omitempty"`
+	ActivationUnit          string    `json:"activation_unit,omitempty"`
+	DispatchAttempts        int       `json:"dispatch_attempts,omitempty"`
+	DispatchObserved        bool      `json:"dispatch_observed,omitempty"`
+	UpdatedUTC              time.Time `json:"updated_utc"`
 }
 
 type productionReleaseControllerResult struct {
@@ -253,7 +254,16 @@ func (runtime *productionReleaseRuntime) promote(ctx context.Context, options pr
 	if err := runtime.verifyRemoteStagedRelease(ctx, plan, state); err != nil {
 		return productionReleaseControllerResult{}, err
 	}
-	if plan.WithBackups && state.TargetBackup == "" {
+	if !plan.WithBackups && options.AgeIdentityFile != "" {
+		return productionReleaseControllerResult{}, errors.New("disabled backup plans forbid --age-identity-file")
+	}
+	if plan.Format == productionReleasePlanFormat && plan.WithBackups && state.DispatchAttempts == 0 &&
+		(state.Phase == productionReleasePhaseStaged || state.Phase == productionReleasePhaseBackupsReady) {
+		if err := runtime.prepareControllerOnlyBackup(ctx, plan, &state, options.AgeIdentityFile); err != nil {
+			return productionReleaseControllerResult{}, err
+		}
+	}
+	if plan.Format == 5 && plan.WithBackups && state.TargetBackup == "" {
 		if options.AgeIdentityFile == "" {
 			return productionReleaseControllerResult{}, errors.New("--age-identity-file is required by this backup-enabled plan")
 		}
@@ -308,6 +318,9 @@ func (runtime *productionReleaseRuntime) control(ctx context.Context, action str
 	if err := runtime.assertRemoteHost(ctx, plan.TargetAlias, plan.ExpectedHost); err != nil {
 		return productionReleaseControllerResult{}, err
 	}
+	if !plan.WithBackups && options.AgeIdentityFile != "" {
+		return productionReleaseControllerResult{}, errors.New("disabled backup plans forbid --age-identity-file")
+	}
 	if action == "confirm" && plan.WithBackups {
 		if options.AgeIdentityFile == "" {
 			return productionReleaseControllerResult{}, errors.New("--age-identity-file is required to reverify backup-enabled confirmation")
@@ -321,7 +334,11 @@ func (runtime *productionReleaseRuntime) control(ctx context.Context, action str
 		if action == "rollback" {
 			arguments = append(arguments, "--reason", options.Reason)
 		}
-		output, err := runtime.ssh(ctx, plan.TargetAlias, 12*time.Minute, append([]string{productionOperatorBinary}, arguments...)...)
+		operator, err := runtime.controllerRecoveryOperator(ctx, plan, state)
+		if err != nil {
+			return productionReleaseControllerResult{}, err
+		}
+		output, err := runtime.ssh(ctx, plan.TargetAlias, 12*time.Minute, append([]string{operator}, arguments...)...)
 		if err != nil {
 			return productionReleaseControllerResult{}, fmt.Errorf("production %s failed or became transport-ambiguous: %w", action, err)
 		}
@@ -393,7 +410,15 @@ func (runtime *productionReleaseRuntime) productionApplyArguments(plan productio
 		arguments = append(arguments, "--web-changed")
 	}
 	if plan.WithBackups {
-		arguments = append(arguments, "--with-backups", "--backup-dir", state.TargetBackup)
+		if plan.Format == productionReleasePlanFormat {
+			arguments = append(arguments, "--with-backups",
+				"--controller-backup-public-key", plan.ControllerBackupPublicKey,
+				"--release-plan-sha256", state.PlanSHA256,
+				"--controller-backup-receipt", filepath.Join(state.RemoteWorkspace, "state", controllerBackupReceiptName),
+				"--controller-backup-receipt-sha256", state.ControllerReceiptSHA256)
+		} else {
+			arguments = append(arguments, "--with-backups", "--backup-dir", state.TargetBackup)
+		}
 	}
 	if plan.PreserveEdgePolicy {
 		arguments = append(arguments, "--preserve-edge-policy")
@@ -545,9 +570,27 @@ func (runtime *productionReleaseRuntime) waitForDispatchObservation(ctx context.
 	}
 }
 
+func (runtime *productionReleaseRuntime) controllerRecoveryOperator(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) (string, error) {
+	if plan.Format == productionReleasePlanFormat && plan.WithBackups {
+		// After activation the installed, package-bound CLI is sufficient even
+		// if disposable staging has disappeared. Never infer compatibility from
+		// a version string or fall back to an unverified N-1 provider.
+		provider := filepath.Join(filepath.Dir(productionOperatorBinary), backendGoName)
+		if err := runtime.verifyRemoteProviderEntrypoint(ctx, plan.TargetAlias, productionOperatorBinary, provider, plan.GoCandidate.PayloadSHA256); err == nil {
+			return productionOperatorBinary, nil
+		}
+		return runtime.remoteCandidateCommand(ctx, plan, state)
+	}
+	return productionOperatorBinary, nil
+}
+
 func (runtime *productionReleaseRuntime) readRemoteReleaseStatus(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) (productionStatus, error) {
+	operator, err := runtime.controllerRecoveryOperator(ctx, plan, state)
+	if err != nil {
+		return productionStatus{}, err
+	}
 	output, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute,
-		productionOperatorBinary, "deploy", "production", "status", "--workspace", state.RemoteWorkspace)
+		operator, "deploy", "production", "status", "--workspace", state.RemoteWorkspace)
 	if err != nil {
 		return productionStatus{}, fmt.Errorf("read production release status: %w", err)
 	}
@@ -588,7 +631,7 @@ func productionReleaseStageFiles(plan productionReleasePlan, planPath string) ([
 		{planPath, planSHA256, false},
 		{digestPath, digestSHA256, false},
 	}
-	if plan.WithBackups {
+	if plan.WithBackups && plan.Format == 5 {
 		files = append(files, productionReleaseStageFile{plan.AgeRecipient.Path, plan.AgeRecipient.SHA256, false})
 	}
 	unique := make([]productionReleaseStageFile, 0, len(files))
@@ -669,22 +712,29 @@ func (runtime *productionReleaseRuntime) ensureRemoteCandidateEntrypoint(ctx con
 func (runtime *productionReleaseRuntime) verifyRemoteCandidateEntrypoint(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState) error {
 	link := productionRemoteOperatorPath(state)
 	target := filepath.Join(state.RemoteWorkspace, "staging", backendGoName)
-	output, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "readlink", "--", link)
-	if err != nil || strings.TrimSpace(string(output)) != backendGoName {
-		return errors.New("remote candidate entrypoint is not a one-hop relative lmm-api link")
+	return runtime.verifyRemoteProviderEntrypoint(ctx, plan.TargetAlias, link, target, plan.GoCandidate.PayloadSHA256)
+}
+
+func (runtime *productionReleaseRuntime) verifyRemoteProviderEntrypoint(ctx context.Context, alias, link, target, expectedSHA256 string) error {
+	if !productionSHA256Pattern.MatchString(expectedSHA256) {
+		return errors.New("remote provider verification requires a frozen package payload digest")
 	}
-	metadata, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "stat", "-c", "%u:%a:%h:%F", "--", target)
-	parts := strings.SplitN(strings.TrimSpace(string(metadata)), ":", 4)
-	if err != nil || len(parts) != 4 || parts[0] != "0" || parts[2] != "1" || parts[3] != "regular file" {
+	output, err := runtime.ssh(ctx, alias, 2*time.Minute, "readlink", "--", link)
+	if err != nil || strings.TrimSpace(string(output)) != backendGoName {
+		return errors.New("remote provider entrypoint is not a one-hop relative lmm-api link")
+	}
+	metadata, err := runtime.ssh(ctx, alias, 2*time.Minute, "stat", "-c", "%u:%f:%h", "--", target)
+	parts := strings.SplitN(strings.TrimSpace(string(metadata)), ":", 3)
+	if err != nil || len(parts) != 3 || parts[0] != "0" || parts[2] != "1" {
 		return errors.New("remote candidate provider target is not a root-owned single-link regular file")
 	}
-	mode, parseErr := strconv.ParseUint(parts[1], 8, 32)
-	if parseErr != nil || mode&0o022 != 0 || mode&0o100 == 0 {
+	mode, parseErr := strconv.ParseUint(parts[1], 16, 32)
+	if parseErr != nil || mode&0o170000 != 0o100000 || mode&0o7022 != 0 || mode&0o100 == 0 {
 		return errors.New("remote candidate provider target mode is unsafe")
 	}
 	for _, path := range []string{target, link} {
-		digest, err := runtime.remoteFileSHA256(ctx, plan.TargetAlias, path)
-		if err != nil || digest != plan.GoCandidate.PayloadSHA256 {
+		digest, err := runtime.remoteFileSHA256(ctx, alias, path)
+		if err != nil || digest != expectedSHA256 {
 			return errors.New("remote candidate entrypoint target digest mismatch")
 		}
 	}
@@ -700,7 +750,7 @@ func (runtime *productionReleaseRuntime) verifyRemoteStagedRelease(ctx context.C
 		plan.ProbeBinary,
 		plan.OperatorBinary,
 	}
-	if plan.WithBackups {
+	if plan.WithBackups && plan.Format == 5 {
 		files = append(files, plan.AgeRecipient)
 	}
 	seen := make(map[string]string)
@@ -729,6 +779,9 @@ type productionPreparedBackups struct {
 }
 
 func (runtime *productionReleaseRuntime) prepareControllerBackups(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState, ageIdentityFile string) (productionPreparedBackups, error) {
+	if plan.Format != 5 || !plan.WithBackups {
+		return productionPreparedBackups{}, errors.New("legacy multi-copy backup creation is unavailable to new release plans")
+	}
 	if err := runtime.assertRemoteHost(ctx, productionOffhostAlias, productionOffhostExpectedHost); err != nil {
 		return productionPreparedBackups{}, err
 	}
@@ -969,6 +1022,12 @@ func (runtime *productionReleaseRuntime) verifyRemoteExternalBackupCopy(ctx cont
 }
 
 func (runtime *productionReleaseRuntime) reverifyControllerBackups(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState, ageIdentityFile string) error {
+	if plan.Format == productionReleasePlanFormat {
+		return runtime.reverifyControllerOnlyBackup(ctx, plan, state, ageIdentityFile)
+	}
+	if plan.Format != 5 || !plan.WithBackups {
+		return errors.New("backup re-verification requires an explicitly selected supported plan")
+	}
 	if err := validateAgeIdentity(ageIdentityFile); err != nil {
 		return err
 	}
@@ -1139,6 +1198,9 @@ func validateProductionReleaseControllerState(plan productionReleasePlan, planSH
 	}
 	if state.Phase == productionReleasePhaseActivationDispatched && state.DispatchAttempts == 0 {
 		return errors.New("controller release state activation phase lacks a dispatch attempt")
+	}
+	if err := validateControllerOnlyBackupState(plan, state); err != nil {
+		return err
 	}
 	for _, path := range []string{state.TargetBackup, state.ControllerBackup, state.OffhostBackup} {
 		if path != "" && !filepath.IsAbs(path) {

--- a/apps/api-go/internal/appcli/deploy_production_controller_backup_flow.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller_backup_flow.go
@@ -1,0 +1,186 @@
+package appcli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Only this metadata crosses the controller/target boundary. The imported
+// archives and private age/signing keys are never part of the stage list.
+func (runtime *productionReleaseRuntime) prepareControllerOnlyBackup(ctx context.Context, plan productionReleasePlan, state *productionReleaseControllerState, identity string) error {
+	if plan.Format != productionReleasePlanFormat || plan.BackupMode != "controller-only" || !plan.WithBackups || state.DispatchAttempts != 0 {
+		return errors.New("controller-only backup preparation requires an undispatched selected plan")
+	}
+	local := filepath.Join(plan.ControllerWorkspace, "state", controllerBackupReceiptName)
+	if err := checkInitialControllerReceiptRetry(local, plan, state.ControllerReceiptSHA256, runtime.now()); err != nil {
+		return err
+	}
+	verification := &productionRuntime{runner: runtime.runner, now: runtime.now, effectiveUID: os.Geteuid}
+	set, setSHA, err := verification.verifyControllerBackupSet(ctx, plan, plan.ControllerBackupDir, identity)
+	if err != nil {
+		return err
+	}
+	encoded, err := signedControllerBackupReceipt(plan, set, setSHA, state.PlanSHA256, "prepare", "", runtime.now())
+	if err != nil {
+		return err
+	}
+	if err := retainInitialControllerReceipt(local, encoded, plan, runtime.now()); err != nil {
+		return err
+	}
+	digest, err := sha256File(local)
+	if err != nil {
+		return err
+	}
+	if state.ControllerReceiptSHA256 != "" && state.ControllerReceiptSHA256 != digest {
+		return errors.New("controller receipt differs from persisted preparation evidence")
+	}
+	if err := runtime.stageControllerReceipt(ctx, plan, *state, local, digest, false); err != nil {
+		return err
+	}
+	state.ControllerBackup = plan.ControllerBackupDir
+	state.ControllerReceiptSHA256 = digest
+	state.Phase = productionReleasePhaseBackupsReady
+	state.UpdatedUTC = utcSecond(runtime.now())
+	return writeProductionReleaseControllerState(plan, *state)
+}
+
+func retainInitialControllerReceipt(name string, encoded []byte, plan productionReleasePlan, now time.Time) error {
+	if _, err := os.Lstat(name); err == nil {
+		initial, err := readControllerBackupReceipt(name, plan.ControllerBackupPublicKey, "", uint32(os.Geteuid()))
+		if err != nil {
+			return err
+		}
+		expected, err := decodeSignedControllerBackupReceipt(encoded, plan.ControllerBackupPublicKey)
+		if err != nil {
+			return err
+		}
+		// A retry may reuse, never rewrite, the initial receipt. All bindings
+		// except the time spent re-verifying must still agree byte-for-byte.
+		expected.VerifiedUTC = initial.VerifiedUTC
+		expected.CapturedUTC = expected.CapturedUTC.UTC()
+		initial.CapturedUTC = initial.CapturedUTC.UTC()
+		left, leftErr := json.Marshal(initial)
+		right, rightErr := json.Marshal(expected)
+		if leftErr != nil || rightErr != nil || !bytes.Equal(left, right) {
+			return errors.New("controller backup evidence changed during preparation retry")
+		}
+		return validateControllerBackupFreshness(initial, now)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	// Never expose a partially written initial receipt at its immutable name.
+	// Unique failed temporary files remain as evidence; a later retry uses a
+	// new temporary path rather than overwriting or trusting partial bytes.
+	file, err := os.CreateTemp(filepath.Dir(name), ".controller-receipt.partial-*")
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.Write(encoded)
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if err := errors.Join(writeErr, syncErr, closeErr); err != nil {
+		return err
+	}
+	if err := os.Link(file.Name(), name); err != nil {
+		return err
+	}
+	if err := os.Remove(file.Name()); err != nil {
+		return err
+	}
+	return syncDirectory(filepath.Dir(name))
+}
+
+func (runtime *productionReleaseRuntime) reverifyControllerOnlyBackup(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState, identity string) error {
+	if plan.Format != productionReleasePlanFormat || plan.BackupMode != "controller-only" || !plan.WithBackups || state.ControllerBackup != plan.ControllerBackupDir || !productionSHA256Pattern.MatchString(state.ControllerReceiptSHA256) {
+		return errors.New("controller-only confirmation lacks selected immutable evidence")
+	}
+	localInitial := filepath.Join(plan.ControllerWorkspace, "state", controllerBackupReceiptName)
+	initial, err := readControllerBackupReceipt(localInitial, plan.ControllerBackupPublicKey, state.ControllerReceiptSHA256, uint32(os.Geteuid()))
+	if err != nil {
+		return err
+	}
+	verification := &productionRuntime{runner: runtime.runner, now: runtime.now, effectiveUID: os.Geteuid}
+	set, setSHA, err := verification.verifyControllerBackupSet(ctx, plan, plan.ControllerBackupDir, identity)
+	if err != nil {
+		return err
+	}
+	manifest, manifestSHA, err := runtime.readControllerBackupRemoteManifest(ctx, plan, state, initial)
+	if err != nil {
+		return err
+	}
+	encoded, err := signedControllerBackupReceipt(plan, set, setSHA, state.PlanSHA256, "confirm", manifestSHA, runtime.now())
+	if err != nil {
+		return err
+	}
+	confirmation, err := decodeSignedControllerBackupReceipt(encoded, plan.ControllerBackupPublicKey)
+	if err != nil {
+		return err
+	}
+	if !sameControllerBackupSnapshot(initial, confirmation) {
+		return errors.New("confirmation cannot replace the original backup snapshot")
+	}
+	if err := matchControllerBackupReceipt(confirmation, manifest); err != nil {
+		return err
+	}
+	local := filepath.Join(plan.ControllerWorkspace, "state", controllerBackupConfirmationName)
+	if err := writeAtomicRegularFile(local, encoded, 0o600); err != nil {
+		return err
+	}
+	return runtime.stageControllerReceipt(ctx, plan, state, local, controllerBackupDigest(encoded), true)
+}
+
+func (runtime *productionReleaseRuntime) readControllerBackupRemoteManifest(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState, initial controllerBackupReceipt) (productionManifest, string, error) {
+	var manifest productionManifest
+	remote := filepath.Join(state.RemoteWorkspace, "state", productionManifestFilename)
+	digest, err := runtime.remoteFileSHA256(ctx, plan.TargetAlias, remote)
+	if err != nil {
+		return manifest, "", err
+	}
+	data, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "head", "-c", "1048577", "--", remote)
+	if err != nil || len(data) > 1<<20 || controllerBackupDigest(data) != digest || decodeControllerBackupJSON(data, &manifest) != nil {
+		return manifest, "", errors.New("remote deployment manifest could not be verified")
+	}
+	workspace := productionWorkspace{id: plan.DeploymentID, stateDir: filepath.Join(state.RemoteWorkspace, "state")}
+	if err := validateControllerBackupBinding(workspace, manifest); err != nil {
+		return manifest, "", err
+	}
+	binding := manifest.ControllerOnlyBackup
+	if manifest.Format != productionTransactionFormat || initial.Purpose != "prepare" || initial.PlanSHA256 != state.PlanSHA256 || binding.PublicKey != plan.ControllerBackupPublicKey || binding.ReceiptSHA256 != state.ControllerReceiptSHA256 {
+		return manifest, "", errors.New("remote manifest changed the frozen controller backup binding")
+	}
+	if err := matchControllerBackupReceipt(initial, manifest); err != nil {
+		return manifest, "", err
+	}
+	return manifest, digest, nil
+}
+
+func validateControllerOnlyBackupState(plan productionReleasePlan, state productionReleaseControllerState) error {
+	if plan.Format == 5 {
+		if state.ControllerReceiptSHA256 != "" {
+			return errors.New("legacy controller state cannot contain controller-only receipts")
+		}
+		return nil
+	}
+	if !plan.WithBackups {
+		if state.ControllerBackup != "" || state.ControllerReceiptSHA256 != "" || state.TargetBackup != "" || state.OffhostBackup != "" || state.Phase == productionReleasePhaseBackupsReady {
+			return errors.New("disabled backup plan cannot contain backup state")
+		}
+		return nil
+	}
+	if state.TargetBackup != "" || state.OffhostBackup != "" {
+		return errors.New("controller-only plans forbid target or off-host backup paths")
+	}
+	ready := state.ControllerBackup != "" || state.ControllerReceiptSHA256 != ""
+	if ready && (state.ControllerBackup != plan.ControllerBackupDir || !productionSHA256Pattern.MatchString(state.ControllerReceiptSHA256)) {
+		return errors.New("controller-only backup state is incomplete or differs from the plan")
+	}
+	if (state.DispatchAttempts > 0 || state.Phase == productionReleasePhaseBackupsReady || (state.Phase != productionReleasePhaseWorkspaceCreated && state.Phase != productionReleasePhaseStaged && state.Phase != "ABORTED")) && !ready {
+		return errors.New("controller-only activation requires prepared receipt evidence")
+	}
+	return nil
+}

--- a/apps/api-go/internal/appcli/deploy_production_controller_import.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller_import.go
@@ -1,0 +1,548 @@
+package appcli
+
+import (
+	"archive/tar"
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"time"
+
+	"github.com/shirou/gopsutil/disk"
+)
+
+// These limits bound scratch disk, decompression work and inventory memory.
+// age itself does not compress: a plaintext cannot exceed its ciphertext size.
+const (
+	controllerBackupMaxArchive = int64(2 << 30)
+	controllerBackupMaxTar     = int64(4 << 30)
+	controllerBackupHeadroom   = uint64(1 << 30)
+	controllerBackupMaxEntries = 100000
+)
+
+type controllerBackupArchive struct {
+	CiphertextSHA256 string `json:"ciphertext_sha256"`
+	PlaintextSHA256  string `json:"plaintext_sha256"`
+	CiphertextBytes  int64  `json:"ciphertext_bytes"`
+	PlaintextBytes   int64  `json:"plaintext_bytes"`
+}
+
+type controllerBackupSet struct {
+	Format                  int                                `json:"format"`
+	DeploymentID            string                             `json:"deployment_id"`
+	ExpectedHost            string                             `json:"expected_host"`
+	CapturedUTC             time.Time                          `json:"captured_utc"`
+	DatabaseSchema          string                             `json:"database_schema"`
+	EnvironmentSHA256       string                             `json:"environment_sha256"`
+	GoRollbackSHA256        string                             `json:"go_rollback_sha256"`
+	WebRollbackSHA256       string                             `json:"web_rollback_sha256"`
+	GoRollbackPayloadSHA256 string                             `json:"go_rollback_payload_sha256"`
+	FrontendRollbackSHA256  string                             `json:"frontend_rollback_sha256"`
+	Archives                map[string]controllerBackupArchive `json:"archives"`
+}
+
+// verifyControllerBackupSet imports evidence only. It never creates a source
+// backup or invokes transport/target commands. Errors deliberately omit paths,
+// archive member names, configuration values and subprocess diagnostics.
+func (runtime *productionRuntime) verifyControllerBackupSet(ctx context.Context, plan productionReleasePlan, root, identity string) (set controllerBackupSet, digest string, err error) {
+	fail := func() (controllerBackupSet, string, error) {
+		return controllerBackupSet{}, "", errors.New("controller backup import verification failed")
+	}
+	if runtime.runner == nil || ctx.Err() != nil || !productionIDPattern.MatchString(plan.DeploymentID) || plan.ExpectedHost != productionExpectedHost {
+		return fail()
+	}
+	uid := os.Geteuid()
+	if runtime.effectiveUID != nil {
+		uid = runtime.effectiveUID()
+	}
+	if err = controllerBackupInventory(root, uid); err != nil {
+		return fail()
+	}
+	manifest, err := controllerBackupReadPrivate(filepath.Join(root, "backup-set.json"), uid, 64<<10)
+	if err != nil || decodeControllerBackupJSON(manifest, &set) != nil {
+		return fail()
+	}
+	digest = controllerBackupDigest(manifest)
+	complete, err := controllerBackupReadPrivate(filepath.Join(root, ".complete"), uid, 65)
+	if err != nil || string(complete) != digest+"\n" {
+		return fail()
+	}
+	now := time.Now()
+	if runtime.now != nil {
+		now = runtime.now()
+	}
+	if controllerBackupValidateSet(set, plan, now) != nil || controllerBackupValidateWorkspace(plan, uid) != nil {
+		return fail()
+	}
+	key, err := controllerBackupOpenPrivate(identity, uid)
+	if err != nil {
+		return fail()
+	}
+	if err = key.Close(); err != nil {
+		return fail()
+	}
+	temporaryRoot := filepath.Join(plan.ControllerWorkspace, "tmp")
+	if controllerBackupDirectory(temporaryRoot, uid) != nil {
+		return fail()
+	}
+	scratch, err := os.MkdirTemp(temporaryRoot, "controller-backup-verify-")
+	if err != nil {
+		return fail()
+	}
+	defer func() {
+		if cleanupErr := os.RemoveAll(scratch); cleanupErr != nil {
+			set, digest, err = controllerBackupSet{}, "", errors.New("controller backup plaintext cleanup failed")
+		}
+	}()
+	for _, kind := range controllerBackupKinds {
+		if ctx.Err() != nil || runtime.controllerBackupVerifyArchive(ctx, root, identity, scratch, kind, set, uid) != nil {
+			return fail()
+		}
+	}
+	// Catch collection replacement/tampering while expensive verification ran.
+	if controllerBackupInventory(root, uid) != nil {
+		return fail()
+	}
+	again, readErr := controllerBackupReadPrivate(filepath.Join(root, "backup-set.json"), uid, 64<<10)
+	complete, completeErr := controllerBackupReadPrivate(filepath.Join(root, ".complete"), uid, 65)
+	if readErr != nil || completeErr != nil || !bytes.Equal(again, manifest) || string(complete) != digest+"\n" {
+		return fail()
+	}
+	for _, kind := range controllerBackupKinds {
+		archive := set.Archives[kind]
+		if controllerBackupVerifyFile(filepath.Join(root, kind+".age"), uid, archive.CiphertextBytes, archive.CiphertextSHA256) != nil {
+			return fail()
+		}
+	}
+	return set, digest, nil
+}
+
+func controllerBackupValidateSet(set controllerBackupSet, plan productionReleasePlan, now time.Time) error {
+	_, offset := set.CapturedUTC.Zone()
+	if set.Format != 1 || set.DeploymentID != plan.DeploymentID || set.ExpectedHost != plan.ExpectedHost ||
+		set.CapturedUTC.IsZero() || offset != 0 || set.CapturedUTC.After(now.Add(30*time.Second)) || set.CapturedUTC.Before(now.Add(-24*time.Hour)) ||
+		!isDatabaseSchema(set.DatabaseSchema) || len(set.Archives) != len(controllerBackupKinds) {
+		return errors.New("invalid controller backup collection identity or capture time")
+	}
+	bindings := [][2]string{
+		{set.GoRollbackSHA256, plan.GoRollback.PackageSHA256},
+		{set.WebRollbackSHA256, plan.WebRollback.PackageSHA256},
+		{set.GoRollbackPayloadSHA256, plan.GoRollback.PayloadSHA256},
+		{set.FrontendRollbackSHA256, plan.WebRollback.PayloadSHA256},
+	}
+	for _, binding := range bindings {
+		if !productionSHA256Pattern.MatchString(binding[0]) || binding[0] != binding[1] {
+			return errors.New("controller backup rollback binding mismatch")
+		}
+	}
+	if !productionSHA256Pattern.MatchString(set.EnvironmentSHA256) {
+		return errors.New("invalid controller backup configuration digest")
+	}
+	for _, kind := range controllerBackupKinds {
+		archive, ok := set.Archives[kind]
+		if !ok || !productionSHA256Pattern.MatchString(archive.CiphertextSHA256) || !productionSHA256Pattern.MatchString(archive.PlaintextSHA256) ||
+			archive.CiphertextBytes <= 0 || archive.CiphertextBytes > controllerBackupMaxArchive ||
+			archive.PlaintextBytes <= 0 || archive.PlaintextBytes > archive.CiphertextBytes {
+			return errors.New("invalid controller backup archive declaration")
+		}
+	}
+	return nil
+}
+
+// Check every component, not just the leaf: EvalSymlinks alone permits aliases
+// that happen to resolve back to the same textual path.
+func controllerBackupNoLinks(name string) error {
+	if !filepath.IsAbs(name) || filepath.Clean(name) != name || name == string(filepath.Separator) {
+		return errors.New("controller backup path must be canonical and absolute")
+	}
+	current := string(filepath.Separator)
+	parts := strings.Split(strings.TrimPrefix(name, current), string(filepath.Separator))
+	for i, component := range parts {
+		current = filepath.Join(current, component)
+		info, err := os.Lstat(current)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 || (i < len(parts)-1 && !info.IsDir()) {
+			return errors.New("controller backup path has an unsafe component")
+		}
+	}
+	return nil
+}
+
+func controllerBackupDirectory(name string, uid int) error {
+	if controllerBackupNoLinks(name) != nil {
+		return errors.New("unsafe controller backup directory path")
+	}
+	info, err := os.Lstat(name)
+	if err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 || info.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		return errors.New("controller backup directory must be private")
+	}
+	owner, _, ok := deploymentFileOwnership(info)
+	if !ok || int(owner) != uid {
+		return errors.New("controller backup directory owner mismatch")
+	}
+	return nil
+}
+
+func controllerBackupOpenPrivate(name string, uid int) (*os.File, error) {
+	if controllerBackupNoLinks(name) != nil {
+		return nil, errors.New("unsafe controller backup file path")
+	}
+	before, err := os.Lstat(name)
+	if err != nil || !before.Mode().IsRegular() || before.Mode().Perm() != 0o600 || before.Size() <= 0 || before.Mode()&(os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 {
+		return nil, errors.New("controller backup file must be private and nonempty")
+	}
+	owner, links, ok := deploymentFileOwnership(before)
+	if !ok || int(owner) != uid || links != 1 {
+		return nil, errors.New("controller backup file ownership or link count mismatch")
+	}
+	file, err := os.Open(name)
+	if err != nil {
+		return nil, errors.New("cannot open controller backup file")
+	}
+	after, err := file.Stat()
+	if err != nil || !os.SameFile(before, after) || controllerBackupNoLinks(name) != nil {
+		_ = file.Close()
+		return nil, errors.New("controller backup file changed during open")
+	}
+	return file, nil
+}
+
+func controllerBackupReadPrivate(name string, uid int, limit int64) ([]byte, error) {
+	file, err := controllerBackupOpenPrivate(name, uid)
+	if err != nil {
+		return nil, err
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, limit+1))
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil || int64(len(data)) > limit {
+		return nil, errors.New("controller backup metadata read failed or exceeds limit")
+	}
+	return data, nil
+}
+
+func controllerBackupInventory(root string, uid int) error {
+	if controllerBackupDirectory(root, uid) != nil {
+		return errors.New("unsafe controller backup inventory root")
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil || len(entries) != 6 {
+		return errors.New("controller backup inventory must have exactly six members")
+	}
+	allowed := map[string]bool{"backup-set.json": true, ".complete": true}
+	for _, kind := range controllerBackupKinds {
+		allowed[kind+".age"] = true
+	}
+	for _, entry := range entries {
+		if !allowed[entry.Name()] {
+			return errors.New("unexpected controller backup inventory member")
+		}
+		file, err := controllerBackupOpenPrivate(filepath.Join(root, entry.Name()), uid)
+		if err != nil {
+			return err
+		}
+		if err := file.Close(); err != nil {
+			return errors.New("controller backup inventory close failed")
+		}
+	}
+	return nil
+}
+
+func controllerBackupValidateWorkspace(plan productionReleasePlan, uid int) error {
+	if controllerBackupDirectory(plan.ControllerWorkspace, uid) != nil {
+		return errors.New("unsafe controller backup verification workspace")
+	}
+	marker, err := controllerBackupReadPrivate(filepath.Join(plan.ControllerWorkspace, productionWorkspaceMarker), uid, 16<<10)
+	if err != nil {
+		return err
+	}
+	values, err := parseSimpleManifest(marker)
+	if err != nil || values["deployment_id"] != plan.DeploymentID {
+		return errors.New("controller backup workspace transaction mismatch")
+	}
+	return nil
+}
+
+func controllerBackupCheckSpace(root string, ciphertextBytes int64) error {
+	// gopsutil's Linux Usage uses statfs, not a shell/df process. Import is
+	// deliberately unavailable on other OSes rather than taking a fallback.
+	if goruntime.GOOS != "linux" || ciphertextBytes <= 0 || ciphertextBytes > controllerBackupMaxArchive {
+		return errors.New("controller backup scratch budget unsupported")
+	}
+	usage, err := disk.Usage(root)
+	// Btrfs reports zero total/free inodes because it allocates them dynamically;
+	// apply the inode reserve only to filesystems with a finite reported pool.
+	needed := uint64(ciphertextBytes)*2 + controllerBackupHeadroom
+	if err != nil || usage.Total == 0 || usage.Free < needed || usage.UsedPercent >= 80 ||
+		(usage.InodesTotal > 0 && (usage.InodesFree < 16 || usage.InodesUsedPercent >= 80)) || float64(usage.Free-needed) < float64(usage.Total)*0.20 {
+		return errors.New("insufficient controller backup scratch disk or inode budget")
+	}
+	return nil
+}
+
+func controllerBackupDigest(data []byte) string {
+	digest := sha256.Sum256(data)
+	return hex.EncodeToString(digest[:])
+}
+
+func controllerBackupCopyVerified(name string, uid int, length int64, digest string, destination io.Writer) error {
+	file, err := controllerBackupOpenPrivate(name, uid)
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	count, copyErr := io.Copy(io.MultiWriter(destination, hash), io.LimitReader(file, length+1))
+	closeErr := file.Close()
+	if copyErr != nil || closeErr != nil || count != length || hex.EncodeToString(hash.Sum(nil)) != digest {
+		return errors.New("controller backup byte length or digest mismatch")
+	}
+	return nil
+}
+
+func controllerBackupVerifyFile(name string, uid int, length int64, digest string) error {
+	return controllerBackupCopyVerified(name, uid, length, digest, io.Discard)
+}
+
+func (runtime *productionRuntime) controllerBackupVerifyArchive(ctx context.Context, root, identity, scratch, kind string, set controllerBackupSet, uid int) error {
+	archive := set.Archives[kind]
+	if controllerBackupCheckSpace(scratch, archive.CiphertextBytes) != nil {
+		return errors.New("controller backup scratch budget rejected")
+	}
+	// Decrypt a checked, private snapshot instead of reopening mutable imported
+	// ciphertext in age. At most one ciphertext and one plaintext coexist.
+	cipherPath, plainPath := filepath.Join(scratch, "ciphertext.age"), filepath.Join(scratch, "plaintext")
+	cipher, err := os.OpenFile(cipherPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return errors.New("cannot create controller backup scratch ciphertext")
+	}
+	copyErr := controllerBackupCopyVerified(filepath.Join(root, kind+".age"), uid, archive.CiphertextBytes, archive.CiphertextSHA256, cipher)
+	closeErr := cipher.Close()
+	if copyErr != nil || closeErr != nil {
+		return errors.New("controller backup ciphertext verification failed")
+	}
+	// Claim output privately instead of depending on the caller's umask.
+	plain, err := os.OpenFile(plainPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return errors.New("cannot create private controller backup plaintext")
+	}
+	if err := plain.Close(); err != nil {
+		return errors.New("cannot close private controller backup plaintext")
+	}
+	if _, err := runtime.runner.Run(ctx, productionCommand{Name: commandAge,
+		Args: []string{"--decrypt", "--identity", identity, "--output", plainPath, cipherPath},
+		Dir:  scratch, Env: []string{"PATH=/usr/bin:/bin", "LC_ALL=C", "TMPDIR=" + scratch}, Timeout: 10 * time.Minute, Sensitive: true}); err != nil {
+		return errors.New("controller backup age authentication failed")
+	}
+	if controllerBackupVerifyFile(plainPath, uid, archive.PlaintextBytes, archive.PlaintextSHA256) != nil {
+		return errors.New("controller backup plaintext verification failed")
+	}
+	if kind == "database" {
+		if err := runtime.controllerBackupVerifyDatabase(ctx, plainPath, scratch, uid); err != nil {
+			return err
+		}
+	} else if controllerBackupVerifyTar(plainPath, kind, set, uid) != nil {
+		return errors.New("controller backup archive verification failed")
+	}
+	// The subprocess must not have altered its input while validating it.
+	if ctx.Err() != nil || controllerBackupVerifyFile(plainPath, uid, archive.PlaintextBytes, archive.PlaintextSHA256) != nil {
+		return errors.New("controller backup plaintext changed during validation")
+	}
+	if err := os.Remove(plainPath); err != nil {
+		return errors.New("controller backup plaintext removal failed")
+	}
+	if err := os.Remove(cipherPath); err != nil {
+		return errors.New("controller backup scratch ciphertext removal failed")
+	}
+	return nil
+}
+
+func (runtime *productionRuntime) controllerBackupVerifyDatabase(ctx context.Context, name, scratch string, uid int) error {
+	file, err := controllerBackupOpenPrivate(name, uid)
+	if err != nil {
+		return err
+	}
+	magic := make([]byte, 5)
+	_, readErr := io.ReadFull(file, magic)
+	closeErr := file.Close()
+	if readErr != nil || closeErr != nil || string(magic) != "PGDMP" {
+		return errors.New("controller backup database is not a custom PostgreSQL archive")
+	}
+	_, err = runtime.runner.Run(ctx, productionCommand{Name: commandPGRestore,
+		Args: []string{"--format=custom", "--file=/dev/null", name}, Dir: scratch,
+		Env: []string{"PATH=/usr/bin:/bin", "LC_ALL=C", "TMPDIR=" + scratch}, Timeout: 30 * time.Minute, Sensitive: true})
+	if err != nil {
+		return errors.New("controller backup full PostgreSQL archive validation failed")
+	}
+	return nil
+}
+
+type controllerBackupCountingReader struct {
+	reader io.Reader
+	count  int64
+}
+
+func (reader *controllerBackupCountingReader) Read(data []byte) (int, error) {
+	n, err := reader.reader.Read(data)
+	reader.count += int64(n)
+	return n, err
+}
+
+func controllerBackupVerifyTar(name, kind string, set controllerBackupSet, uid int) (err error) {
+	file, err := controllerBackupOpenPrivate(name, uid)
+	if err != nil {
+		return err
+	}
+	defer func() { err = errors.Join(err, file.Close()) }()
+	buffer := bufio.NewReader(file)
+	magic, err := buffer.Peek(2)
+	if err != nil {
+		return errors.New("controller backup tar is truncated")
+	}
+	var source io.Reader = buffer
+	if magic[0] == 0x1f && magic[1] == 0x8b {
+		compressed, err := gzip.NewReader(buffer)
+		if err != nil {
+			return errors.New("controller backup gzip header is invalid")
+		}
+		defer func() { err = errors.Join(err, compressed.Close()) }()
+		source = compressed
+	}
+	counted := &controllerBackupCountingReader{reader: io.LimitReader(source, controllerBackupMaxTar+1)}
+	reader := tar.NewReader(counted)
+	required, expected := "", ""
+	switch kind {
+	case "application":
+		required, expected = "usr/bin/lmm-api-go", set.GoRollbackPayloadSHA256
+	case "frontend":
+		required, expected = "index.html", set.FrontendRollbackSHA256
+	case "configuration":
+		required, expected = "etc/lmm-api-go/lmm-api-go.env", set.EnvironmentSHA256
+	default:
+		return errors.New("unknown controller backup tar kind")
+	}
+	seen := make(map[string]byte)
+	parents := make(map[string]bool)
+	found, padding := false, int64(0)
+	for {
+		before := counted.count
+		header, nextErr := reader.Next()
+		if errors.Is(nextErr, io.EOF) {
+			// archive/tar also returns EOF without the two required zero blocks.
+			if counted.count-before < padding+1024 {
+				return errors.New("controller backup tar end marker is missing")
+			}
+			break
+		}
+		if nextErr != nil || counted.count > controllerBackupMaxTar || len(seen) >= controllerBackupMaxEntries {
+			return errors.New("controller backup tar is invalid or exceeds limits")
+		}
+		entry := header.Name
+		if header.Typeflag == tar.TypeDir {
+			entry = strings.TrimSuffix(entry, "/")
+		}
+		if entry == "" || entry == "." || path.IsAbs(entry) || path.Clean(entry) != entry || entry == ".." || strings.HasPrefix(entry, "../") ||
+			strings.ContainsAny(entry, "\\\x00\r\n") || len(entry) > 1024 || header.Linkname != "" || len(header.PAXRecords) != 0 ||
+			(header.Typeflag != tar.TypeReg && header.Typeflag != tar.TypeDir) || header.Size < 0 || header.Size > controllerBackupMaxArchive {
+			return errors.New("controller backup tar member is unsafe")
+		}
+		if _, exists := seen[entry]; exists {
+			return errors.New("controller backup tar contains duplicate members")
+		}
+		// A regular ancestor would make the archive impossible to restore.
+		if header.Typeflag == tar.TypeReg && parents[entry] {
+			return errors.New("controller backup tar replaces an ancestor with a file")
+		}
+		for parent := path.Dir(entry); parent != "."; parent = path.Dir(parent) {
+			if prior, exists := seen[parent]; exists && prior != tar.TypeDir {
+				return errors.New("controller backup tar has a non-directory ancestor")
+			}
+			parents[parent] = true
+		}
+		seen[entry] = header.Typeflag
+		padding = (512 - header.Size%512) % 512
+		if header.Typeflag == tar.TypeDir {
+			if header.Size != 0 || entry == required {
+				return errors.New("controller backup required member is not a regular file")
+			}
+			continue
+		}
+		if entry == required {
+			if header.Size <= 0 {
+				return errors.New("controller backup required member is empty")
+			}
+			hash := sha256.New()
+			var environment bytes.Buffer
+			var writer io.Writer = hash
+			if kind == "configuration" {
+				if header.Size > 1<<20 {
+					return errors.New("controller backup configuration exceeds limit")
+				}
+				writer = io.MultiWriter(hash, &environment)
+			}
+			if _, err := io.Copy(writer, reader); err != nil || hex.EncodeToString(hash.Sum(nil)) != expected {
+				return errors.New("controller backup required member digest mismatch")
+			}
+			if kind == "configuration" && controllerBackupValidateEnvironment(environment.Bytes()) != nil {
+				return errors.New("controller backup configuration authority is invalid")
+			}
+			found = true
+		} else if _, err := io.Copy(io.Discard, reader); err != nil {
+			return errors.New("controller backup tar member is truncated")
+		}
+	}
+	// Read all compressed bytes through the gzip trailer/EOF, not just tar EOF.
+	// Only zero tar record padding may follow the end marker.
+	var trailing [32 << 10]byte
+	for {
+		n, readErr := counted.Read(trailing[:])
+		if counted.count > controllerBackupMaxTar || !controllerBackupAllZero(trailing[:n]) {
+			return errors.New("controller backup tar trailing data is invalid")
+		}
+		if errors.Is(readErr, io.EOF) {
+			break
+		}
+		if readErr != nil {
+			return errors.New("controller backup compressed stream failed full validation")
+		}
+	}
+	if !found || counted.count%512 != 0 {
+		return errors.New("controller backup tar is incomplete")
+	}
+	return nil
+}
+
+func controllerBackupAllZero(data []byte) bool {
+	for _, value := range data {
+		if value != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func controllerBackupValidateEnvironment(data []byte) error {
+	values, err := parseProductionEnvironment(data)
+	if err != nil {
+		return errors.New("invalid controller backup environment syntax")
+	}
+	databaseURL, err := productionDatabaseURL(values)
+	if err != nil {
+		return errors.New("invalid controller backup PostgreSQL authority")
+	}
+	parsed, err := url.Parse(databaseURL)
+	if err != nil || parsed.Hostname() == "" || parsed.Path == "" || parsed.Path == "/" || parsed.Fragment != "" {
+		return errors.New("invalid controller backup PostgreSQL URL")
+	}
+	if _, err := url.ParseQuery(parsed.RawQuery); err != nil {
+		return errors.New("invalid controller backup PostgreSQL parameters")
+	}
+	return nil
+}

--- a/apps/api-go/internal/appcli/deploy_production_controller_import_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller_import_test.go
@@ -1,0 +1,566 @@
+//go:build linux
+
+package appcli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// These are bounded format fixtures, not real encrypted/database backups.
+// Cryptographic EOF and PostgreSQL parser failures are modeled by the runner;
+// archive traversal, metadata, digests and cleanup use real local files.
+type controllerImportRunner struct {
+	t             *testing.T
+	plain         map[string][]byte
+	calls         []productionCommand
+	ageFailure    bool
+	pgFailure     bool
+	ageWrongBytes bool
+	afterPG       func()
+}
+
+func (runner *controllerImportRunner) Run(ctx context.Context, command productionCommand) ([]byte, error) {
+	runner.t.Helper()
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	runner.calls = append(runner.calls, command)
+	if !command.Sensitive || command.Timeout <= 0 || command.Dir == "" {
+		runner.t.Fatal("import command is not private, bounded and workspace-local")
+	}
+	for _, env := range command.Env {
+		if strings.HasPrefix(env, "PG") || strings.Contains(env, "secret") {
+			runner.t.Fatal("import command inherited PostgreSQL authority or secrets")
+		}
+	}
+	switch command.Name {
+	case commandAge:
+		if len(command.Args) != 6 || !reflect.DeepEqual(command.Args[:2], []string{"--decrypt", "--identity"}) || command.Args[3] != "--output" {
+			runner.t.Fatalf("unexpected age arguments: %#v", command.Args)
+		}
+		return runner.decryptFixture(command)
+	case commandPGRestore:
+		if len(command.Args) != 3 || command.Args[0] != "--format=custom" || command.Args[1] != "--file=/dev/null" {
+			runner.t.Fatal("PostgreSQL import must read the full archive without database access")
+		}
+		if runner.afterPG != nil {
+			runner.afterPG()
+		}
+		if runner.pgFailure {
+			return nil, errors.New("private PostgreSQL diagnostic secret-password")
+		}
+		return nil, nil
+	default:
+		runner.t.Fatalf("forbidden import subprocess %q", command.Name)
+		return nil, errors.New("forbidden command")
+	}
+}
+
+// Separate the age fixture implementation to make output/EOF failure paths
+// explicit without invoking age, PostgreSQL, SSH, tar or any other process.
+func (runner *controllerImportRunner) decryptFixture(command productionCommand) ([]byte, error) {
+	cipher, err := os.ReadFile(command.Args[5])
+	if err != nil {
+		return nil, err
+	}
+	plain, ok := runner.plain[controllerBackupDigest(cipher)]
+	if !ok {
+		runner.t.Fatal("age received unchecked or unexpected ciphertext")
+	}
+	info, err := os.Stat(command.Args[4])
+	if err != nil || info.Mode().Perm() != 0o600 {
+		runner.t.Fatal("plaintext output was not preclaimed privately")
+	}
+	if runner.ageWrongBytes {
+		plain = append(append([]byte(nil), plain...), '!')
+	}
+	if err := os.WriteFile(command.Args[4], plain, 0o600); err != nil {
+		return nil, err
+	}
+	if runner.ageFailure {
+		return nil, errors.New("private age diagnostic secret-identity")
+	}
+	return nil, nil
+}
+
+type controllerImportFixture struct {
+	t        *testing.T
+	root     string
+	identity string
+	plan     productionReleasePlan
+	set      controllerBackupSet
+	runner   *controllerImportRunner
+	runtime  *productionRuntime
+}
+
+func newControllerImportFixture(t *testing.T) *controllerImportFixture {
+	t.Helper()
+	base := t.TempDir()
+	root, workspace := filepath.Join(base, "collection"), filepath.Join(base, "workspace")
+	for _, dir := range []string{root, workspace, filepath.Join(workspace, "tmp")} {
+		if err := os.Mkdir(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fixture := &controllerImportFixture{t: t, root: root, identity: filepath.Join(base, "identity")}
+	fixture.write(fixture.identity, []byte("fixture-private-age-identity"))
+	now := time.Date(2026, 9, 7, 10, 0, 0, 0, time.UTC)
+	application, frontend := []byte("fixture-go-provider"), []byte("<!doctype html><title>N-1</title>")
+	environment := []byte("DATABASE_URL=postgresql://user:secret@127.0.0.1:5432/production\nGIN_MODE=release\n")
+	fixture.plan = productionReleasePlan{DeploymentID: "controller-import-test", ExpectedHost: productionExpectedHost, ControllerWorkspace: workspace,
+		GoRollback:  productionReleasePackagePlan{PackageSHA256: controllerBackupDigest([]byte("go package")), PayloadSHA256: controllerBackupDigest(application)},
+		WebRollback: productionReleasePackagePlan{PackageSHA256: controllerBackupDigest([]byte("web package")), PayloadSHA256: controllerBackupDigest(frontend)}}
+	fixture.set = controllerBackupSet{Format: 1, DeploymentID: fixture.plan.DeploymentID, ExpectedHost: fixture.plan.ExpectedHost, CapturedUTC: now,
+		DatabaseSchema: "public", EnvironmentSHA256: controllerBackupDigest(environment),
+		GoRollbackSHA256: fixture.plan.GoRollback.PackageSHA256, WebRollbackSHA256: fixture.plan.WebRollback.PackageSHA256,
+		GoRollbackPayloadSHA256: fixture.plan.GoRollback.PayloadSHA256, FrontendRollbackSHA256: fixture.plan.WebRollback.PayloadSHA256,
+		Archives: make(map[string]controllerBackupArchive)}
+	fixture.write(filepath.Join(workspace, productionWorkspaceMarker), []byte("format=1\ndeployment_id="+fixture.plan.DeploymentID+"\nrole=controller\n"))
+	fixture.runner = &controllerImportRunner{t: t, plain: make(map[string][]byte)}
+	fixture.runtime = &productionRuntime{runner: fixture.runner, now: func() time.Time { return now }, effectiveUID: os.Geteuid}
+	fixture.archive("application", controllerImportTar(t, []controllerImportTarMember{{name: "usr/bin/lmm-api-go", data: application}}))
+	fixture.archive("frontend", controllerImportGzip(t, controllerImportTar(t, []controllerImportTarMember{{name: "index.html", data: frontend}})))
+	fixture.archive("configuration", controllerImportTar(t, []controllerImportTarMember{{name: "etc/lmm-api-go/lmm-api-go.env", data: environment}}))
+	fixture.archive("database", []byte("PGDMP-fixture-full-custom-archive"))
+	fixture.manifest(nil)
+	return fixture
+}
+
+func (fixture *controllerImportFixture) write(name string, data []byte) {
+	fixture.t.Helper()
+	if err := os.WriteFile(name, data, 0o600); err != nil {
+		fixture.t.Fatal(err)
+	}
+}
+
+func (fixture *controllerImportFixture) archive(kind string, plain []byte) {
+	fixture.t.Helper()
+	// Synthetic cipher is deliberately larger than plaintext, as real age is.
+	cipher := append([]byte("fixture-ciphertext-"+kind+strings.Repeat("!", 128)), plain...)
+	fixture.set.Archives[kind] = controllerBackupArchive{CiphertextSHA256: controllerBackupDigest(cipher), PlaintextSHA256: controllerBackupDigest(plain),
+		CiphertextBytes: int64(len(cipher)), PlaintextBytes: int64(len(plain))}
+	fixture.runner.plain[controllerBackupDigest(cipher)] = plain
+	fixture.write(filepath.Join(fixture.root, kind+".age"), cipher)
+}
+
+func (fixture *controllerImportFixture) manifest(change func([]byte) []byte) {
+	fixture.t.Helper()
+	data, err := json.Marshal(fixture.set)
+	if err != nil {
+		fixture.t.Fatal(err)
+	}
+	if change != nil {
+		data = change(data)
+	}
+	fixture.write(filepath.Join(fixture.root, "backup-set.json"), data)
+	fixture.write(filepath.Join(fixture.root, ".complete"), []byte(controllerBackupDigest(data)+"\n"))
+}
+
+func (fixture *controllerImportFixture) verify() (controllerBackupSet, string, error) {
+	fixture.t.Helper()
+	set, digest, err := fixture.runtime.verifyControllerBackupSet(context.Background(), fixture.plan, fixture.root, fixture.identity)
+	entries, readErr := os.ReadDir(filepath.Join(fixture.plan.ControllerWorkspace, "tmp"))
+	if readErr != nil || len(entries) != 0 {
+		fixture.t.Fatalf("plaintext scratch survived verification: entries=%d err=%v", len(entries), readErr)
+	}
+	if err != nil && (digest != "" || set.Format != 0 || strings.Contains(err.Error(), "secret")) {
+		fixture.t.Fatal("failed verification leaked diagnostics or returned usable evidence")
+	}
+	return set, digest, err
+}
+
+type controllerImportTarMember struct {
+	name string
+	data []byte
+	kind byte
+	link string
+}
+
+func controllerImportTar(t *testing.T, members []controllerImportTarMember) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := tar.NewWriter(&buffer)
+	for _, member := range members {
+		kind := member.kind
+		if kind == 0 {
+			kind = tar.TypeReg
+		}
+		if err := writer.WriteHeader(&tar.Header{Name: member.name, Mode: 0o600, Typeflag: kind, Linkname: member.link, Size: int64(len(member.data))}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write(member.data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func controllerImportGzip(t *testing.T, plain []byte) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	writer := gzip.NewWriter(&buffer)
+	if _, err := writer.Write(plain); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buffer.Bytes()
+}
+
+func TestControllerBackupImportValidatesSequentiallyAndCleans(t *testing.T) {
+	fixture := newControllerImportFixture(t)
+	set, digest, err := fixture.verify()
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := os.ReadFile(filepath.Join(fixture.root, "backup-set.json"))
+	if err != nil || digest != controllerBackupDigest(manifest) || !reflect.DeepEqual(set, fixture.set) {
+		t.Fatal("import did not return exact verified collection and manifest digest")
+	}
+	if len(fixture.runner.calls) != 5 {
+		t.Fatalf("expected four age commands and one full pg_restore, got %d", len(fixture.runner.calls))
+	}
+	for index, command := range fixture.runner.calls {
+		expected := commandAge
+		if index == 4 {
+			expected = commandPGRestore
+		}
+		if command.Name != expected {
+			t.Fatal("verification command order is not sequential")
+		}
+	}
+	if err := controllerBackupInventory(fixture.root, os.Geteuid()); err != nil {
+		t.Fatal("successful import altered original inventory")
+	}
+}
+
+func TestControllerBackupImportRejectsStrictJSONAndMetadata(t *testing.T) {
+	cases := map[string]func(*controllerImportFixture){
+		"cross-deployment": func(f *controllerImportFixture) { f.set.DeploymentID = "another-deployment"; f.manifest(nil) },
+		"cross-host":       func(f *controllerImportFixture) { f.set.ExpectedHost = "archczy"; f.manifest(nil) },
+		"missing-schema":   func(f *controllerImportFixture) { f.set.DatabaseSchema = ""; f.manifest(nil) },
+		"reserved-schema":  func(f *controllerImportFixture) { f.set.DatabaseSchema = "pg_catalog"; f.manifest(nil) },
+		"unsafe-schema":    func(f *controllerImportFixture) { f.set.DatabaseSchema = "public;DROP"; f.manifest(nil) },
+		"future": func(f *controllerImportFixture) {
+			f.set.CapturedUTC = f.set.CapturedUTC.Add(31 * time.Second)
+			f.manifest(nil)
+		},
+		"stale": func(f *controllerImportFixture) {
+			f.set.CapturedUTC = f.set.CapturedUTC.Add(-24*time.Hour - time.Second)
+			f.manifest(nil)
+		},
+		"non-utc": func(f *controllerImportFixture) {
+			f.set.CapturedUTC = f.set.CapturedUTC.In(time.FixedZone("east", 3600))
+			f.manifest(nil)
+		},
+		"package-binding": func(f *controllerImportFixture) { f.set.GoRollbackSHA256 = f.set.WebRollbackSHA256; f.manifest(nil) },
+		"payload-binding": func(f *controllerImportFixture) {
+			f.set.GoRollbackPayloadSHA256 = f.set.FrontendRollbackSHA256
+			f.manifest(nil)
+		},
+		"index-binding": func(f *controllerImportFixture) {
+			f.set.FrontendRollbackSHA256 = f.set.GoRollbackPayloadSHA256
+			f.manifest(nil)
+		},
+		"uppercase-digest": func(f *controllerImportFixture) { f.set.EnvironmentSHA256 = strings.Repeat("A", 64); f.manifest(nil) },
+		"extra-archive": func(f *controllerImportFixture) {
+			f.set.Archives["extra"] = f.set.Archives["database"]
+			f.manifest(nil)
+		},
+		"missing-archive": func(f *controllerImportFixture) { delete(f.set.Archives, "database"); f.manifest(nil) },
+		"null-archive": func(f *controllerImportFixture) {
+			f.manifest(func(data []byte) []byte {
+				var values map[string]any
+				if err := json.Unmarshal(data, &values); err != nil {
+					t.Fatal(err)
+				}
+				values["archives"] = nil
+				result, err := json.Marshal(values)
+				if err != nil {
+					t.Fatal(err)
+				}
+				return result
+			})
+		},
+		"negative-length": func(f *controllerImportFixture) {
+			a := f.set.Archives["database"]
+			a.PlaintextBytes = -1
+			f.set.Archives["database"] = a
+			f.manifest(nil)
+		},
+		"excessive-length": func(f *controllerImportFixture) {
+			a := f.set.Archives["database"]
+			a.CiphertextBytes = controllerBackupMaxArchive + 1
+			f.set.Archives["database"] = a
+			f.manifest(nil)
+		},
+		"age-expansion": func(f *controllerImportFixture) {
+			a := f.set.Archives["database"]
+			a.PlaintextBytes = a.CiphertextBytes + 1
+			f.set.Archives["database"] = a
+			f.manifest(nil)
+		},
+		"duplicate-field": func(f *controllerImportFixture) {
+			f.manifest(func(data []byte) []byte { return append([]byte(`{"format":1,`), data[1:]...) })
+		},
+		"nested-duplicate": func(f *controllerImportFixture) {
+			f.manifest(func(data []byte) []byte {
+				return bytes.Replace(data, []byte(`"application":{`), []byte(`"application":{"ciphertext_bytes":1,`), 1)
+			})
+		},
+		"unknown-field": func(f *controllerImportFixture) {
+			f.manifest(func(data []byte) []byte { return append([]byte(`{"unknown":true,`), data[1:]...) })
+		},
+		"nested-unknown": func(f *controllerImportFixture) {
+			f.manifest(func(data []byte) []byte {
+				return bytes.Replace(data, []byte(`"application":{`), []byte(`"application":{"unknown":1,`), 1)
+			})
+		},
+		"wrong-case": func(f *controllerImportFixture) {
+			f.manifest(func(data []byte) []byte { return bytes.Replace(data, []byte(`"format"`), []byte(`"Format"`), 1) })
+		},
+		"second-value": func(f *controllerImportFixture) {
+			f.manifest(func(data []byte) []byte { return append(data, []byte(` {}`)...) })
+		},
+		"truncated-json": func(f *controllerImportFixture) { f.manifest(func(data []byte) []byte { return data[:len(data)-1] }) },
+		"bad-complete": func(f *controllerImportFixture) {
+			f.write(filepath.Join(f.root, ".complete"), []byte(strings.Repeat("0", 64)+"\n"))
+		},
+		"complete-no-newline": func(f *controllerImportFixture) {
+			data, err := os.ReadFile(filepath.Join(f.root, "backup-set.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			f.write(filepath.Join(f.root, ".complete"), []byte(controllerBackupDigest(data)))
+		},
+		"workspace-cross-id": func(f *controllerImportFixture) {
+			f.write(filepath.Join(f.plan.ControllerWorkspace, productionWorkspaceMarker), []byte("deployment_id=someone-else\n"))
+		},
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			fixture := newControllerImportFixture(t)
+			mutate(fixture)
+			if _, _, err := fixture.verify(); err == nil {
+				t.Fatal("unsafe metadata accepted")
+			}
+			if len(fixture.runner.calls) != 0 {
+				t.Fatal("invalid metadata reached subprocess execution")
+			}
+		})
+	}
+}
+
+func TestControllerBackupImportRejectsInventoryAndLinks(t *testing.T) {
+	for _, name := range []string{"extra", "missing", "empty", "file-mode", "root-mode", "symlink-member", "hardlink-member", "symlink-parent", "identity-symlink", "workspace-symlink", "wrong-owner"} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newControllerImportFixture(t)
+			member := filepath.Join(fixture.root, "application.age")
+			var err error
+			switch name {
+			case "extra":
+				fixture.write(filepath.Join(fixture.root, "unexpected.part"), []byte("partial"))
+			case "missing":
+				err = os.Remove(member)
+			case "empty":
+				fixture.write(member, nil)
+			case "file-mode":
+				err = os.Chmod(member, 0o644)
+			case "root-mode":
+				err = os.Chmod(fixture.root, 0o755)
+			case "symlink-member", "hardlink-member":
+				outside := filepath.Join(filepath.Dir(fixture.root), "saved.age")
+				if err = os.Rename(member, outside); err == nil {
+					if name == "symlink-member" {
+						err = os.Symlink(outside, member)
+					} else {
+						err = os.Link(outside, member)
+					}
+				}
+			case "symlink-parent":
+				alias := filepath.Join(filepath.Dir(fixture.root), "alias")
+				err = os.Symlink(filepath.Dir(fixture.root), alias)
+				fixture.root = filepath.Join(alias, "collection")
+			case "identity-symlink":
+				alias := fixture.identity + "-alias"
+				err = os.Symlink(fixture.identity, alias)
+				fixture.identity = alias
+			case "workspace-symlink":
+				alias := fixture.plan.ControllerWorkspace + "-alias"
+				err = os.Symlink(fixture.plan.ControllerWorkspace, alias)
+				fixture.plan.ControllerWorkspace = alias
+			case "wrong-owner":
+				fixture.runtime.effectiveUID = func() int { return os.Geteuid() + 1 }
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := fixture.verify(); err == nil {
+				t.Fatal("unsafe inventory accepted")
+			}
+			if len(fixture.runner.calls) != 0 {
+				t.Fatal("unsafe inventory reached a subprocess")
+			}
+		})
+	}
+}
+
+func TestControllerBackupImportSubprocessAndTamperFailuresCleanPlaintext(t *testing.T) {
+	for _, name := range []string{"age-eof", "age-wrong-bytes", "pg-full-read", "cipher-tamper", "cipher-length", "plain-hash", "post-validation-tamper", "database-magic", "cancelled"} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newControllerImportFixture(t)
+			switch name {
+			case "age-eof":
+				fixture.runner.ageFailure = true
+			case "age-wrong-bytes":
+				fixture.runner.ageWrongBytes = true
+			case "pg-full-read":
+				fixture.runner.pgFailure = true
+			case "cipher-tamper":
+				fixture.write(filepath.Join(fixture.root, "application.age"), []byte("tamper"))
+			case "cipher-length":
+				a := fixture.set.Archives["application"]
+				a.CiphertextBytes++
+				fixture.set.Archives["application"] = a
+				fixture.manifest(nil)
+			case "plain-hash":
+				a := fixture.set.Archives["application"]
+				a.PlaintextSHA256 = strings.Repeat("0", 64)
+				fixture.set.Archives["application"] = a
+				fixture.manifest(nil)
+			case "post-validation-tamper":
+				fixture.runner.afterPG = func() {
+					fixture.write(filepath.Join(fixture.root, "application.age"), []byte("changed after age verification"))
+				}
+			case "database-magic":
+				fixture.archive("database", []byte("not-a-custom-archive"))
+				fixture.manifest(nil)
+			case "cancelled":
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				if _, _, err := fixture.runtime.verifyControllerBackupSet(ctx, fixture.plan, fixture.root, fixture.identity); err == nil {
+					t.Fatal("cancelled import accepted")
+				}
+				if len(fixture.runner.calls) != 0 {
+					t.Fatal("cancelled import dispatched command")
+				}
+				return
+			}
+			if _, _, err := fixture.verify(); err == nil {
+				t.Fatal("failed verification accepted")
+			}
+			if _, err := os.Stat(filepath.Join(fixture.root, "database.age")); err != nil {
+				t.Fatal("failed import deleted encrypted original")
+			}
+		})
+	}
+}
+
+func TestControllerBackupImportRejectsUnsafeTarAndGzip(t *testing.T) {
+	for _, name := range []string{"traversal", "absolute", "dot-component", "backslash", "duplicate", "symlink", "hardlink", "device", "fifo", "missing-required", "required-directory", "payload-tamper", "truncated-body", "missing-footer", "partial-footer", "trailing-nonzero", "gzip-trailer", "gzip-truncated", "gzip-extra-stream", "ancestor-file", "late-ancestor-file"} {
+		t.Run(name, func(t *testing.T) {
+			fixture := newControllerImportFixture(t)
+			required := controllerImportTarMember{name: "usr/bin/lmm-api-go", data: []byte("fixture-go-provider")}
+			members := []controllerImportTarMember{required}
+			switch name {
+			case "traversal":
+				members = append(members, controllerImportTarMember{name: "../escape", data: []byte("x")})
+			case "absolute":
+				members = append(members, controllerImportTarMember{name: "/escape", data: []byte("x")})
+			case "dot-component":
+				members = append(members, controllerImportTarMember{name: "a/../escape", data: []byte("x")})
+			case "backslash":
+				members = append(members, controllerImportTarMember{name: "a\\escape", data: []byte("x")})
+			case "duplicate":
+				members = append(members, required)
+			case "symlink":
+				members = append(members, controllerImportTarMember{name: "link", kind: tar.TypeSymlink, link: "outside"})
+			case "hardlink":
+				members = append(members, controllerImportTarMember{name: "link", kind: tar.TypeLink, link: required.name})
+			case "device":
+				members = append(members, controllerImportTarMember{name: "device", kind: tar.TypeChar})
+			case "fifo":
+				members = append(members, controllerImportTarMember{name: "fifo", kind: tar.TypeFifo})
+			case "missing-required":
+				members = []controllerImportTarMember{{name: "irrelevant", data: []byte("x")}}
+			case "required-directory":
+				members = []controllerImportTarMember{{name: required.name + "/", kind: tar.TypeDir}}
+			case "payload-tamper":
+				members[0].data = []byte("different-provider")
+			case "ancestor-file":
+				members = append([]controllerImportTarMember{{name: "usr", data: []byte("x")}}, members...)
+			case "late-ancestor-file":
+				members = append(members, controllerImportTarMember{name: "usr", data: []byte("x")})
+			}
+			archive := controllerImportTar(t, members)
+			switch name {
+			case "truncated-body":
+				archive = archive[:513]
+			case "missing-footer":
+				archive = archive[:len(archive)-1024]
+			case "partial-footer":
+				archive = archive[:len(archive)-512]
+			case "trailing-nonzero":
+				archive = append(archive, []byte("hidden-data")...)
+			case "gzip-trailer":
+				archive = controllerImportGzip(t, archive)
+				archive[len(archive)-8] ^= 0xff
+			case "gzip-truncated":
+				archive = controllerImportGzip(t, archive)
+				archive = archive[:len(archive)-1]
+			case "gzip-extra-stream":
+				archive = append(controllerImportGzip(t, archive), controllerImportGzip(t, []byte("hidden-data"))...)
+			}
+			fixture.archive("application", archive)
+			fixture.manifest(nil)
+			if _, _, err := fixture.verify(); err == nil {
+				t.Fatal("unsafe archive accepted")
+			}
+		})
+	}
+}
+
+func TestControllerBackupImportRejectsUnsafeConfiguration(t *testing.T) {
+	for _, environment := range []string{
+		"DATABASE_URL=$(command)\n", "DATABASE_URL=sqlite://local\n", "DATABASE_URL=postgres://\n",
+		"DATABASE_URL=postgresql://host/db\nSQL_DSN=postgresql://other/db\n", "DATABASE_URL=postgresql://host/db\nDATABASE_URL=postgresql://host/db\n",
+		"DATABASE_URL=postgresql://host/db\nexport TOKEN=secret\n",
+	} {
+		t.Run(controllerBackupDigest([]byte(environment))[:8], func(t *testing.T) {
+			fixture := newControllerImportFixture(t)
+			fixture.set.EnvironmentSHA256 = controllerBackupDigest([]byte(environment))
+			fixture.archive("configuration", controllerImportTar(t, []controllerImportTarMember{{name: "etc/lmm-api-go/lmm-api-go.env", data: []byte(environment)}}))
+			fixture.manifest(nil)
+			if _, _, err := fixture.verify(); err == nil {
+				t.Fatal("unsafe configuration accepted")
+			}
+		})
+	}
+}
+
+func TestControllerBackupImportClockBoundaries(t *testing.T) {
+	fixture := newControllerImportFixture(t)
+	now := fixture.runtime.now()
+	for _, offset := range []time.Duration{-24 * time.Hour, 30 * time.Second} {
+		set := fixture.set
+		set.CapturedUTC = now.Add(offset)
+		if err := controllerBackupValidateSet(set, fixture.plan, now); err != nil {
+			t.Fatalf("valid clock boundary rejected: %v", err)
+		}
+	}
+}

--- a/apps/api-go/internal/appcli/deploy_production_controller_real_tools_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller_real_tools_test.go
@@ -1,0 +1,138 @@
+//go:build linux
+
+package appcli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Opt in explicitly: this creates only an owned, temporary PostgreSQL cluster
+// with no TCP listener, and never uses the workstation's database or credentials.
+func TestControllerBackupImportWithRealAgeAndPostgres(t *testing.T) {
+	if os.Getenv("LMM_CONTROLLER_BACKUP_REAL_TOOLS_TEST") != "1" {
+		t.Skip("requires explicit local real-tool test opt-in")
+	}
+	for _, tool := range []string{"age", "age-keygen", "initdb", "pg_ctl", "pg_dump", "pg_restore", "psql"} {
+		if _, err := os.Stat("/usr/bin/" + tool); err != nil {
+			t.Fatalf("required local test tool unavailable: %s", tool)
+		}
+	}
+	fixture := newControllerImportFixture(t)
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	data := filepath.Join(root, "pgdata")
+	socket := "@lmm-import-" + controllerBackupDigest([]byte(root))[:16]
+	env := []string{"PATH=/usr/bin", "LANG=C", "LC_ALL=C", "HOME=" + root, "TMPDIR=" + root,
+		"PGHOST=" + socket, "PGPORT=55432", "PGUSER=lmm_import_fixture", "PGDATABASE=postgres"}
+	run := func(tool string, args ...string) []byte {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "/usr/bin/"+tool, args...)
+		cmd.Env, cmd.Dir = env, root
+		output, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("owned local %s fixture failed: %v", tool, err)
+		}
+		return output
+	}
+	run("initdb", "-D", data, "--no-locale", "--encoding=UTF8", "--auth=trust", "--username=lmm_import_fixture")
+	// Register stop before start: even a startup timeout leaves a scoped cleanup.
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "/usr/bin/pg_ctl", "-D", data, "-m", "immediate", "-w", "stop")
+		cmd.Env, cmd.Dir = env, root
+		if err := cmd.Run(); err != nil {
+			t.Errorf("owned temporary PostgreSQL stop failed: %v", err)
+		}
+	})
+	run("pg_ctl", "-D", data, "-l", filepath.Join(root, "postgres.log"), "-w", "-o", "-h '' -k "+socket+" -p 55432 -c shared_buffers=16MB -c max_connections=8 -c autovacuum=off", "start")
+	run("psql", "--no-psqlrc", "--set", "ON_ERROR_STOP=1", "-c", "CREATE TABLE backup_fixture AS SELECT n, md5(n::text) AS value FROM generate_series(1, 5000) AS n")
+	dump := filepath.Join(root, "database.pgc")
+	run("pg_dump", "--format=custom", "--compress=zstd:1", "--file", dump, "postgres")
+	if err := os.Remove(fixture.identity); err != nil {
+		t.Fatal(err)
+	}
+	run("age-keygen", "-o", fixture.identity)
+	recipient := strings.TrimSpace(string(run("age-keygen", "-y", fixture.identity)))
+	plaintexts := make(map[string][]byte)
+	for _, kind := range controllerBackupKinds {
+		archive := fixture.set.Archives[kind]
+		plain := fixture.runner.plain[archive.CiphertextSHA256]
+		if kind == "database" {
+			var err error
+			plain, err = os.ReadFile(dump)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+		plaintexts[kind] = plain
+	}
+	encrypt := func(kind string, plaintext []byte) {
+		t.Helper()
+		archive := fixture.set.Archives[kind]
+		plain := filepath.Join(root, kind+".plain")
+		if err := os.WriteFile(plain, plaintext, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		cipher := filepath.Join(fixture.root, kind+".age")
+		if err := os.Remove(cipher); err != nil {
+			t.Fatal(err)
+		}
+		run("age", "-r", recipient, "-o", cipher, plain)
+		if err := os.Chmod(cipher, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		info, err := os.Stat(cipher)
+		if err != nil {
+			t.Fatal(err)
+		}
+		archive.CiphertextBytes, archive.PlaintextBytes = info.Size(), int64(len(plaintext))
+		archive.CiphertextSHA256, archive.PlaintextSHA256 = mustHashFile(t, cipher), controllerBackupDigest(plaintext)
+		fixture.set.Archives[kind] = archive
+		if err := os.Remove(plain); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, kind := range controllerBackupKinds {
+		encrypt(kind, plaintexts[kind])
+	}
+	fixture.manifest(nil)
+	fixture.runtime.runner = osProductionCommandRunner{}
+	if _, _, err := fixture.verify(); err != nil {
+		t.Fatal("real age/PostgreSQL import rejected valid complete archive")
+	}
+	// Keep age encryption and both declared hashes valid: only the full custom
+	// dump parser can reject this truncated PostgreSQL payload.
+	encrypt("database", plaintexts["database"][:len(plaintexts["database"])/2])
+	fixture.manifest(nil)
+	if _, _, err := fixture.verify(); err == nil {
+		t.Fatal("real PostgreSQL parser accepted a truncated archive")
+	}
+	encrypt("database", plaintexts["database"])
+	archive := fixture.set.Archives["application"]
+	cipherPath := filepath.Join(fixture.root, "application.age")
+	cipher, err := os.ReadFile(cipherPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cipher[len(cipher)-1] ^= 1
+	if err := os.WriteFile(cipherPath, cipher, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	archive.CiphertextSHA256 = controllerBackupDigest(cipher)
+	fixture.set.Archives["application"] = archive
+	fixture.manifest(nil)
+	if _, _, err := fixture.verify(); err == nil {
+		t.Fatal("real age accepted damaged authenticated EOF with self-consistent ciphertext hash")
+	}
+}

--- a/apps/api-go/internal/appcli/deploy_production_controller_receipt.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller_receipt.go
@@ -1,0 +1,534 @@
+package appcli
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"filippo.io/edwards25519"
+)
+
+const (
+	controllerBackupReceiptName      = "controller-backup-receipt.json"
+	controllerBackupConfirmationName = "controller-backup-confirmation.json"
+	controllerBackupKeyName          = "controller-backup.key"
+	controllerBackupEvidenceFormat   = 3
+	controllerBackupReceiptMaxBytes  = 64 << 10
+)
+
+var controllerBackupKinds = []string{"application", "frontend", "configuration", "database"}
+
+type controllerBackupBinding struct {
+	PublicKey     string `json:"public_key"`
+	PlanSHA256    string `json:"plan_sha256"`
+	ReceiptPath   string `json:"receipt_path"`
+	ReceiptSHA256 string `json:"receipt_sha256"`
+}
+
+type controllerBackupEnvelope struct {
+	Format    int    `json:"format"`
+	Payload   []byte `json:"payload"`
+	Signature string `json:"signature"`
+}
+
+type controllerBackupReceipt struct {
+	Format                   int               `json:"format"`
+	Purpose                  string            `json:"purpose"`
+	DeploymentID             string            `json:"deployment_id"`
+	ExpectedHost             string            `json:"expected_host"`
+	PlanSHA256               string            `json:"plan_sha256"`
+	VerifiedUTC              time.Time         `json:"verified_utc"`
+	CapturedUTC              time.Time         `json:"captured_utc"`
+	DeploymentManifestSHA256 string            `json:"deployment_manifest_sha256"`
+	BackupSetSHA256          string            `json:"backup_set_sha256"`
+	DatabaseSchema           string            `json:"database_schema"`
+	EnvironmentSHA256        string            `json:"environment_sha256"`
+	GoCandidateSHA256        string            `json:"go_candidate_sha256"`
+	GoRollbackSHA256         string            `json:"go_rollback_sha256"`
+	WebCandidateSHA256       string            `json:"web_candidate_sha256"`
+	WebRollbackSHA256        string            `json:"web_rollback_sha256"`
+	GoRollbackPayloadSHA256  string            `json:"go_rollback_payload_sha256"`
+	FrontendRollbackSHA256   string            `json:"frontend_rollback_sha256"`
+	ArchiveCiphertexts       map[string]string `json:"archive_ciphertexts"`
+	ArchivePlaintexts        map[string]string `json:"archive_plaintexts"`
+}
+
+// decodeControllerBackupJSON rejects duplicate keys before decoding typed fields.
+// Exact tag casing avoids Go's otherwise case-insensitive field matching differing
+// from the Rust recovery reader. No extra JSON values or fields are accepted.
+func decodeControllerBackupJSON(data []byte, value any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := rejectControllerBackupDuplicateKeys(decoder); err != nil {
+		return err
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return errors.New("backup JSON must contain one value")
+	}
+	if err := validateControllerBackupJSONFields(data, reflect.TypeOf(value)); err != nil {
+		return err
+	}
+	decoder = json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		return errors.New("backup JSON has invalid fields or values")
+	}
+	return nil
+}
+
+func rejectControllerBackupDuplicateKeys(decoder *json.Decoder) error {
+	token, err := decoder.Token()
+	if err != nil {
+		return errors.New("backup JSON is malformed")
+	}
+	delim, nested := token.(json.Delim)
+	if !nested {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]bool)
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			key, ok := keyToken.(string)
+			if err != nil || !ok || seen[key] {
+				return errors.New("backup JSON has invalid or duplicate object keys")
+			}
+			seen[key] = true
+			if err := rejectControllerBackupDuplicateKeys(decoder); err != nil {
+				return err
+			}
+		}
+	case '[':
+		for decoder.More() {
+			if err := rejectControllerBackupDuplicateKeys(decoder); err != nil {
+				return err
+			}
+		}
+	default:
+		return errors.New("backup JSON has an unexpected delimiter")
+	}
+	closing, err := decoder.Token()
+	if err != nil || (delim == '{' && closing != json.Delim('}')) || (delim == '[' && closing != json.Delim(']')) {
+		return errors.New("backup JSON is incomplete")
+	}
+	return nil
+}
+
+func validateControllerBackupJSONFields(data json.RawMessage, target reflect.Type) error {
+	if bytes.Equal(bytes.TrimSpace(data), []byte("null")) {
+		if target.Kind() == reflect.Pointer {
+			return nil
+		}
+		return errors.New("backup JSON does not permit null scalar or collection values")
+	}
+	for target.Kind() == reflect.Pointer {
+		target = target.Elem()
+	}
+	if target == reflect.TypeOf(time.Time{}) {
+		return nil
+	}
+	if target == reflect.TypeOf([]byte{}) {
+		var encoded string
+		if err := json.Unmarshal(data, &encoded); err != nil {
+			return errors.New("backup JSON byte payload must be a base64 string, not a numeric array")
+		}
+		return nil
+	}
+	switch target.Kind() {
+	case reflect.Struct:
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(data, &object); err != nil || object == nil {
+			return errors.New("backup JSON requires an object")
+		}
+		fields := make(map[string]reflect.Type)
+		for i := 0; i < target.NumField(); i++ {
+			field := target.Field(i)
+			tag := strings.Split(field.Tag.Get("json"), ",")[0]
+			if tag != "" && tag != "-" {
+				fields[tag] = field.Type
+			}
+		}
+		if target == reflect.TypeOf(controllerBackupReceipt{}) || target == reflect.TypeOf(controllerBackupEnvelope{}) ||
+			target == reflect.TypeOf(controllerBackupSet{}) || target == reflect.TypeOf(controllerBackupArchive{}) || target == reflect.TypeOf(controllerBackupBinding{}) {
+			for key := range fields {
+				if _, ok := object[key]; !ok {
+					return errors.New("backup JSON has a missing required field")
+				}
+			}
+		}
+		for key, child := range object {
+			kind, ok := fields[key]
+			if !ok {
+				return errors.New("backup JSON has an unknown or incorrectly cased field")
+			}
+			if err := validateControllerBackupJSONFields(child, kind); err != nil {
+				return err
+			}
+		}
+	case reflect.Map:
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(data, &object); err != nil || object == nil {
+			return errors.New("backup JSON requires a non-null map")
+		}
+		for _, child := range object {
+			if err := validateControllerBackupJSONFields(child, target.Elem()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateControllerBackupDigestMap(values map[string]string) error {
+	if len(values) != len(controllerBackupKinds) {
+		return errors.New("backup evidence requires exactly four archive kinds")
+	}
+	for _, kind := range controllerBackupKinds {
+		if !productionSHA256Pattern.MatchString(values[kind]) {
+			return errors.New("backup evidence has an invalid archive digest")
+		}
+	}
+	return nil
+}
+
+func validateControllerBackupReceiptShape(receipt controllerBackupReceipt) error {
+	if receipt.Format != 1 || !productionIDPattern.MatchString(receipt.DeploymentID) || receipt.ExpectedHost != productionExpectedHost {
+		return errors.New("controller backup receipt identity or format is invalid")
+	}
+	if receipt.Purpose != "prepare" && receipt.Purpose != "confirm" {
+		return errors.New("controller backup receipt purpose is invalid")
+	}
+	if receipt.Purpose == "prepare" && receipt.DeploymentManifestSHA256 != "" {
+		return errors.New("prepare receipt cannot predeclare a deployment manifest hash")
+	}
+	if receipt.Purpose == "confirm" && !productionSHA256Pattern.MatchString(receipt.DeploymentManifestSHA256) {
+		return errors.New("confirmation receipt requires a manifest hash")
+	}
+	for _, digest := range []string{receipt.PlanSHA256, receipt.BackupSetSHA256, receipt.EnvironmentSHA256, receipt.GoCandidateSHA256, receipt.GoRollbackSHA256, receipt.WebCandidateSHA256, receipt.WebRollbackSHA256, receipt.GoRollbackPayloadSHA256, receipt.FrontendRollbackSHA256} {
+		if !productionSHA256Pattern.MatchString(digest) {
+			return errors.New("controller backup receipt contains an invalid digest")
+		}
+	}
+	_, verifiedOffset := receipt.VerifiedUTC.Zone()
+	_, capturedOffset := receipt.CapturedUTC.Zone()
+	if !isDatabaseSchema(receipt.DatabaseSchema) || receipt.VerifiedUTC.Unix() <= 0 || receipt.CapturedUTC.Unix() <= 0 || verifiedOffset != 0 || capturedOffset != 0 || receipt.CapturedUTC.After(receipt.VerifiedUTC.Add(30*time.Second)) || receipt.VerifiedUTC.Sub(receipt.CapturedUTC) > 24*time.Hour {
+		return errors.New("controller backup receipt schema or snapshot time is invalid")
+	}
+	if err := validateControllerBackupDigestMap(receipt.ArchiveCiphertexts); err != nil {
+		return err
+	}
+	return validateControllerBackupDigestMap(receipt.ArchivePlaintexts)
+}
+
+func validateControllerBackupFreshness(receipt controllerBackupReceipt, now time.Time) error {
+	if receipt.VerifiedUTC.After(now.Add(30*time.Second)) || now.Sub(receipt.VerifiedUTC) >= 5*time.Minute {
+		return errors.New("controller backup verification receipt is stale or future-dated")
+	}
+	return nil
+}
+
+func controllerBackupVerificationKey(value string) (ed25519.PublicKey, error) {
+	if !productionSHA256Pattern.MatchString(value) {
+		return nil, errors.New("controller backup public key is invalid")
+	}
+	key, err := hex.DecodeString(value)
+	if err != nil || !controllerBackupStrongPoint(key) {
+		return nil, errors.New("controller backup public key is invalid or weak")
+	}
+	return ed25519.PublicKey(key), nil
+}
+
+// Match the strict Rust reader: reject noncanonical or small-order points as
+// well as invalid signatures. Use the vetted Edwards implementation, not a
+// hand-maintained blacklist or custom curve arithmetic.
+func controllerBackupStrongPoint(encoded []byte) bool {
+	point, err := new(edwards25519.Point).SetBytes(encoded)
+	return err == nil && bytes.Equal(point.Bytes(), encoded) && new(edwards25519.Point).MultByCofactor(point).Equal(edwards25519.NewIdentityPoint()) != 1
+}
+
+func decodeSignedControllerBackupReceipt(data []byte, publicKey string) (controllerBackupReceipt, error) {
+	var receipt controllerBackupReceipt
+	key, err := controllerBackupVerificationKey(publicKey)
+	if err != nil {
+		return receipt, err
+	}
+	var envelope controllerBackupEnvelope
+	if len(data) > controllerBackupReceiptMaxBytes || decodeControllerBackupJSON(data, &envelope) != nil || envelope.Format != 1 || len(envelope.Payload) == 0 || len(envelope.Payload) > controllerBackupReceiptMaxBytes || len(envelope.Signature) != ed25519.SignatureSize*2 || envelope.Signature != strings.ToLower(envelope.Signature) {
+		return receipt, errors.New("controller backup receipt envelope is invalid")
+	}
+	signature, err := hex.DecodeString(envelope.Signature)
+	if err != nil || len(signature) != ed25519.SignatureSize || !controllerBackupStrongPoint(signature[:32]) || !ed25519.Verify(key, envelope.Payload, signature) {
+		return receipt, errors.New("controller backup receipt signature is invalid")
+	}
+	if err := decodeControllerBackupJSON(envelope.Payload, &receipt); err != nil {
+		return receipt, err
+	}
+	return receipt, validateControllerBackupReceiptShape(receipt)
+}
+
+func readControllerBackupReceipt(path, publicKey, expectedSHA string, owner uint32) (controllerBackupReceipt, error) {
+	var receipt controllerBackupReceipt
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&(os.ModeSymlink|os.ModeSetuid|os.ModeSetgid|os.ModeSticky) != 0 || info.Mode().Perm() != 0o600 || info.Size() > controllerBackupReceiptMaxBytes || info.Size() == 0 {
+		return receipt, errors.New("controller backup receipt file is missing or unsafe")
+	}
+	uid, links, ok := deploymentFileOwnership(info)
+	canonical, canonicalErr := filepath.EvalSymlinks(path)
+	if !ok || uid != owner || links != 1 || canonicalErr != nil || canonical != path {
+		return receipt, errors.New("controller backup receipt ownership or path is unsafe")
+	}
+	data, err := readPrivateRegularFile(path, controllerBackupReceiptMaxBytes)
+	if err != nil {
+		return receipt, errors.New("controller backup receipt cannot be read")
+	}
+	actual := fmt.Sprintf("%x", sha256.Sum256(data))
+	if expectedSHA != "" && actual != expectedSHA {
+		return receipt, errors.New("controller backup receipt digest differs from immutable evidence")
+	}
+	return decodeSignedControllerBackupReceipt(data, publicKey)
+}
+
+func controllerBackupKey(plan productionReleasePlan) (ed25519.PrivateKey, error) {
+	path := filepath.Join(plan.ControllerWorkspace, "state", controllerBackupKeyName)
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		return nil, errors.New("controller backup signing key is unavailable")
+	}
+	uid, links, ok := deploymentFileOwnership(info)
+	if !ok || uid != uint32(os.Geteuid()) || links != 1 {
+		return nil, errors.New("controller backup signing key ownership is invalid")
+	}
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil || canonical != path {
+		return nil, errors.New("controller backup signing key path is unsafe")
+	}
+	data, err := readPrivateRegularFile(path, ed25519.PrivateKeySize)
+	if err != nil || len(data) != ed25519.PrivateKeySize {
+		return nil, errors.New("controller backup signing key is invalid")
+	}
+	key := ed25519.PrivateKey(data)
+	if hex.EncodeToString(key.Public().(ed25519.PublicKey)) != plan.ControllerBackupPublicKey {
+		return nil, errors.New("controller backup signing key differs from frozen plan")
+	}
+	return key, nil
+}
+
+func initializeControllerBackupKey(workspace string) (string, error) {
+	path := filepath.Join(workspace, "state", controllerBackupKeyName)
+	if _, err := os.Lstat(path); err == nil {
+		data, readErr := readPrivateRegularFile(path, ed25519.PrivateKeySize)
+		if readErr != nil || len(data) != ed25519.PrivateKeySize {
+			return "", errors.New("existing controller backup key is invalid")
+		}
+		public := hex.EncodeToString(ed25519.PrivateKey(data).Public().(ed25519.PublicKey))
+		_, keyErr := controllerBackupKey(productionReleasePlan{ControllerWorkspace: workspace, ControllerBackupPublicKey: public})
+		return public, keyErr
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", errors.New("could not create controller backup signing key")
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return "", err
+	}
+	_, writeErr := file.Write(private)
+	syncErr := file.Sync()
+	closeErr := file.Close()
+	if err := errors.Join(writeErr, syncErr, closeErr); err != nil {
+		return "", err
+	}
+	if err := syncDirectory(filepath.Dir(path)); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(public), nil
+}
+
+func signedControllerBackupReceipt(plan productionReleasePlan, set controllerBackupSet, setSHA, planSHA, purpose, manifestSHA string, now time.Time) ([]byte, error) {
+	key, err := controllerBackupKey(plan)
+	if err != nil {
+		return nil, err
+	}
+	receipt := controllerBackupReceipt{
+		Format: 1, Purpose: purpose, DeploymentID: plan.DeploymentID, ExpectedHost: plan.ExpectedHost, PlanSHA256: planSHA,
+		VerifiedUTC: utcSecond(now), CapturedUTC: set.CapturedUTC, DeploymentManifestSHA256: manifestSHA,
+		BackupSetSHA256: setSHA, DatabaseSchema: set.DatabaseSchema, EnvironmentSHA256: set.EnvironmentSHA256,
+		GoCandidateSHA256: plan.GoCandidate.PackageSHA256, GoRollbackSHA256: plan.GoRollback.PackageSHA256,
+		WebCandidateSHA256: plan.WebCandidate.PackageSHA256, WebRollbackSHA256: plan.WebRollback.PackageSHA256,
+		GoRollbackPayloadSHA256: plan.GoRollback.PayloadSHA256, FrontendRollbackSHA256: plan.WebRollback.PayloadSHA256,
+		ArchiveCiphertexts: make(map[string]string), ArchivePlaintexts: make(map[string]string),
+	}
+	for _, kind := range controllerBackupKinds {
+		receipt.ArchiveCiphertexts[kind] = set.Archives[kind].CiphertextSHA256
+		receipt.ArchivePlaintexts[kind] = set.Archives[kind].PlaintextSHA256
+	}
+	if err := validateControllerBackupReceiptShape(receipt); err != nil {
+		return nil, err
+	}
+	payload, err := json.Marshal(receipt)
+	if err != nil {
+		return nil, err
+	}
+	envelope := controllerBackupEnvelope{Format: 1, Payload: payload, Signature: hex.EncodeToString(ed25519.Sign(key, payload))}
+	return json.Marshal(envelope)
+}
+
+func validateControllerOnlyReleasePlanPolicy(plan productionReleasePlan) error {
+	if plan.Format == 5 {
+		if plan.BackupMode != "" || plan.ControllerBackupDir != "" || plan.ControllerBackupPublicKey != "" {
+			return errors.New("legacy plans cannot contain controller-only backup fields")
+		}
+		return nil
+	}
+	if plan.AgeRecipient != (productionReleaseFilePlan{}) {
+		return errors.New("controller-only plans cannot contain legacy target backup recipients")
+	}
+	if plan.BackupMode == "disabled" {
+		if plan.WithBackups || plan.ControllerBackupDir != "" || plan.ControllerBackupPublicKey != "" {
+			return errors.New("disabled backup plans cannot contain backup paths or keys")
+		}
+		return nil
+	}
+	if plan.BackupMode != "controller-only" || !plan.WithBackups || !productionSHA256Pattern.MatchString(plan.ControllerBackupPublicKey) {
+		return errors.New("selected backups require controller-only mode and a frozen verification key")
+	}
+	if _, err := controllerBackupVerificationKey(plan.ControllerBackupPublicKey); err != nil {
+		return err
+	}
+	clean, err := cleanAbsoluteNonRoot(plan.ControllerBackupDir)
+	if err != nil || clean != plan.ControllerBackupDir {
+		return errors.New("controller backup import path must be absolute and canonical")
+	}
+	return nil
+}
+
+func validateControllerBackupTransactionOptions(options productionTransactionOptions) error {
+	binding := options.ControllerBackup
+	hasBinding := binding != (controllerBackupBinding{})
+	if !hasBinding {
+		if options.WithBackups != (options.BackupDir != "") {
+			return errors.New("selected legacy backups require --backup-dir; disabled backups forbid it")
+		}
+		return nil
+	}
+	if !options.WithBackups || options.BackupDir != "" {
+		return errors.New("controller-only evidence requires selected backups without a target backup directory")
+	}
+	if binding.ReceiptPath != filepath.Join(options.Workspace, "state", controllerBackupReceiptName) {
+		return errors.New("controller-only receipt must be at the exact workspace state path")
+	}
+	if _, err := controllerBackupVerificationKey(binding.PublicKey); err != nil {
+		return err
+	}
+	for _, value := range []string{binding.PublicKey, binding.PlanSHA256, binding.ReceiptSHA256} {
+		if !productionSHA256Pattern.MatchString(value) {
+			return errors.New("all controller-only receipt bindings are required and must be lowercase 64-character hexadecimal")
+		}
+	}
+	return nil
+}
+
+func validateControllerBackupBinding(workspace productionWorkspace, manifest productionManifest) error {
+	binding := manifest.ControllerOnlyBackup
+	if binding == nil || manifest.BackupEvidenceFormat != controllerBackupEvidenceFormat || !manifest.BackupsEnabled || manifest.BackupDir != "" || manifest.TargetBackupSHA256 != "" || manifest.OffhostBackupSHA256 != "" {
+		return errors.New("controller-only backup evidence is missing or mixed with legacy copies")
+	}
+	if binding.ReceiptPath != filepath.Join(workspace.stateDir, controllerBackupReceiptName) {
+		return errors.New("controller-only receipt must be in the exact retained state directory")
+	}
+	if !isDatabaseSchema(manifest.DatabaseSchema) {
+		return errors.New("controller backup database schema is invalid")
+	}
+	if _, err := controllerBackupVerificationKey(binding.PublicKey); err != nil {
+		return err
+	}
+	for _, digest := range []string{binding.PublicKey, binding.PlanSHA256, binding.ReceiptSHA256, manifest.ControllerBackupSHA256, manifest.DatabaseBackupSHA256} {
+		if !productionSHA256Pattern.MatchString(digest) {
+			return errors.New("controller-only backup binding has an invalid digest or key")
+		}
+	}
+	return nil
+}
+
+func matchControllerBackupReceipt(receipt controllerBackupReceipt, manifest productionManifest) error {
+	binding := manifest.ControllerOnlyBackup
+	if binding == nil || receipt.DeploymentID != manifest.DeploymentID || receipt.PlanSHA256 != binding.PlanSHA256 || receipt.BackupSetSHA256 != manifest.ControllerBackupSHA256 || receipt.DatabaseSchema != manifest.DatabaseSchema || receipt.EnvironmentSHA256 != manifest.EnvironmentRestoreSHA256 || receipt.GoCandidateSHA256 != manifest.Go.CandidateSHA256 || receipt.GoRollbackSHA256 != manifest.Go.RollbackSHA256 || receipt.WebCandidateSHA256 != manifest.Web.CandidateSHA256 || receipt.WebRollbackSHA256 != manifest.Web.RollbackSHA256 || receipt.FrontendRollbackSHA256 != manifest.Frontend.OldIndexSHA256 || receipt.ArchivePlaintexts["database"] != manifest.DatabaseBackupSHA256 {
+		return errors.New("controller backup receipt does not bind the exact deployment, source configuration and packages")
+	}
+	return nil
+}
+
+func (runtime *productionRuntime) verifyControllerBackupEvidence(workspace productionWorkspace, manifest productionManifest, fresh bool) error {
+	if err := validateControllerBackupBinding(workspace, manifest); err != nil {
+		return err
+	}
+	binding := manifest.ControllerOnlyBackup
+	receipt, err := readControllerBackupReceipt(binding.ReceiptPath, binding.PublicKey, binding.ReceiptSHA256, runtime.requiredOwnerUID)
+	if err != nil {
+		return err
+	}
+	if receipt.Purpose != "prepare" {
+		return errors.New("initial controller backup receipt must have prepare purpose")
+	}
+	if err := matchControllerBackupReceipt(receipt, manifest); err != nil {
+		return err
+	}
+	if fresh {
+		if err := validateControllerBackupFreshness(receipt, runtime.now()); err != nil {
+			return err
+		}
+		actual, err := sha256File(runtime.paths.InstalledBinary)
+		if err != nil || actual != receipt.GoRollbackPayloadSHA256 {
+			return errors.New("controller backup application payload differs from the verified active Go baseline")
+		}
+	}
+	return nil
+}
+
+func sameControllerBackupSnapshot(initial, confirmation controllerBackupReceipt) bool {
+	return initial.CapturedUTC.Equal(confirmation.CapturedUTC) && initial.BackupSetSHA256 == confirmation.BackupSetSHA256 &&
+		initial.GoRollbackPayloadSHA256 == confirmation.GoRollbackPayloadSHA256 &&
+		reflect.DeepEqual(initial.ArchiveCiphertexts, confirmation.ArchiveCiphertexts) && reflect.DeepEqual(initial.ArchivePlaintexts, confirmation.ArchivePlaintexts)
+}
+
+func (runtime *productionRuntime) verifyControllerBackupConfirmation(workspace productionWorkspace, manifest productionManifest) error {
+	if err := runtime.verifyControllerBackupEvidence(workspace, manifest, false); err != nil {
+		return err
+	}
+	binding := manifest.ControllerOnlyBackup
+	receipt, err := readControllerBackupReceipt(filepath.Join(workspace.stateDir, controllerBackupConfirmationName), binding.PublicKey, "", runtime.requiredOwnerUID)
+	if err != nil {
+		return err
+	}
+	if receipt.Purpose != "confirm" {
+		return errors.New("fresh controller backup receipt must have confirm purpose")
+	}
+	if err := matchControllerBackupReceipt(receipt, manifest); err != nil {
+		return err
+	}
+	initial, err := readControllerBackupReceipt(binding.ReceiptPath, binding.PublicKey, binding.ReceiptSHA256, runtime.requiredOwnerUID)
+	if err != nil {
+		return err
+	}
+	if !sameControllerBackupSnapshot(initial, receipt) {
+		return errors.New("controller backup confirmation changed the original snapshot evidence")
+	}
+	manifestSHA, err := sha256File(workspace.manifestPath)
+	if err != nil || receipt.DeploymentManifestSHA256 != manifestSHA {
+		return errors.New("controller backup confirmation does not bind the immutable manifest")
+	}
+	return validateControllerBackupFreshness(receipt, runtime.now())
+}

--- a/apps/api-go/internal/appcli/deploy_production_controller_receipt_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_controller_receipt_test.go
@@ -1,0 +1,303 @@
+//go:build !windows
+
+package appcli
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func controllerReceiptFixture(t *testing.T) (productionFixture, productionReleasePlan, controllerBackupSet) {
+	t.Helper()
+	fixture := newProductionFixture(t)
+	// The archive runner models both package binaries with the probe payload.
+	// Make the on-disk N-1 fixture match that verified rollback payload too.
+	payload, err := os.ReadFile(fixture.runner.probeBinary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fixture.runtime.paths.InstalledBinary, payload, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	public, err := initializeControllerBackupKey(fixture.workspace.root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := productionReleasePlan{Format: 6, DeploymentID: fixture.workspace.id, ExpectedHost: productionExpectedHost,
+		ControllerWorkspace: fixture.workspace.root, WithBackups: true, BackupMode: "controller-only", ControllerBackupPublicKey: public,
+		GoCandidate:  productionReleasePackagePlan{PackageSHA256: fixture.options.GoPackageSHA256},
+		GoRollback:   productionReleasePackagePlan{PackageSHA256: fixture.options.GoRollbackSHA256, PayloadSHA256: mustHashFile(t, fixture.runtime.paths.InstalledBinary)},
+		WebCandidate: productionReleasePackagePlan{PackageSHA256: fixture.options.WebPackageSHA256},
+		WebRollback:  productionReleasePackagePlan{PackageSHA256: fixture.options.WebRollbackSHA256, PayloadSHA256: mustHashFile(t, fixture.runner.oldWebIndex)}}
+	set := controllerBackupSet{Format: 1, DeploymentID: plan.DeploymentID, ExpectedHost: plan.ExpectedHost, CapturedUTC: *fixture.clock,
+		DatabaseSchema: "public", EnvironmentSHA256: controllerBackupDigest(fixture.environment), Archives: make(map[string]controllerBackupArchive)}
+	for _, kind := range controllerBackupKinds {
+		set.Archives[kind] = controllerBackupArchive{CiphertextSHA256: controllerBackupDigest([]byte(kind + "cipher")), PlaintextSHA256: controllerBackupDigest([]byte(kind + "plain"))}
+	}
+	encoded, err := signedControllerBackupReceipt(plan, set, strings.Repeat("e", 64), strings.Repeat("f", 64), "prepare", "", *fixture.clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(fixture.workspace.stateDir, controllerBackupReceiptName)
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.options.BackupDir = ""
+	fixture.options.Workspace = fixture.workspace.root
+	fixture.options.ControllerBackup = controllerBackupBinding{PublicKey: public, PlanSHA256: strings.Repeat("f", 64), ReceiptPath: path, ReceiptSHA256: controllerBackupDigest(encoded)}
+	return fixture, plan, set
+}
+
+func writeControllerConfirmation(t *testing.T, fixture productionFixture, plan productionReleasePlan, set controllerBackupSet, manifestHash string) {
+	t.Helper()
+	encoded, err := signedControllerBackupReceipt(plan, set, strings.Repeat("e", 64), strings.Repeat("f", 64), "confirm", manifestHash, *fixture.clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fixture.workspace.stateDir, controllerBackupConfirmationName), encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestControllerOnlyNativeApplyAndFreshConfirmation(t *testing.T) {
+	fixture, plan, set := controllerReceiptFixture(t)
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := fixture.runtime.readManifest(fixture.workspace)
+	if err != nil || manifest.BackupEvidenceFormat != 3 || manifest.BackupDir != "" || manifest.TargetBackupSHA256 != "" || manifest.OffhostBackupSHA256 != "" {
+		t.Fatalf("mixed or invalid manifest: %v", err)
+	}
+	if _, err := fixture.runtime.confirm(context.Background(), fixture.workspace); err == nil {
+		t.Fatal("confirmation succeeded without fresh controller proof")
+	}
+	writeControllerConfirmation(t, fixture, plan, set, mustHashFile(t, fixture.workspace.manifestPath))
+	if _, err := fixture.runtime.confirm(context.Background(), fixture.workspace); err != nil {
+		t.Fatal(err)
+	}
+	for _, command := range fixture.runner.commands {
+		if command.Name == commandAge || command.Name == commandPGDump || command.Name == commandPGRestore || command.Name == commandSSH || command.Name == commandSCP {
+			t.Fatalf("target performed forbidden backup operation %s", command.Name)
+		}
+	}
+}
+
+func TestControllerOnlyRollbackDoesNotNeedReceiptOrController(t *testing.T) {
+	fixture, _, _ := controllerReceiptFixture(t)
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(fixture.options.ControllerBackup.ReceiptPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(fixture.workspace.stateDir, controllerBackupKeyName)); err != nil {
+		t.Fatal(err)
+	}
+	status, err := fixture.runtime.rollback(context.Background(), fixture.workspace, "test-explicit-operator-request")
+	if err != nil || status.Phase != "ROLLED_BACK" {
+		t.Fatalf("receipt unavailable blocked manual recovery: status=%s error=%v", status.Phase, err)
+	}
+}
+
+func TestControllerOnlyHistoricalProofAndFreshnessBoundaries(t *testing.T) {
+	fixture, plan, set := controllerReceiptFixture(t)
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := fixture.runtime.readManifest(fixture.workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	*fixture.clock = fixture.clock.Add(6 * time.Minute)
+	if err := fixture.runtime.verifyControllerBackupEvidence(fixture.workspace, manifest, false); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.runtime.verifyControllerBackupEvidence(fixture.workspace, manifest, true); err == nil {
+		t.Fatal("stale initial proof was accepted as fresh preparation")
+	}
+	writeControllerConfirmation(t, fixture, plan, set, strings.Repeat("0", 64))
+	if err := fixture.runtime.verifyControllerBackupConfirmation(fixture.workspace, manifest); err == nil {
+		t.Fatal("wrong manifest hash accepted")
+	}
+	writeControllerConfirmation(t, fixture, plan, set, mustHashFile(t, fixture.workspace.manifestPath))
+	if err := fixture.runtime.verifyControllerBackupConfirmation(fixture.workspace, manifest); err != nil {
+		t.Fatal(err)
+	}
+	*fixture.clock = fixture.clock.Add(5 * time.Minute)
+	if err := fixture.runtime.verifyControllerBackupConfirmation(fixture.workspace, manifest); err == nil {
+		t.Fatal("exact five-minute-old confirmation accepted")
+	}
+}
+
+func TestControllerOnlyConfirmationCannotRewriteArchiveSnapshot(t *testing.T) {
+	fixture, plan, set := controllerReceiptFixture(t)
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	manifest, err := fixture.runtime.readManifest(fixture.workspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archive := set.Archives["application"]
+	archive.PlaintextSHA256 = strings.Repeat("1", 64)
+	set.Archives["application"] = archive
+	writeControllerConfirmation(t, fixture, plan, set, mustHashFile(t, fixture.workspace.manifestPath))
+	if err := fixture.runtime.verifyControllerBackupConfirmation(fixture.workspace, manifest); err == nil {
+		t.Fatal("validly signed replacement archive was accepted")
+	}
+}
+
+func TestControllerReceiptStrictSignedJSON(t *testing.T) {
+	fixture, plan, _ := controllerReceiptFixture(t)
+	original, err := os.ReadFile(fixture.options.ControllerBackup.ReceiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope controllerBackupEnvelope
+	if err := json.Unmarshal(original, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	key, err := controllerBackupKey(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, change := range map[string]func([]byte) []byte{
+		"duplicate": func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`{"format":`), []byte(`{"format":1,"format":`), 1)
+		},
+		"case alias": func(data []byte) []byte { return bytes.Replace(data, []byte(`"purpose"`), []byte(`"Purpose"`), 1) },
+		"missing empty field": func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"deployment_manifest_sha256":"",`), nil, 1)
+		},
+		"null empty field": func(data []byte) []byte {
+			return bytes.Replace(data, []byte(`"deployment_manifest_sha256":""`), []byte(`"deployment_manifest_sha256":null`), 1)
+		},
+		"non UTC":    func(data []byte) []byte { return bytes.Replace(data, []byte(`Z"`), []byte(`+01:00"`), 1) },
+		"extra JSON": func(data []byte) []byte { return append(bytes.Clone(data), []byte(` {}`)...) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			payload := change(envelope.Payload)
+			if bytes.Equal(payload, envelope.Payload) {
+				t.Fatal("test mutation did not change payload")
+			}
+			forged := controllerBackupEnvelope{Format: 1, Payload: payload, Signature: hex.EncodeToString(ed25519.Sign(key, payload))}
+			encoded, err := json.Marshal(forged)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := decodeSignedControllerBackupReceipt(encoded, plan.ControllerBackupPublicKey); err == nil {
+				t.Fatal("invalid signed JSON was accepted")
+			}
+		})
+	}
+	envelope.Payload = append(envelope.Payload, ' ')
+	tampered, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeSignedControllerBackupReceipt(tampered, plan.ControllerBackupPublicKey); err == nil {
+		t.Fatal("changed exact payload bytes accepted without resigning")
+	}
+}
+
+// Explicitly export only public, synthetic evidence for the Rust compatibility
+// test. No private key, plaintext configuration or database data is exported.
+func TestControllerReceiptExportInterop(t *testing.T) {
+	root := os.Getenv("LMM_CONTROLLER_BACKUP_INTEROP_FIXTURE_DIR")
+	if root == "" {
+		t.Skip("explicit cross-language fixture export not selected")
+	}
+	if !filepath.IsAbs(root) {
+		t.Fatal("interop destination must be absolute")
+	}
+	if err := os.Mkdir(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fixture, _, _ := controllerReceiptFixture(t)
+	if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+		t.Fatal(err)
+	}
+	for name, path := range map[string]string{"receipt.json": fixture.options.ControllerBackup.ReceiptPath, "manifest.json": fixture.workspace.manifestPath} {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, name), data, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestControllerReceiptRejectsWeakSigningKeys(t *testing.T) {
+	for _, key := range []string{strings.Repeat("0", 64), "01" + strings.Repeat("00", 31), "ec" + strings.Repeat("ff", 30) + "7f"} {
+		if _, err := controllerBackupVerificationKey(key); err == nil {
+			t.Fatalf("accepted small-order Ed25519 key %s", key)
+		}
+	}
+}
+
+func TestControllerReceiptRetainsInitialEvidenceWithoutOverwrite(t *testing.T) {
+	fixture, plan, set := controllerReceiptFixture(t)
+	initial, err := os.ReadFile(fixture.options.ControllerBackup.ReceiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := signedControllerBackupReceipt(plan, set, strings.Repeat("e", 64), strings.Repeat("f", 64), "prepare", "", fixture.clock.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := retainInitialControllerReceipt(fixture.options.ControllerBackup.ReceiptPath, encoded, plan, fixture.clock.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(fixture.options.ControllerBackup.ReceiptPath)
+	if err != nil || !bytes.Equal(initial, after) {
+		t.Fatal("preparation retry overwrote immutable receipt")
+	}
+}
+
+func TestNewProductionReleasePlansNeverStageArchiveOrPrivateKey(t *testing.T) {
+	fixture, keyed, _ := controllerReceiptFixture(t)
+	for _, selected := range []bool{false, true} {
+		plan := testProductionReleasePlan(t, t.TempDir())
+		plan.Format, plan.BackupMode, plan.WithBackups = 6, "disabled", selected
+		plan.AgeRecipient = productionReleaseFilePlan{}
+		if selected {
+			plan.BackupMode, plan.ControllerBackupDir, plan.ControllerBackupPublicKey = "controller-only", filepath.Join(fixture.workspace.root, "collection"), keyed.ControllerBackupPublicKey
+		}
+		if err := validateProductionReleasePlan(plan); err != nil {
+			t.Fatal(err)
+		}
+		planPath := filepath.Join(plan.ControllerWorkspace, productionReleasePlanFilename)
+		if err := os.WriteFile(planPath, []byte("fixture-plan"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(plan.ControllerWorkspace, productionReleasePlanHashFilename), []byte("fixture-digest"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		files, err := productionReleaseStageFiles(plan, planPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, file := range files {
+			if file.Path == "" || strings.HasSuffix(file.Path, ".age") || strings.HasSuffix(file.Path, ".key") || strings.Contains(file.Path, "recipient") {
+				t.Fatalf("private or backup file staged in new mode: %q", file.Path)
+			}
+		}
+		state := productionReleaseControllerState{RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, plan.DeploymentID), PlanSHA256: strings.Repeat("a", 64), ControllerReceiptSHA256: strings.Repeat("b", 64)}
+		args := strings.Join((&productionReleaseRuntime{}).productionApplyArguments(plan, state), " ")
+		if strings.Contains(args, "--backup-dir") || strings.Contains(args, ".age") || (!selected && strings.Contains(args, "--with-backups")) {
+			t.Fatalf("new plan staged backup authority: %s", args)
+		}
+		if selected && !strings.Contains(args, "--controller-backup-receipt-sha256") {
+			t.Fatal("selected plan lost its receipt binding")
+		}
+	}
+}

--- a/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_dispatch_test.go
@@ -26,8 +26,8 @@ func (runner *productionDispatchStatusRunner) Run(_ context.Context, command pro
 	if len(remote) == 3 && remote[0] == "readlink" && remote[1] == "--" {
 		return []byte(backendGoName + "\n"), nil
 	}
-	if len(remote) == 5 && remote[0] == "stat" && remote[1] == "-c" {
-		return []byte("0:700:1:regular file\n"), nil
+	if len(remote) == 5 && remote[0] == "stat" && remote[1] == "-c" && remote[2] == "%u:%f:%h" {
+		return []byte("0:81c0:1\n"), nil
 	}
 	if len(remote) == 3 && remote[0] == "sha256sum" && remote[1] == "--" {
 		return []byte(runner.payload + "  " + remote[2] + "\n"), nil
@@ -65,8 +65,8 @@ func (runner *productionDispatchFaultRunner) Run(_ context.Context, command prod
 	if len(remote) == 3 && remote[0] == "readlink" && remote[1] == "--" {
 		return []byte(backendGoName + "\n"), nil
 	}
-	if len(remote) == 5 && remote[0] == "stat" && remote[1] == "-c" {
-		return []byte("0:700:1:regular file\n"), nil
+	if len(remote) == 5 && remote[0] == "stat" && remote[1] == "-c" && remote[2] == "%u:%f:%h" {
+		return []byte("0:81c0:1\n"), nil
 	}
 	if len(remote) == 3 && remote[0] == "sha256sum" && remote[1] == "--" {
 		path := remote[2]
@@ -356,6 +356,49 @@ func TestProductionActivationDispatchFaultReconciliation(t *testing.T) {
 			}
 			if persisted.ActivationUnit != unit || persisted.DispatchAttempts != test.wantAttempts || persisted.DispatchObserved != test.wantObserved {
 				t.Fatalf("persisted state=%#v", persisted)
+			}
+		})
+	}
+}
+
+func TestControllerRecoveryUsesInstalledPackageBoundCLIWithoutStaging(t *testing.T) {
+	plan := testProductionDispatchPlan(t.TempDir(), "controller-recovery-installed")
+	plan.WithBackups, plan.BackupMode = true, "controller-only"
+	state := productionReleaseControllerState{RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, plan.DeploymentID)}
+	provider := filepath.Join(filepath.Dir(productionOperatorBinary), backendGoName)
+	for _, test := range []struct {
+		name              string
+		installed, staged bool
+		want              string
+	}{
+		{"installed verified without candidate staging", true, false, productionOperatorBinary},
+		{"old installed provider uses verified recovery staging", false, true, productionRemoteOperatorPath(state)},
+		{"neither operator trusted", false, false, ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			digests := make(map[string]string)
+			if test.staged {
+				digests = productionDispatchRemoteDigests(plan, state)
+			}
+			digests[provider], digests[productionOperatorBinary] = strings.Repeat("0", 64), strings.Repeat("0", 64)
+			if test.installed {
+				digests[provider], digests[productionOperatorBinary] = plan.GoCandidate.PayloadSHA256, plan.GoCandidate.PayloadSHA256
+			}
+			runner := &productionDispatchFaultRunner{remoteDigests: digests}
+			runtime := &productionReleaseRuntime{runner: runner}
+			operator, err := runtime.controllerRecoveryOperator(context.Background(), plan, state)
+			if test.want == "" {
+				if err == nil {
+					t.Fatal("untrusted installed/candidate operator accepted")
+				}
+			} else if err != nil || operator != test.want {
+				t.Fatalf("operator=%q error=%v", operator, err)
+			}
+			if test.installed && runner.digestCalls[productionRemoteOperatorPath(state)] != 0 {
+				t.Fatal("verified installed CLI still required staging")
+			}
+			if runner.dispatchCalls != 0 {
+				t.Fatal("operator selection dispatched a release")
 			}
 		})
 	}

--- a/apps/api-go/internal/appcli/deploy_production_receipt_transport.go
+++ b/apps/api-go/internal/appcli/deploy_production_receipt_transport.go
@@ -1,0 +1,138 @@
+package appcli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+var controllerReceiptTemporarySuffix = regexp.MustCompile(`^[A-Za-z0-9]{12}$`)
+
+// Stage small verified metadata atomically, never the backing archive or keys.
+// Failed transfers remain at unique .partial paths for audit; they cannot
+// occupy the immutable receipt path or prevent a later retry.
+func (runtime *productionReleaseRuntime) stageControllerReceipt(ctx context.Context, plan productionReleasePlan, state productionReleaseControllerState, local, digest string, confirmation bool) error {
+	name := controllerBackupReceiptName
+	if confirmation {
+		name = controllerBackupConfirmationName
+	}
+	if plan.Format != productionReleasePlanFormat || !plan.WithBackups || plan.BackupMode != "controller-only" || local != filepath.Join(plan.ControllerWorkspace, "state", name) || !productionSHA256Pattern.MatchString(digest) {
+		return errors.New("controller receipt staging requires the selected plan and exact metadata path")
+	}
+	receipt, err := readControllerBackupReceipt(local, plan.ControllerBackupPublicKey, digest, uint32(os.Geteuid()))
+	if err != nil {
+		return err
+	}
+	purpose := "prepare"
+	if confirmation {
+		purpose = "confirm"
+	}
+	if receipt.Purpose != purpose || receipt.DeploymentID != plan.DeploymentID || receipt.PlanSHA256 != state.PlanSHA256 {
+		return errors.New("controller receipt staging context differs from the frozen plan")
+	}
+	if err := validateControllerBackupFreshness(receipt, runtime.now()); err != nil {
+		return err
+	}
+	remote := filepath.Join(state.RemoteWorkspace, "state", name)
+	present, err := runtime.controllerReceiptDestination(ctx, plan.TargetAlias, remote, digest, confirmation)
+	if err != nil || present {
+		return err
+	}
+	prefix := remote + ".partial."
+	output, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, "mktemp", "--", prefix+"XXXXXXXXXXXX")
+	if err != nil {
+		return errors.New("could not allocate private remote receipt staging")
+	}
+	temporary := strings.TrimSpace(string(output))
+	if !strings.HasPrefix(temporary, prefix) || !controllerReceiptTemporarySuffix.MatchString(strings.TrimPrefix(temporary, prefix)) {
+		return errors.New("remote receipt temporary path escaped its exact namespace")
+	}
+	if err := runtime.verifyRemoteReceiptFile(ctx, plan.TargetAlias, temporary, ""); err != nil {
+		return err
+	}
+	if err := runtime.scpTo(ctx, local, plan.TargetAlias, temporary); err != nil {
+		return fmt.Errorf("receipt transfer interrupted; partial metadata retained: %w", err)
+	}
+	if err := runtime.verifyRemoteReceiptFile(ctx, plan.TargetAlias, temporary, digest); err != nil {
+		return err
+	}
+	arguments := []string{"mv", "-T"}
+	if !confirmation {
+		arguments = append(arguments, "--no-clobber")
+	}
+	arguments = append(arguments, "--", temporary, remote)
+	if _, err := runtime.ssh(ctx, plan.TargetAlias, 2*time.Minute, arguments...); err != nil {
+		return err
+	}
+	return runtime.verifyRemoteReceiptFile(ctx, plan.TargetAlias, remote, digest)
+}
+
+func (runtime *productionReleaseRuntime) controllerReceiptDestination(ctx context.Context, alias, remote, digest string, replace bool) (bool, error) {
+	if _, err := runtime.ssh(ctx, alias, 2*time.Minute, "test", "!", "-L", remote); err != nil {
+		return false, errors.New("remote receipt destination is a link or cannot be inspected")
+	}
+	if _, err := runtime.ssh(ctx, alias, 2*time.Minute, "test", "-e", remote); err != nil {
+		if _, absentErr := runtime.ssh(ctx, alias, 2*time.Minute, "test", "!", "-e", remote); absentErr != nil {
+			return false, errors.New("remote receipt absence could not be proven")
+		}
+		return false, nil
+	}
+	if err := runtime.verifyRemoteReceiptFile(ctx, alias, remote, ""); err != nil {
+		return false, err
+	}
+	current, err := runtime.remoteFileSHA256(ctx, alias, remote)
+	if err != nil {
+		return false, err
+	}
+	if current == digest {
+		return true, nil
+	}
+	if !replace {
+		return false, errors.New("immutable remote receipt already contains different evidence; use a new deployment ID")
+	}
+	return false, nil
+}
+
+func (runtime *productionReleaseRuntime) verifyRemoteReceiptFile(ctx context.Context, alias, path, digest string) error {
+	// %f includes the numeric file type and permission bits (0100600 = 8180).
+	// Unlike %F it is locale-independent and treats empty mktemp files as
+	// regular files too; newly allocated receipts are necessarily empty.
+	output, err := runtime.ssh(ctx, alias, 2*time.Minute, "stat", "-c", "%u:%f:%h", "--", path)
+	if err != nil || strings.TrimSpace(string(output)) != "0:8180:1" {
+		return errors.New("remote receipt is not a private root-owned single-link regular file")
+	}
+	if digest != "" {
+		actual, err := runtime.remoteFileSHA256(ctx, alias, path)
+		if err != nil || actual != digest {
+			return errors.New("remote receipt digest mismatch")
+		}
+	}
+	return nil
+}
+
+func checkInitialControllerReceiptRetry(local string, plan productionReleasePlan, expectedDigest string, now time.Time) error {
+	if _, err := os.Lstat(local); errors.Is(err, os.ErrNotExist) {
+		if expectedDigest != "" {
+			return errors.New("persisted initial receipt is missing; restore the original evidence or use a new deployment ID")
+		}
+		return nil
+	} else if err != nil {
+		return err
+	}
+	receipt, err := readControllerBackupReceipt(local, plan.ControllerBackupPublicKey, expectedDigest, uint32(os.Geteuid()))
+	if err != nil {
+		return err
+	}
+	if receipt.Purpose != "prepare" || receipt.DeploymentID != plan.DeploymentID {
+		return errors.New("initial receipt has a different deployment identity or purpose")
+	}
+	if err := validateControllerBackupFreshness(receipt, now); err != nil {
+		return fmt.Errorf("initial receipt cannot be renewed in place; create a new deployment ID and collect newly bound evidence: %w", err)
+	}
+	return nil
+}

--- a/apps/api-go/internal/appcli/deploy_production_receipt_transport_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_receipt_transport_test.go
@@ -1,0 +1,358 @@
+//go:build !windows
+
+package appcli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+type receiptTransportRunner struct {
+	files          map[string][]byte
+	metadata       map[string]string
+	failTransfer   bool
+	raceFinal      []byte
+	temporaryCount int
+	transferCount  int
+	commands       []productionCommand
+}
+
+func (r *receiptTransportRunner) Run(_ context.Context, command productionCommand) ([]byte, error) {
+	r.commands = append(r.commands, command)
+	if command.Name == commandSCP {
+		if len(command.Args) != 5 {
+			return nil, errors.New("unexpected SCP arguments")
+		}
+		remote, ok := strings.CutPrefix(command.Args[4], productionTargetAlias+":")
+		if !ok {
+			return nil, errors.New("unexpected SCP host")
+		}
+		data, err := os.ReadFile(command.Args[3])
+		if err != nil {
+			return nil, err
+		}
+		r.transferCount++
+		if r.failTransfer {
+			r.failTransfer = false
+			r.files[remote] = bytes.Clone(data[:len(data)/2])
+			return nil, errors.New("injected interrupted metadata transfer")
+		}
+		r.files[remote] = data
+		return nil, nil
+	}
+	if command.Name != commandSSH || len(command.Args) < 4 || command.Args[2] != productionTargetAlias {
+		return nil, errors.New("unexpected transport command or host")
+	}
+	args := command.Args[3:]
+	switch args[0] {
+	case "test":
+		path := args[len(args)-1]
+		_, exists := r.files[path]
+		if slices.Contains(args, "-L") {
+			return nil, nil
+		}
+		if exists != slices.Contains(args, "!") {
+			return nil, nil
+		}
+		return nil, errors.New("test predicate is false")
+	case "mktemp":
+		r.temporaryCount++
+		path := strings.TrimSuffix(args[2], "XXXXXXXXXXXX") + fmt.Sprintf("%012d", r.temporaryCount)
+		r.files[path] = []byte{}
+		return []byte(path + "\n"), nil
+	case "stat":
+		if len(args) != 5 || args[2] != "%u:%f:%h" {
+			return nil, errors.New("receipt metadata must use locale-independent numeric file types")
+		}
+		path := args[len(args)-1]
+		if _, exists := r.files[path]; !exists {
+			return nil, os.ErrNotExist
+		}
+		mode := r.metadata[path]
+		if mode == "" {
+			mode = "0:8180:1"
+		}
+		return []byte(mode + "\n"), nil
+	case "sha256sum":
+		path := args[len(args)-1]
+		data, exists := r.files[path]
+		if !exists {
+			return nil, os.ErrNotExist
+		}
+		return []byte(controllerBackupDigest(data) + "  " + path + "\n"), nil
+	case "head":
+		data, exists := r.files[args[len(args)-1]]
+		if !exists {
+			return nil, os.ErrNotExist
+		}
+		return bytes.Clone(data), nil
+	case "mv":
+		from, to := args[len(args)-2], args[len(args)-1]
+		if r.raceFinal != nil {
+			r.files[to] = bytes.Clone(r.raceFinal)
+		}
+		if _, exists := r.files[to]; exists && slices.Contains(args, "--no-clobber") {
+			return nil, nil
+		}
+		data, exists := r.files[from]
+		if !exists {
+			return nil, os.ErrNotExist
+		}
+		r.files[to] = data
+		delete(r.files, from)
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unexpected remote metadata operation: %s", args[0])
+	}
+}
+
+func receiptTransportFixture(t *testing.T) (productionFixture, productionReleasePlan, controllerBackupSet, productionReleaseControllerState, *receiptTransportRunner, *productionReleaseRuntime) {
+	t.Helper()
+	fixture, plan, set := controllerReceiptFixture(t)
+	plan.TargetAlias = productionTargetAlias
+	state := productionReleaseControllerState{RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, plan.DeploymentID), PlanSHA256: fixture.options.ControllerBackup.PlanSHA256}
+	runner := &receiptTransportRunner{files: make(map[string][]byte), metadata: make(map[string]string)}
+	runtime := &productionReleaseRuntime{runner: runner, now: fixture.runtime.now}
+	return fixture, plan, set, state, runner, runtime
+}
+
+type controllerReceiptIntegrationRunner struct {
+	transport *receiptTransportRunner
+	archives  *controllerImportRunner
+}
+
+func (runner *controllerReceiptIntegrationRunner) Run(ctx context.Context, command productionCommand) ([]byte, error) {
+	if command.Name == commandSSH || command.Name == commandSCP {
+		return runner.transport.Run(ctx, command)
+	}
+	return runner.archives.Run(ctx, command)
+}
+
+func TestControllerOnlyImportPrepareAndManifestBoundConfirmationFlow(t *testing.T) {
+	fixture := newControllerImportFixture(t)
+	plan := fixture.plan
+	plan.Format, plan.WithBackups, plan.BackupMode = productionReleasePlanFormat, true, "controller-only"
+	plan.TargetAlias, plan.ControllerBackupDir, plan.GoChanged, plan.WebChanged = productionTargetAlias, fixture.root, true, true
+	plan.GoCandidate.PackageSHA256, plan.WebCandidate.PackageSHA256 = strings.Repeat("a", 64), strings.Repeat("b", 64)
+	if err := os.Mkdir(filepath.Join(plan.ControllerWorkspace, "state"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	publicKey, err := initializeControllerBackupKey(plan.ControllerWorkspace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan.ControllerBackupPublicKey = publicKey
+	state := productionReleaseControllerState{Format: productionReleaseStateFormat, DeploymentID: plan.DeploymentID,
+		PlanSHA256: strings.Repeat("c", 64), Phase: productionReleasePhaseStaged,
+		RemoteWorkspace: filepath.Join(defaultProductionPaths().WorkRoot, plan.DeploymentID), UpdatedUTC: fixture.runtime.now()}
+	transport := &receiptTransportRunner{files: make(map[string][]byte), metadata: make(map[string]string)}
+	runner := &controllerReceiptIntegrationRunner{transport: transport, archives: fixture.runner}
+	runtime := &productionReleaseRuntime{runner: runner, now: fixture.runtime.now}
+	if err := runtime.prepareControllerOnlyBackup(context.Background(), plan, &state, fixture.identity); err != nil {
+		t.Fatal(err)
+	}
+	if state.Phase != productionReleasePhaseBackupsReady || state.TargetBackup != "" || state.OffhostBackup != "" || state.ControllerReceiptSHA256 == "" {
+		t.Fatal("invalid prepared controller-only state")
+	}
+	initialPath := filepath.Join(state.RemoteWorkspace, "state", controllerBackupReceiptName)
+	initial, err := decodeSignedControllerBackupReceipt(transport.files[initialPath], publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := productionManifest{Format: productionTransactionFormat, DeploymentID: plan.DeploymentID,
+		BackupsEnabled: true, BackupEvidenceFormat: controllerBackupEvidenceFormat,
+		ControllerOnlyBackup: &controllerBackupBinding{PublicKey: publicKey, PlanSHA256: state.PlanSHA256, ReceiptPath: initialPath, ReceiptSHA256: state.ControllerReceiptSHA256},
+		DatabaseSchema:       initial.DatabaseSchema, DatabaseBackupSHA256: initial.ArchivePlaintexts["database"], ControllerBackupSHA256: initial.BackupSetSHA256,
+		EnvironmentRestoreSHA256: initial.EnvironmentSHA256,
+		Go:                       productionPackageTransition{CandidateSHA256: plan.GoCandidate.PackageSHA256, RollbackSHA256: plan.GoRollback.PackageSHA256},
+		Web:                      productionPackageTransition{CandidateSHA256: plan.WebCandidate.PackageSHA256, RollbackSHA256: plan.WebRollback.PackageSHA256},
+		Frontend:                 productionFrontendTransition{OldIndexSHA256: plan.WebRollback.PayloadSHA256}}
+	encoded, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(state.RemoteWorkspace, "state", productionManifestFilename)
+	transport.files[manifestPath] = append(encoded, '\n')
+	state.Phase = "AWAITING_CONFIRMATION"
+	if err := runtime.reverifyControllerOnlyBackup(context.Background(), plan, state, fixture.identity); err != nil {
+		t.Fatal(err)
+	}
+	confirmation, err := decodeSignedControllerBackupReceipt(transport.files[filepath.Join(state.RemoteWorkspace, "state", controllerBackupConfirmationName)], publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confirmation.Purpose != "confirm" || confirmation.DeploymentManifestSHA256 != controllerBackupDigest(transport.files[manifestPath]) || !sameControllerBackupSnapshot(initial, confirmation) {
+		t.Fatal("confirmation lost its immutable snapshot/manifest binding")
+	}
+	if controllerBackupDigest(transport.files[initialPath]) != state.ControllerReceiptSHA256 {
+		t.Fatal("confirmation rewrote initial receipt")
+	}
+	entries, err := os.ReadDir(filepath.Join(plan.ControllerWorkspace, "tmp"))
+	if err != nil || len(entries) != 0 {
+		t.Fatal("plaintext scratch survived controller confirmation")
+	}
+	if transport.transferCount != 2 {
+		t.Fatalf("expected only two small receipt transfers, got %d", transport.transferCount)
+	}
+}
+
+func TestControllerReceiptInterruptedTransferIsRetryableAndAtomic(t *testing.T) {
+	fixture, plan, _, state, runner, runtime := receiptTransportFixture(t)
+	remote := filepath.Join(state.RemoteWorkspace, "state", controllerBackupReceiptName)
+	local, digest := fixture.options.ControllerBackup.ReceiptPath, fixture.options.ControllerBackup.ReceiptSHA256
+	runner.failTransfer = true
+	if err := runtime.stageControllerReceipt(context.Background(), plan, state, local, digest, false); err == nil {
+		t.Fatal("interrupted transfer succeeded")
+	}
+	if _, exists := runner.files[remote]; exists {
+		t.Fatal("partial data occupied immutable receipt path")
+	}
+	if len(runner.files) != 1 {
+		t.Fatal("partial metadata was not retained")
+	}
+	if err := runtime.stageControllerReceipt(context.Background(), plan, state, local, digest, false); err != nil {
+		t.Fatal(err)
+	}
+	if controllerBackupDigest(runner.files[remote]) != digest || runner.temporaryCount != 2 {
+		t.Fatal("retry failed to publish the complete original evidence")
+	}
+	if err := runtime.stageControllerReceipt(context.Background(), plan, state, local, digest, false); err != nil {
+		t.Fatal(err)
+	}
+	if runner.transferCount != 2 {
+		t.Fatal("matching immutable receipt was unnecessarily transferred again")
+	}
+}
+
+func TestControllerReceiptPublishCannotClobberConcurrentInitialEvidence(t *testing.T) {
+	fixture, plan, _, state, runner, runtime := receiptTransportFixture(t)
+	runner.raceFinal = []byte("concurrently published different evidence")
+	if err := runtime.stageControllerReceipt(context.Background(), plan, state, fixture.options.ControllerBackup.ReceiptPath, fixture.options.ControllerBackup.ReceiptSHA256, false); err == nil {
+		t.Fatal("concurrent mismatched receipt accepted")
+	}
+	remote := filepath.Join(state.RemoteWorkspace, "state", controllerBackupReceiptName)
+	if !bytes.Equal(runner.files[remote], runner.raceFinal) {
+		t.Fatal("immutable receipt overwritten during a publication race")
+	}
+}
+
+func TestControllerConfirmationRetriesWithoutChangingInitialReceipt(t *testing.T) {
+	fixture, plan, set, state, runner, runtime := receiptTransportFixture(t)
+	if err := runtime.stageControllerReceipt(context.Background(), plan, state, fixture.options.ControllerBackup.ReceiptPath, fixture.options.ControllerBackup.ReceiptSHA256, false); err != nil {
+		t.Fatal(err)
+	}
+	initial := filepath.Join(state.RemoteWorkspace, "state", controllerBackupReceiptName)
+	original := bytes.Clone(runner.files[initial])
+	local := filepath.Join(plan.ControllerWorkspace, "state", controllerBackupConfirmationName)
+	remote := filepath.Join(state.RemoteWorkspace, "state", controllerBackupConfirmationName)
+	for attempt := 0; attempt < 2; attempt++ {
+		*fixture.clock = fixture.clock.Add(time.Second)
+		writeControllerConfirmation(t, fixture, plan, set, strings.Repeat("a", 64))
+		runner.failTransfer = true
+		digest := mustHashFile(t, local)
+		if err := runtime.stageControllerReceipt(context.Background(), plan, state, local, digest, true); err == nil {
+			t.Fatal("interrupted confirmation succeeded")
+		}
+		if err := runtime.stageControllerReceipt(context.Background(), plan, state, local, digest, true); err != nil {
+			t.Fatal(err)
+		}
+		if controllerBackupDigest(runner.files[remote]) != digest {
+			t.Fatal("confirmation was not atomically updated")
+		}
+	}
+	if !bytes.Equal(runner.files[initial], original) {
+		t.Fatal("confirmation changed immutable initial evidence")
+	}
+}
+
+func TestControllerReceiptRejectsUnsafeExistingDestination(t *testing.T) {
+	fixture, plan, _, state, runner, runtime := receiptTransportFixture(t)
+	remote := filepath.Join(state.RemoteWorkspace, "state", controllerBackupReceiptName)
+	runner.files[remote] = []byte("occupied")
+	for _, metadata := range []string{"0:8180:2", "0:81a4:1", "1000:8180:1", "0:a180:1", "0:8980:1"} {
+		runner.metadata[remote] = metadata
+		if err := runtime.stageControllerReceipt(context.Background(), plan, state, fixture.options.ControllerBackup.ReceiptPath, fixture.options.ControllerBackup.ReceiptSHA256, false); err == nil {
+			t.Fatalf("accepted unsafe metadata %s", metadata)
+		}
+	}
+	if runner.transferCount != 0 {
+		t.Fatal("unsafe destination reached transfer")
+	}
+}
+
+func TestExpiredPreparationStopsBeforeDecryptOrSSHWithoutRelabeling(t *testing.T) {
+	fixture, plan, _, state, runner, runtime := receiptTransportFixture(t)
+	original, err := os.ReadFile(fixture.options.ControllerBackup.ReceiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	*fixture.clock = fixture.clock.Add(5 * time.Minute)
+	err = runtime.prepareControllerOnlyBackup(context.Background(), plan, &state, "unused-private-key")
+	if err == nil || !strings.Contains(err.Error(), "new deployment ID") {
+		t.Fatalf("expiry recovery message: %v", err)
+	}
+	if len(runner.commands) != 0 {
+		t.Fatal("expired proof caused decryption or remote commands")
+	}
+	after, err := os.ReadFile(fixture.options.ControllerBackup.ReceiptPath)
+	if err != nil || !bytes.Equal(original, after) {
+		t.Fatal("expired receipt was relabeled")
+	}
+}
+
+func TestInitialReceiptPublishLeavesPartialFilesOutsideImmutableName(t *testing.T) {
+	fixture, plan, _ := controllerReceiptFixture(t)
+	name := fixture.options.ControllerBackup.ReceiptPath
+	encoded, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(name); err != nil {
+		t.Fatal(err)
+	}
+	partial := filepath.Join(filepath.Dir(name), ".controller-receipt.partial-failed")
+	if err := os.WriteFile(partial, encoded[:7], 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := retainInitialControllerReceipt(name, encoded, plan, *fixture.clock); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readControllerBackupReceipt(name, plan.ControllerBackupPublicKey, fixture.options.ControllerBackup.ReceiptSHA256, uint32(os.Geteuid())); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(partial); err != nil {
+		t.Fatal("failed partial metadata was removed")
+	}
+}
+
+func TestControllerReceiptRejectsNumericPayloadArray(t *testing.T) {
+	fixture, plan, _ := controllerReceiptFixture(t)
+	encoded, err := os.ReadFile(fixture.options.ControllerBackup.ReceiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var envelope controllerBackupEnvelope
+	if err := json.Unmarshal(encoded, &envelope); err != nil {
+		t.Fatal(err)
+	}
+	numbers := make([]int, len(envelope.Payload))
+	for i, value := range envelope.Payload {
+		numbers[i] = int(value)
+	}
+	array, err := json.Marshal(map[string]any{"format": 1, "payload": numbers, "signature": envelope.Signature})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := decodeSignedControllerBackupReceipt(array, plan.ControllerBackupPublicKey); err == nil {
+		t.Fatal("numeric array accepted instead of cross-language base64 string")
+	}
+}

--- a/apps/api-go/internal/appcli/deploy_production_release.go
+++ b/apps/api-go/internal/appcli/deploy_production_release.go
@@ -23,7 +23,7 @@ const (
 	productionOffhostAlias            = "archczy"
 	productionOffhostExpectedHost     = "archczy"
 	productionOffhostRoot             = "/home/arch/.local/state/lmm-api-production-backups"
-	productionReleasePlanFormat       = 5
+	productionReleasePlanFormat       = 6
 	productionReleaseStateFormat      = 3
 	productionReleasePlanFilename     = "release-plan.json"
 	productionReleasePlanHashFilename = "release-plan.sha256"
@@ -51,6 +51,7 @@ type productionReleasePlanOptions struct {
 	ProbeBinary              string
 	OperatorBinary           string
 	AgeRecipientFile         string
+	ControllerBackupDir      string
 	ObservationSeconds       int
 	PreserveEdgePolicy       bool
 	WithBackups              bool
@@ -79,27 +80,30 @@ type productionReleaseFilePlan struct {
 }
 
 type productionReleasePlan struct {
-	Format              int                          `json:"format"`
-	DeploymentID        string                       `json:"deployment_id"`
-	CreatedUTC          time.Time                    `json:"created_utc"`
-	ControllerWorkspace string                       `json:"controller_workspace"`
-	Repository          string                       `json:"repository"`
-	TargetAlias         string                       `json:"target_alias"`
-	ExpectedHost        string                       `json:"expected_host"`
-	OperatorUser        string                       `json:"operator_user"`
-	ExpectedVersion     string                       `json:"expected_version"`
-	GoCandidate         productionReleasePackagePlan `json:"go_candidate"`
-	GoRollback          productionReleasePackagePlan `json:"go_rollback"`
-	WebCandidate        productionReleasePackagePlan `json:"web_candidate"`
-	WebRollback         productionReleasePackagePlan `json:"web_rollback"`
-	ProbeBinary         productionReleaseFilePlan    `json:"probe_binary"`
-	OperatorBinary      productionReleaseFilePlan    `json:"operator_binary,omitempty"`
-	GoChanged           bool                         `json:"go_changed"`
-	WebChanged          bool                         `json:"web_changed"`
-	ObservationSeconds  int                          `json:"observation_seconds"`
-	PreserveEdgePolicy  bool                         `json:"preserve_edge_policy"`
-	WithBackups         bool                         `json:"with_backups"`
-	AgeRecipient        productionReleaseFilePlan    `json:"age_recipient,omitempty"`
+	Format                    int                          `json:"format"`
+	DeploymentID              string                       `json:"deployment_id"`
+	CreatedUTC                time.Time                    `json:"created_utc"`
+	ControllerWorkspace       string                       `json:"controller_workspace"`
+	Repository                string                       `json:"repository"`
+	TargetAlias               string                       `json:"target_alias"`
+	ExpectedHost              string                       `json:"expected_host"`
+	OperatorUser              string                       `json:"operator_user"`
+	ExpectedVersion           string                       `json:"expected_version"`
+	GoCandidate               productionReleasePackagePlan `json:"go_candidate"`
+	GoRollback                productionReleasePackagePlan `json:"go_rollback"`
+	WebCandidate              productionReleasePackagePlan `json:"web_candidate"`
+	WebRollback               productionReleasePackagePlan `json:"web_rollback"`
+	ProbeBinary               productionReleaseFilePlan    `json:"probe_binary"`
+	OperatorBinary            productionReleaseFilePlan    `json:"operator_binary,omitempty"`
+	GoChanged                 bool                         `json:"go_changed"`
+	WebChanged                bool                         `json:"web_changed"`
+	ObservationSeconds        int                          `json:"observation_seconds"`
+	PreserveEdgePolicy        bool                         `json:"preserve_edge_policy"`
+	WithBackups               bool                         `json:"with_backups"`
+	BackupMode                string                       `json:"backup_mode,omitempty"`
+	ControllerBackupDir       string                       `json:"controller_backup_dir,omitempty"`
+	ControllerBackupPublicKey string                       `json:"controller_backup_public_key,omitempty"`
+	AgeRecipient              productionReleaseFilePlan    `json:"age_recipient,omitempty"`
 }
 
 type productionReleasePlanResult struct {
@@ -155,8 +159,9 @@ func parseProductionReleasePlanOptions(args []string, stderr io.Writer) (product
 	flags.StringVar(&options.WebRollbackReleaseBundle, "web-rollback-release-bundle", "", "rollback Web Sigstore bundle")
 	flags.StringVar(&options.ProbeBinary, "probe-binary", "", "candidate lmm-api binary extracted from the signed Go release")
 	flags.StringVar(&options.OperatorBinary, "operator-binary", "", "optional additional candidate operator artifact to verify before normalizing execution to --probe-binary")
-	flags.BoolVar(&options.WithBackups, "with-backups", false, "require verified target, controller, and off-host backups (mandatory for Go changes)")
-	flags.StringVar(&options.AgeRecipientFile, "age-recipient-file", "", "age or SSH public recipient file used when backups are enabled")
+	flags.BoolVar(&options.WithBackups, "with-backups", false, "select an independently collected controller-only encrypted backup set")
+	flags.StringVar(&options.ControllerBackupDir, "controller-backup-dir", "", "private controller directory containing the completed encrypted backup set")
+	flags.StringVar(&options.AgeRecipientFile, "age-recipient-file", "", "legacy input rejected by new controller-only release plans")
 	flags.IntVar(&options.ObservationSeconds, "observation-seconds", options.ObservationSeconds, "stability observation window (120-360)")
 	flags.BoolVar(&options.PreserveEdgePolicy, "preserve-edge-policy", false, "preserve the active nginx edge policy during activation")
 	flags.Usage = func() { writeProductionDeployUsage(stderr) }
@@ -190,10 +195,13 @@ func parseProductionReleasePlanOptions(args []string, stderr io.Writer) (product
 		"--probe-binary":                &options.ProbeBinary,
 		"--operator-binary":             &options.OperatorBinary,
 	}
+	if options.AgeRecipientFile != "" {
+		return productionReleasePlanOptions{}, errors.New("new plans import controller-only backups; --age-recipient-file cannot create target or off-host copies")
+	}
 	if options.WithBackups {
-		paths["--age-recipient-file"] = &options.AgeRecipientFile
-	} else if options.AgeRecipientFile != "" {
-		return productionReleasePlanOptions{}, errors.New("--age-recipient-file requires --with-backups")
+		paths["--controller-backup-dir"] = &options.ControllerBackupDir
+	} else if options.ControllerBackupDir != "" {
+		return productionReleasePlanOptions{}, errors.New("--controller-backup-dir requires explicit --with-backups")
 	}
 	for label, value := range paths {
 		if *value == "" {
@@ -242,10 +250,11 @@ func (runtime *productionReleaseRuntime) createPlan(ctx context.Context, options
 	if err := validateControllerArtifact(options.OperatorBinary, "operator binary", true); err != nil {
 		return productionReleasePlanResult{}, err
 	}
-	if options.WithBackups {
-		if err := validateControllerArtifact(options.AgeRecipientFile, "age recipient", false); err != nil {
-			return productionReleasePlanResult{}, err
-		}
+	if options.AgeRecipientFile != "" {
+		return productionReleasePlanResult{}, errors.New("new release plans do not create target or off-host backup copies")
+	}
+	if options.WithBackups != (options.ControllerBackupDir != "") {
+		return productionReleasePlanResult{}, errors.New("controller-only backups must be explicitly selected with their import directory")
 	}
 	planPath := filepath.Join(options.Workspace, productionReleasePlanFilename)
 	digestPath := filepath.Join(options.Workspace, productionReleasePlanHashFilename)
@@ -276,9 +285,6 @@ func (runtime *productionReleaseRuntime) createPlan(ctx context.Context, options
 	webChanged := webCandidate.PackageSHA256 != webRollback.PackageSHA256
 	if !goChanged && !webChanged {
 		return productionReleasePlanResult{}, errors.New("candidate release is byte-identical to both rollback packages")
-	}
-	if goChanged && !options.WithBackups {
-		return productionReleasePlanResult{}, errors.New("production Go releases require verified three-copy backups; supply --with-backups and --age-recipient-file")
 	}
 	if err := validateChangedIdentity(goChanged, releasePlanMetadata(goCandidate), releasePlanMetadata(goRollback), goCandidate.PackageSHA256, goRollback.PackageSHA256); err != nil {
 		return productionReleasePlanResult{}, fmt.Errorf("Go package pair: %w", err)
@@ -331,13 +337,16 @@ func (runtime *productionReleaseRuntime) createPlan(ctx context.Context, options
 		ObservationSeconds:  options.ObservationSeconds,
 		PreserveEdgePolicy:  options.PreserveEdgePolicy,
 		WithBackups:         options.WithBackups,
+		BackupMode:          "disabled",
 	}
 	if options.WithBackups {
-		recipientSHA256, err := sha256File(options.AgeRecipientFile)
+		publicKey, err := initializeControllerBackupKey(options.Workspace)
 		if err != nil {
-			return productionReleasePlanResult{}, fmt.Errorf("hash age recipient: %w", err)
+			return productionReleasePlanResult{}, err
 		}
-		plan.AgeRecipient = productionReleaseFilePlan{Path: options.AgeRecipientFile, SHA256: recipientSHA256}
+		plan.BackupMode = "controller-only"
+		plan.ControllerBackupDir = options.ControllerBackupDir
+		plan.ControllerBackupPublicKey = publicKey
 	}
 	if err := validateProductionReleasePlan(plan); err != nil {
 		return productionReleasePlanResult{}, err
@@ -1206,8 +1215,11 @@ func loadProductionReleasePlan(path, expectedSHA256 string) (productionReleasePl
 
 // pi-lens-ignore: go-bare-error
 func validateProductionReleasePlan(plan productionReleasePlan) error {
-	if plan.Format != productionReleasePlanFormat {
+	if plan.Format != productionReleasePlanFormat && plan.Format != 5 {
 		return errors.New("unsupported release plan format")
+	}
+	if err := validateControllerOnlyReleasePlanPolicy(plan); err != nil {
+		return err
 	}
 	if !productionIDPattern.MatchString(plan.DeploymentID) {
 		return errors.New("release plan deployment ID is invalid")
@@ -1221,8 +1233,8 @@ func validateProductionReleasePlan(plan productionReleasePlan) error {
 	if !productionVersionPattern.MatchString(plan.ExpectedVersion) || plan.ObservationSeconds < 120 || plan.ObservationSeconds > 360 {
 		return errors.New("release plan timing or version contract is invalid")
 	}
-	if plan.GoChanged && !plan.WithBackups {
-		return errors.New("production release plans with Go changes require verified three-copy backups")
+	if plan.Format == 5 && plan.GoChanged && !plan.WithBackups {
+		return errors.New("legacy production release plans with Go changes require verified three-copy backups")
 	}
 	workspace, err := cleanAbsoluteNonRoot(plan.ControllerWorkspace)
 	if err != nil || workspace != plan.ControllerWorkspace {
@@ -1285,7 +1297,7 @@ func validateProductionReleasePlan(plan productionReleasePlan) error {
 		plan.OperatorBinary.SHA256 != plan.ProbeBinary.SHA256 {
 		return errors.New("release plan operator identity is invalid")
 	}
-	if plan.WithBackups {
+	if plan.WithBackups && plan.Format == 5 {
 		recipient, err := cleanAbsoluteNonRoot(plan.AgeRecipient.Path)
 		if err != nil || recipient != plan.AgeRecipient.Path || !productionSHA256Pattern.MatchString(plan.AgeRecipient.SHA256) {
 			return errors.New("release plan age recipient is invalid")
@@ -1306,7 +1318,7 @@ func validateReleaseBasenameCollisions(plan productionReleasePlan) error {
 		plan.ProbeBinary,
 		plan.OperatorBinary,
 	}
-	if plan.WithBackups {
+	if plan.WithBackups && plan.Format == 5 {
 		files = append(files, plan.AgeRecipient)
 	}
 	for _, file := range files {
@@ -1349,7 +1361,7 @@ func validateProductionReleasePlanArtifacts(ctx context.Context, runtime *produc
 		{plan.ProbeBinary.Path, plan.ProbeBinary.SHA256, "probe binary"},
 		{plan.OperatorBinary.Path, plan.OperatorBinary.SHA256, "operator binary"},
 	}
-	if plan.WithBackups {
+	if plan.WithBackups && plan.Format == 5 {
 		files = append(files, struct {
 			path   string
 			digest string

--- a/apps/api-go/internal/appcli/deploy_production_release_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_release_test.go
@@ -89,10 +89,10 @@ func TestParseProductionReleasePlanAcceptsSafeAbsoluteInputs(t *testing.T) {
 	}
 }
 
-func TestParseProductionReleasePlanRequiresAgeRecipientWithBackups(t *testing.T) {
+func TestParseProductionReleasePlanRequiresControllerImportWithSelectedBackups(t *testing.T) {
 	arguments := append(validProductionReleasePlanArguments(t.TempDir()), "--with-backups")
 	_, err := parseProductionReleasePlanOptions(arguments, &bytes.Buffer{})
-	if err == nil || !strings.Contains(err.Error(), "--age-recipient-file is required") {
+	if err == nil || !strings.Contains(err.Error(), "--controller-backup-dir is required") {
 		t.Fatalf("backup input error=%v", err)
 	}
 }
@@ -207,7 +207,8 @@ func testProductionReleasePlan(t *testing.T, root string) productionReleasePlan 
 	goRollback := testProductionReleasePackage(t, root, productionAURPackageName, "0.1.69-1", strings.Repeat("3", 64), strings.Repeat("4", 64))
 	web := testProductionReleasePackage(t, root, productionWebPackageName, "0.1.41-1", strings.Repeat("5", 64), strings.Repeat("6", 64))
 	return productionReleasePlan{
-		Format:              productionReleasePlanFormat,
+		// Keep this fixture format 5 to exercise legacy recovery compatibility.
+		Format:              5,
 		DeploymentID:        "release-0.2.0-test",
 		CreatedUTC:          time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC),
 		ControllerWorkspace: root,
@@ -268,7 +269,7 @@ func TestValidateProductionReleasePlanRejectsCandidateContractMismatch(t *testin
 	}
 }
 
-func TestValidateProductionReleasePlanRequiresBackupsForGoChanges(t *testing.T) {
+func TestValidateLegacyProductionReleasePlanPreservesGoBackupRequirement(t *testing.T) {
 	plan := testProductionReleasePlan(t, t.TempDir())
 	plan.WithBackups = false
 	plan.AgeRecipient = productionReleaseFilePlan{}

--- a/apps/api-go/internal/appcli/deploy_production_state.go
+++ b/apps/api-go/internal/appcli/deploy_production_state.go
@@ -318,6 +318,7 @@ type productionTransactionOptions struct {
 	ExpectedVersion      string
 	BackupDir            string
 	WithBackups          bool
+	ControllerBackup     controllerBackupBinding
 	ObservationWindow    time.Duration
 	PreserveEdgePolicy   bool
 	Reason               string
@@ -364,6 +365,7 @@ type productionManifest struct {
 	BackupDir                string                       `json:"backup_dir,omitempty"`
 	BackupsEnabled           bool                         `json:"backups_enabled"`
 	BackupEvidenceFormat     int                          `json:"backup_evidence_format,omitempty"`
+	ControllerOnlyBackup     *controllerBackupBinding     `json:"controller_only_backup,omitempty"`
 	DatabaseBackupSHA256     string                       `json:"database_backup_sha256,omitempty"`
 	TargetBackupSHA256       string                       `json:"target_backup_sha256,omitempty"`
 	ControllerBackupSHA256   string                       `json:"controller_backup_sha256,omitempty"`
@@ -787,7 +789,11 @@ func parseProductionTransactionOptions(action string, args []string, stderr io.W
 		flags.StringVar(&options.OperatorBinarySHA256, "operator-binary-sha256", "", "operator binary SHA-256")
 		flags.StringVar(&options.ExpectedVersion, "expected-version", "", "candidate service version")
 		flags.StringVar(&options.BackupDir, "backup-dir", "", "verified target copy from the production three-copy backup set")
-		flags.BoolVar(&options.WithBackups, "with-backups", false, "bind verified production backups (mandatory for Go changes)")
+		flags.BoolVar(&options.WithBackups, "with-backups", false, "bind explicitly selected verified production backup evidence")
+		flags.StringVar(&options.ControllerBackup.PublicKey, "controller-backup-public-key", "", "frozen controller verification public key")
+		flags.StringVar(&options.ControllerBackup.PlanSHA256, "release-plan-sha256", "", "immutable controller release-plan SHA-256")
+		flags.StringVar(&options.ControllerBackup.ReceiptPath, "controller-backup-receipt", "", "root-owned signed controller-only verification receipt")
+		flags.StringVar(&options.ControllerBackup.ReceiptSHA256, "controller-backup-receipt-sha256", "", "signed controller verification receipt SHA-256")
 		observationSeconds := int(options.ObservationWindow / time.Second)
 		flags.IntVar(&observationSeconds, "observation-seconds", observationSeconds, "stability observation window (120-360)")
 		flags.BoolVar(&options.PreserveEdgePolicy, "preserve-edge-policy", false, "preserve the active nginx edge policy")
@@ -875,11 +881,8 @@ func parseProductionTransactionOptions(action string, args []string, stderr io.W
 			}
 			*value = clean
 		}
-		if options.WithBackups != (options.BackupDir != "") {
-			return productionTransactionOptions{}, errors.New("--with-backups and --backup-dir must be supplied together")
-		}
-		if options.GoChanged && !options.WithBackups {
-			return productionTransactionOptions{}, errors.New("--go-changed requires verified three-copy backups via --with-backups and --backup-dir")
+		if err := validateControllerBackupTransactionOptions(options); err != nil {
+			return productionTransactionOptions{}, err
 		}
 		if options.BackupDir != "" {
 			clean, err := cleanAbsoluteNonRoot(options.BackupDir)
@@ -1236,7 +1239,14 @@ func (runtime *productionRuntime) validateManifestSchema(workspace productionWor
 	if manifest.ConfigRestorePath != workspace.configRestore {
 		return errors.New("deployment manifest configuration rollback path escapes root-only state")
 	}
-	if manifest.BackupsEnabled {
+	if manifest.BackupEvidenceFormat == controllerBackupEvidenceFormat {
+		if err := validateControllerBackupBinding(workspace, manifest); err != nil {
+			return err
+		}
+	} else if manifest.BackupsEnabled {
+		if manifest.ControllerOnlyBackup != nil {
+			return errors.New("legacy backup evidence cannot contain a controller-only binding")
+		}
 		if manifest.BackupDir != filepath.Join(runtime.paths.BackupRoot, workspace.id) || !productionSHA256Pattern.MatchString(manifest.DatabaseBackupSHA256) {
 			return errors.New("deployment manifest backup path or digest is not release-scoped")
 		}
@@ -1249,7 +1259,7 @@ func (runtime *productionRuntime) validateManifestSchema(workspace productionWor
 			(manifest.BackupEvidenceFormat != 0 && manifest.BackupEvidenceFormat != 2) {
 			return errors.New("deployment manifest external backup digests are incomplete")
 		}
-	} else if manifest.BackupDir != "" || manifest.BackupEvidenceFormat != 0 || manifest.DatabaseBackupSHA256 != "" || manifest.TargetBackupSHA256 != "" || manifest.ControllerBackupSHA256 != "" || manifest.OffhostBackupSHA256 != "" {
+	} else if manifest.ControllerOnlyBackup != nil || manifest.BackupDir != "" || manifest.BackupEvidenceFormat != 0 || manifest.DatabaseBackupSHA256 != "" || manifest.TargetBackupSHA256 != "" || manifest.ControllerBackupSHA256 != "" || manifest.OffhostBackupSHA256 != "" {
 		return errors.New("deployment manifest contains unauthorized optional backup state")
 	}
 	if manifest.ObservationSeconds < 120 || manifest.ObservationSeconds > 360 {

--- a/apps/api-go/internal/appcli/deploy_production_transaction.go
+++ b/apps/api-go/internal/appcli/deploy_production_transaction.go
@@ -242,7 +242,11 @@ func (runtime *productionRuntime) verifyManifestArchives(ctx context.Context, wo
 	if err != nil || fmt.Sprintf("%x", sha256Bytes(restoredEnvironment)) != manifest.EnvironmentRestoreSHA256 {
 		return errors.New("configuration rollback snapshot no longer matches the deployment manifest")
 	}
-	if manifest.BackupsEnabled {
+	if manifest.BackupEvidenceFormat == controllerBackupEvidenceFormat {
+		if err := runtime.verifyControllerBackupEvidence(workspace, manifest, false); err != nil {
+			return err
+		}
+	} else if manifest.BackupsEnabled {
 		if _, err := runtime.validateBackupSet(ctx, workspace, manifest.BackupDir); err != nil {
 			return fmt.Errorf("revalidate target production backup: %w", err)
 		}
@@ -555,11 +559,8 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 	if !options.GoChanged && !options.WebChanged {
 		return productionStatus{}, errors.New("at least one of --go-changed or --web-changed is required")
 	}
-	if options.WithBackups != (options.BackupDir != "") {
-		return productionStatus{}, errors.New("production backups require both --with-backups and --backup-dir")
-	}
-	if options.GoChanged && !options.WithBackups {
-		return productionStatus{}, errors.New("production Go transactions require verified three-copy backups via --with-backups and --backup-dir")
+	if err := validateControllerBackupTransactionOptions(options); err != nil {
+		return productionStatus{}, err
 	}
 	if _, err := os.Lstat(workspace.manifestPath); !errors.Is(err, os.ErrNotExist) {
 		return productionStatus{}, errors.New("deployment manifest already exists")
@@ -810,6 +811,23 @@ func (runtime *productionRuntime) apply(ctx context.Context, workspace productio
 		ObservationSeconds: int64(options.ObservationWindow / time.Second), ConfigRestorePath: workspace.configRestore, EnvironmentRestoreSHA256: environmentRestoreSHA256,
 		NginxEdgeRestoreSHA256: nginxEdgeRestoreSHA256, PreserveEdgePolicy: options.PreserveEdgePolicy,
 	}
+	if options.ControllerBackup != (controllerBackupBinding{}) {
+		binding := options.ControllerBackup
+		receipt, err := readControllerBackupReceipt(binding.ReceiptPath, binding.PublicKey, binding.ReceiptSHA256, runtime.requiredOwnerUID)
+		if err != nil {
+			return productionStatus{}, err
+		}
+		manifest.BackupEvidenceFormat = controllerBackupEvidenceFormat
+		manifest.ControllerOnlyBackup = &binding
+		manifest.DatabaseBackupSHA256 = receipt.ArchivePlaintexts["database"]
+		manifest.ControllerBackupSHA256 = receipt.BackupSetSHA256
+		if receipt.GoRollbackPayloadSHA256 != goRollback.BinarySHA256 {
+			return productionStatus{}, errors.New("controller backup payload does not match the verified rollback Go package")
+		}
+		if err := runtime.verifyControllerBackupEvidence(workspace, manifest, true); err != nil {
+			return productionStatus{}, err
+		}
+	}
 	if err := runtime.writeManifest(workspace, manifest); err != nil {
 		return productionStatus{}, fmt.Errorf("write deployment manifest: %w", err)
 	}
@@ -1041,6 +1059,11 @@ func (runtime *productionRuntime) confirmLoaded(ctx context.Context, workspace p
 			return productionStatus{}, err
 		}
 	}
+	if manifest.BackupEvidenceFormat == controllerBackupEvidenceFormat {
+		if err := runtime.verifyControllerBackupConfirmation(workspace, manifest); err != nil {
+			return productionStatus{}, err
+		}
+	}
 	observationWindow := time.Duration(manifest.ObservationSeconds) * time.Second
 	observationEnd := manifest.ObservationStartedUTC.Add(observationWindow)
 	if manifest.ObservationStartedUTC.IsZero() || observationWindow < 2*time.Minute || runtime.now().Before(observationEnd) {
@@ -1064,6 +1087,11 @@ func (runtime *productionRuntime) confirmLoaded(ctx context.Context, workspace p
 	}
 	if manifest.BackupsEnabled && manifest.BackupEvidenceFormat == 2 {
 		if err := runtime.validateBackupConfirmation(manifest.BackupDir, manifest, runtime.now()); err != nil {
+			return productionStatus{}, err
+		}
+	}
+	if manifest.BackupEvidenceFormat == controllerBackupEvidenceFormat {
+		if err := runtime.verifyControllerBackupConfirmation(workspace, manifest); err != nil {
 			return productionStatus{}, err
 		}
 	}

--- a/apps/api-go/internal/appcli/deploy_production_transaction_test.go
+++ b/apps/api-go/internal/appcli/deploy_production_transaction_test.go
@@ -1377,7 +1377,7 @@ func TestProductionManualRollbackNeverRestoresDatabaseAndPreservesOnlineWrites(t
 	}
 }
 
-func TestProductionBackupsMayBeOmittedOnlyForWebOnlyTransactions(t *testing.T) {
+func TestProductionBackupsAreOptionalForEveryChangeKind(t *testing.T) {
 	t.Run("Web-only omitted", func(t *testing.T) {
 		fixture := newProductionFixture(t)
 		fixture.options.GoChanged = false
@@ -1398,20 +1398,33 @@ func TestProductionBackupsMayBeOmittedOnlyForWebOnlyTransactions(t *testing.T) {
 			t.Fatalf("backup state persisted for Web-only release without backups: %#v", manifest)
 		}
 	})
-	t.Run("Go change omitted", func(t *testing.T) {
-		fixture := newProductionFixture(t)
-		fixture.options.BackupDir = ""
-		fixture.options.WithBackups = false
-		if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err == nil || !strings.Contains(err.Error(), "Go transactions require verified three-copy backups") {
-			t.Fatalf("Go backup requirement error=%v", err)
-		}
-		if _, err := os.Lstat(fixture.workspace.statusPath); !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("rejected Go transaction wrote status: %v", err)
-		}
-		if _, err := os.Lstat(fixture.workspace.manifestPath); !errors.Is(err, os.ErrNotExist) {
-			t.Fatalf("rejected Go transaction wrote manifest: %v", err)
-		}
-	})
+	for _, webChanged := range []bool{false, true} {
+		t.Run(fmt.Sprintf("Go change with Web=%t omitted", webChanged), func(t *testing.T) {
+			fixture := newProductionFixture(t)
+			fixture.options.BackupDir = ""
+			fixture.options.WithBackups = false
+			fixture.options.WebChanged = webChanged
+			if !webChanged {
+				fixture.options.WebPackage = fixture.options.WebRollbackPackage
+				fixture.options.WebPackageSHA256 = fixture.options.WebRollbackSHA256
+			}
+			if _, err := fixture.runtime.apply(context.Background(), fixture.workspace, fixture.options); err != nil {
+				t.Fatal(err)
+			}
+			manifest, err := fixture.runtime.readManifest(fixture.workspace)
+			if err != nil || manifest.BackupsEnabled || manifest.ControllerOnlyBackup != nil || manifest.BackupEvidenceFormat != 0 {
+				t.Fatalf("disabled backup manifest invalid: %v", err)
+			}
+			if _, err := fixture.runtime.confirm(context.Background(), fixture.workspace); err != nil {
+				t.Fatal(err)
+			}
+			for _, command := range fixture.runner.commands {
+				if command.Name == commandAge || command.Name == commandPGDump || command.Name == commandPGRestore {
+					t.Fatalf("disabled mode ran backup command %s", command.Name)
+				}
+			}
+		})
+	}
 	t.Run("authorized-empty-database", func(t *testing.T) {
 		fixture := newProductionFixture(t)
 		if err := os.Truncate(filepath.Join(fixture.options.BackupDir, "database.archive"), 0); err != nil {
@@ -1492,7 +1505,7 @@ func TestParseProductionTransactionRejectsRemovedAutomaticRollbackFlags(t *testi
 	}
 }
 
-func TestParseProductionTransactionRequiresBackupsForGoChanges(t *testing.T) {
+func TestParseProductionTransactionAllowsGoChangesWithoutBackups(t *testing.T) {
 	fixture := newProductionFixture(t)
 	base := []string{
 		"--workspace", fixture.workspace.root, "--operator-user", productionOperatorUser,
@@ -1503,9 +1516,9 @@ func TestParseProductionTransactionRequiresBackupsForGoChanges(t *testing.T) {
 		"--probe-binary", fixture.options.ProbeBinary, "--probe-binary-sha256", fixture.options.ProbeBinarySHA256,
 		"--expected-version", fixture.options.ExpectedVersion,
 	}
-	_, err := parseProductionTransactionOptions("apply", append(slices.Clone(base), "--go-changed"), &bytes.Buffer{})
-	if err == nil || !strings.Contains(err.Error(), "--go-changed requires verified three-copy backups") {
-		t.Fatalf("Go backup parse error=%v", err)
+	goOnly, err := parseProductionTransactionOptions("apply", append(slices.Clone(base), "--go-changed"), &bytes.Buffer{})
+	if err != nil || goOnly.WithBackups || goOnly.BackupDir != "" || goOnly.ControllerBackup != (controllerBackupBinding{}) {
+		t.Fatalf("Go-only transaction without backups rejected or gained backup evidence: %v", err)
 	}
 
 	webOnly, err := parseProductionTransactionOptions("apply", append(slices.Clone(base), "--web-changed"), &bytes.Buffer{})

--- a/apps/api-rust/Cargo.lock
+++ b/apps/api-rust/Cargo.lock
@@ -1681,6 +1681,7 @@ dependencies = [
  "chrono",
  "clap",
  "cortexfs-protocol",
+ "ed25519-dalek",
  "flate2",
  "form_urlencoded",
  "fs2",

--- a/apps/api-rust/Cargo.toml
+++ b/apps/api-rust/Cargo.toml
@@ -71,6 +71,7 @@ brotli.workspace = true
 chrono.workspace = true
 clap.workspace = true
 cortexfs-protocol = "0.1.7"
+ed25519-dalek = "2.2.0"
 hmac.workspace = true
 hex.workspace = true
 form_urlencoded.workspace = true

--- a/apps/api-rust/src/deployment.rs
+++ b/apps/api-rust/src/deployment.rs
@@ -25,7 +25,8 @@ use crate::provider_link::{
 
 pub const MANIFEST_FORMAT: u32 = 8;
 pub const STATUS_FORMAT: u32 = 2;
-pub const RELEASE_PLAN_FORMAT: u32 = 5;
+pub const RELEASE_PLAN_FORMAT: u32 = 6;
+const LEGACY_RELEASE_PLAN_FORMAT: u32 = 5;
 pub const RELEASE_STATE_FORMAT: u32 = 3;
 pub const MINIMUM_OBSERVATION_SECONDS: i64 = 120;
 const MAXIMUM_OBSERVATION_SECONDS: i64 = 360;
@@ -35,6 +36,9 @@ const TRANSACTION_LOCK: &str = "/var/lib/lmm-api-go-deploy/transaction.lock";
 const EXPECTED_HOST: &str = "arch-dmit";
 const SERVICE: &str = "lmm-api.service";
 const FRONTEND_ROOT: &str = "/srv/lmm-api-frontend";
+
+mod controller_backup;
+pub use controller_backup::ControllerOnlyBackup;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -98,6 +102,8 @@ pub struct ProductionManifest {
     pub controller_backup_sha256: String,
     #[serde(default)]
     pub offhost_backup_sha256: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controller_only_backup: Option<ControllerOnlyBackup>,
     pub database_schema: String,
     #[serde(default)]
     pub observation_started_utc: Option<DateTime<Utc>>,
@@ -188,6 +194,12 @@ pub struct ReleasePlan {
     pub observation_seconds: i64,
     pub preserve_edge_policy: bool,
     pub with_backups: bool,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub backup_mode: String,
+    #[serde(default, skip_serializing_if = "path_is_empty")]
+    pub controller_backup_dir: PathBuf,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub controller_backup_public_key: String,
     #[serde(default)]
     pub age_recipient: Option<ReleaseFilePlan>,
 }
@@ -357,8 +369,15 @@ impl Workspace {
     }
 }
 
+fn path_is_empty(path: &Path) -> bool {
+    path.as_os_str().is_empty()
+}
+
 pub fn validate_release_plan(plan: &ReleasePlan) -> Result<(), DeploymentError> {
-    if plan.format != RELEASE_PLAN_FORMAT {
+    if !matches!(
+        plan.format,
+        LEGACY_RELEASE_PLAN_FORMAT | RELEASE_PLAN_FORMAT
+    ) {
         return Err(DeploymentError::InvalidSchema(
             "unsupported release plan format".to_owned(),
         ));
@@ -396,11 +415,7 @@ pub fn validate_release_plan(plan: &ReleasePlan) -> Result<(), DeploymentError> 
             "release plan candidate provider evidence is invalid".to_owned(),
         ));
     }
-    if plan.go_changed && !plan.with_backups {
-        return Err(DeploymentError::InvalidSchema(
-            "backend changes require verified three-copy backups".to_owned(),
-        ));
-    }
+    controller_backup::validate_plan_mode(plan)?;
     Ok(())
 }
 
@@ -440,9 +455,7 @@ pub async fn target_confirm(workspace_path: &Path) -> Result<ProductionStatus, D
     validate_transaction_lock(&workspace)?;
     let manifest = workspace.read_manifest(true)?;
     verify_manifest_evidence(&workspace, &manifest, true)?;
-    if manifest.backups_enabled && manifest.backup_evidence_format == 2 {
-        verify_backup_confirmation(&manifest, true)?;
-    }
+    verify_confirmation_evidence(&workspace, &manifest, true)?;
     let status = workspace.read_status(true)?;
     if status.phase == "CONFIRMED" {
         finalize_transaction(&workspace)?;
@@ -477,9 +490,7 @@ pub async fn target_confirm(workspace_path: &Path) -> Result<ProductionStatus, D
     };
     workspace.write_status(confirming)?;
     verify_manifest_evidence(&workspace, &manifest, true)?;
-    if manifest.backups_enabled && manifest.backup_evidence_format == 2 {
-        verify_backup_confirmation(&manifest, true)?;
-    }
+    verify_confirmation_evidence(&workspace, &manifest, true)?;
     verify_active_provider(
         &manifest.go.candidate_package_name,
         &manifest.new_provider_target,
@@ -896,7 +907,14 @@ fn validate_manifest_schema(
             "configuration restore path escapes deployment state".to_owned(),
         ));
     }
-    if manifest.backups_enabled {
+    if manifest.backups_enabled && manifest.backup_evidence_format == 3 {
+        controller_backup::validate_schema(workspace, manifest)?;
+    } else if manifest.backups_enabled {
+        if manifest.controller_only_backup.is_some() {
+            return Err(DeploymentError::InvalidSchema(
+                "legacy manifest contains controller-only evidence".to_owned(),
+            ));
+        }
         if manifest.backup_dir != Path::new(BACKUP_ROOT).join(&manifest.deployment_id) {
             return Err(DeploymentError::UnsafePath(
                 "target backup path is not release-scoped".to_owned(),
@@ -927,6 +945,7 @@ fn validate_manifest_schema(
         || !manifest.target_backup_sha256.is_empty()
         || !manifest.controller_backup_sha256.is_empty()
         || !manifest.offhost_backup_sha256.is_empty()
+        || manifest.controller_only_backup.is_some()
     {
         return Err(DeploymentError::InvalidSchema(
             "manifest contains unauthorized backup evidence".to_owned(),
@@ -1079,7 +1098,11 @@ fn verify_manifest_evidence(
             "configuration rollback snapshot no longer matches manifest".to_owned(),
         ));
     }
-    verify_target_backup(manifest, require_root_owner)?;
+    if manifest.backup_evidence_format == 3 {
+        controller_backup::verify_initial(workspace, manifest, require_root_owner)?;
+    } else {
+        verify_target_backup(manifest, require_root_owner)?;
+    }
     Ok(())
 }
 
@@ -1242,6 +1265,21 @@ fn verify_target_backup(
         return Err(DeploymentError::InvalidEvidence(
             "legacy manifest cannot accept current backup evidence".to_owned(),
         ));
+    }
+    Ok(())
+}
+
+fn verify_confirmation_evidence(
+    workspace: &Workspace,
+    manifest: &ProductionManifest,
+    require_root_owner: bool,
+) -> Result<(), DeploymentError> {
+    if manifest.backups_enabled {
+        match manifest.backup_evidence_format {
+            2 => verify_backup_confirmation(manifest, require_root_owner)?,
+            3 => controller_backup::verify_confirmation(workspace, manifest, require_root_owner)?,
+            _ => {}
+        }
     }
     Ok(())
 }
@@ -1713,6 +1751,7 @@ mod tests {
                 target_backup_sha256: String::new(),
                 controller_backup_sha256: String::new(),
                 offhost_backup_sha256: String::new(),
+                controller_only_backup: None,
                 database_schema: "public".to_owned(),
                 observation_started_utc: Some(Utc::now()),
                 observation_seconds: MINIMUM_OBSERVATION_SECONDS,
@@ -1820,6 +1859,7 @@ mod tests {
                 target_backup_sha256: target_digest,
                 controller_backup_sha256: controller_digest,
                 offhost_backup_sha256: offhost_digest,
+                controller_only_backup: None,
                 database_schema: String::new(),
                 observation_started_utc: None,
                 observation_seconds: MINIMUM_OBSERVATION_SECONDS,
@@ -1841,7 +1881,7 @@ mod tests {
     #[test]
     fn formats_match_manual_only_go_contract() {
         assert_eq!((MANIFEST_FORMAT, STATUS_FORMAT), (8, 2));
-        assert_eq!((RELEASE_PLAN_FORMAT, RELEASE_STATE_FORMAT), (5, 3));
+        assert_eq!((RELEASE_PLAN_FORMAT, RELEASE_STATE_FORMAT), (6, 3));
     }
 
     #[test]

--- a/apps/api-rust/src/deployment/controller_backup.rs
+++ b/apps/api-rust/src/deployment/controller_backup.rs
@@ -1,0 +1,425 @@
+//! Target-side verification only. Controller archives and signing keys are never read here.
+
+use std::io::Read;
+
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use ed25519_dalek::{Signature, VerifyingKey};
+
+use super::*;
+
+const MAX_RECEIPT_BYTES: u64 = 64 * 1024;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct ControllerOnlyBackup {
+    pub public_key: String,
+    pub plan_sha256: String,
+    pub receipt_path: PathBuf,
+    pub receipt_sha256: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Envelope {
+    format: u32,
+    payload: String,
+    signature: String,
+}
+
+// A struct, not a map: serde rejects duplicate, unknown AND missing archive kinds.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct ArchiveDigests {
+    application: String,
+    frontend: String,
+    configuration: String,
+    database: String,
+}
+
+impl ArchiveDigests {
+    fn validate(&self) -> Result<(), DeploymentError> {
+        for digest in [
+            &self.application,
+            &self.frontend,
+            &self.configuration,
+            &self.database,
+        ] {
+            require_sha256(digest)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct Receipt {
+    format: u32,
+    purpose: String,
+    deployment_id: String,
+    expected_host: String,
+    plan_sha256: String,
+    #[serde(deserialize_with = "utc_timestamp")]
+    verified_utc: DateTime<Utc>,
+    #[serde(deserialize_with = "utc_timestamp")]
+    captured_utc: DateTime<Utc>,
+    deployment_manifest_sha256: String,
+    backup_set_sha256: String,
+    database_schema: String,
+    environment_sha256: String,
+    go_candidate_sha256: String,
+    go_rollback_sha256: String,
+    web_candidate_sha256: String,
+    web_rollback_sha256: String,
+    go_rollback_payload_sha256: String,
+    frontend_rollback_sha256: String,
+    archive_ciphertexts: ArchiveDigests,
+    archive_plaintexts: ArchiveDigests,
+}
+
+fn utc_timestamp<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    let time = DateTime::parse_from_rfc3339(&value).map_err(serde::de::Error::custom)?;
+    if time.offset().local_minus_utc() != 0 {
+        return Err(serde::de::Error::custom("receipt timestamp must be UTC"));
+    }
+    Ok(time.with_timezone(&Utc))
+}
+
+fn invalid(message: &str) -> DeploymentError {
+    DeploymentError::InvalidEvidence(message.to_owned())
+}
+
+fn public_key(value: &str) -> Result<VerifyingKey, DeploymentError> {
+    require_sha256(value)?;
+    let mut bytes = [0_u8; 32];
+    hex::decode_to_slice(value, &mut bytes)
+        .map_err(|_| invalid("controller backup public key is invalid"))?;
+    let key = VerifyingKey::from_bytes(&bytes)
+        .map_err(|_| invalid("controller backup public key is invalid"))?;
+    if key.is_weak() {
+        return Err(invalid("controller backup public key is weak"));
+    }
+    Ok(key)
+}
+
+pub(super) fn validate_plan_mode(plan: &ReleasePlan) -> Result<(), DeploymentError> {
+    let no_controller_fields = plan.controller_backup_dir.as_os_str().is_empty()
+        && plan.controller_backup_public_key.is_empty();
+    if plan.format == LEGACY_RELEASE_PLAN_FORMAT {
+        if !plan.backup_mode.is_empty() || !no_controller_fields {
+            return Err(DeploymentError::InvalidSchema(
+                "legacy release plan contains controller-only backup policy".to_owned(),
+            ));
+        }
+        if plan.go_changed && !plan.with_backups {
+            return Err(DeploymentError::InvalidSchema(
+                "backend changes require verified three-copy backups".to_owned(),
+            ));
+        }
+        return Ok(());
+    }
+    // Go's legacy value-struct field serializes the unselected recipient as
+    // {"path":"","sha256":""}, even with omitempty. It grants no authority.
+    let legacy_recipient_present = plan.age_recipient.as_ref().is_some_and(|recipient| {
+        !recipient.path.as_os_str().is_empty() || !recipient.sha256.is_empty()
+    });
+    if plan.format != RELEASE_PLAN_FORMAT || legacy_recipient_present {
+        return Err(DeploymentError::InvalidSchema(
+            "release plan contains unsupported backup policy".to_owned(),
+        ));
+    }
+    match plan.backup_mode.as_str() {
+        "disabled" if !plan.with_backups && no_controller_fields => Ok(()),
+        "controller-only" if plan.with_backups => {
+            // This is a controller path, not a target path. Target readers must not
+            // access it; the importing controller enforces ownership and no links.
+            clean_absolute(&plan.controller_backup_dir)?;
+            let normalized: PathBuf = plan.controller_backup_dir.components().collect();
+            if normalized.as_os_str() != plan.controller_backup_dir.as_os_str() {
+                return Err(DeploymentError::UnsafePath(
+                    "controller backup directory must be a clean absolute path".to_owned(),
+                ));
+            }
+            public_key(&plan.controller_backup_public_key)?;
+            require_sha256(&plan.go_rollback.payload_sha256)?;
+            Ok(())
+        }
+        _ => Err(DeploymentError::InvalidSchema(
+            "release plan backup mode and evidence disagree".to_owned(),
+        )),
+    }
+}
+
+pub(super) fn validate_schema(
+    workspace: &Workspace,
+    manifest: &ProductionManifest,
+) -> Result<(), DeploymentError> {
+    let evidence = manifest
+        .controller_only_backup
+        .as_ref()
+        .ok_or_else(|| invalid("controller-only backup metadata is missing"))?;
+    if !manifest.backups_enabled
+        || manifest.backup_evidence_format != 3
+        || !manifest.backup_dir.as_os_str().is_empty()
+        || !manifest.target_backup_sha256.is_empty()
+        || !manifest.offhost_backup_sha256.is_empty()
+        || evidence.receipt_path.as_os_str()
+            != workspace
+                .state
+                .join("controller-backup-receipt.json")
+                .as_os_str()
+        || !valid_database_schema(&manifest.database_schema)
+    {
+        return Err(DeploymentError::InvalidSchema(
+            "controller-only backup evidence is mixed or invalid".to_owned(),
+        ));
+    }
+    public_key(&evidence.public_key)?;
+    for digest in [
+        &evidence.plan_sha256,
+        &evidence.receipt_sha256,
+        &manifest.controller_backup_sha256,
+        &manifest.database_backup_sha256,
+    ] {
+        require_sha256(digest)?;
+    }
+    Ok(())
+}
+
+fn valid_database_schema(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && value != "information_schema"
+        && !value.starts_with("pg_")
+        && (value.as_bytes()[0].is_ascii_lowercase() || value.as_bytes()[0] == b'_')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+fn decode_receipt(bytes: &[u8], key: &str) -> Result<Receipt, DeploymentError> {
+    if bytes.is_empty() || bytes.len() > MAX_RECEIPT_BYTES as usize {
+        return Err(invalid("controller backup receipt size is invalid"));
+    }
+    let envelope: Envelope = serde_json::from_slice(bytes)?;
+    if envelope.format != 1
+        || envelope.signature.len() != 128
+        || !envelope
+            .signature
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(invalid("controller backup signature envelope is invalid"));
+    }
+    let payload = STANDARD
+        .decode(&envelope.payload)
+        .map_err(|_| invalid("controller backup payload encoding is invalid"))?;
+    let mut signature = [0_u8; 64];
+    hex::decode_to_slice(&envelope.signature, &mut signature)
+        .map_err(|_| invalid("controller backup signature encoding is invalid"))?;
+    // Verify the original decoded bytes, never a reserialized JSON representation.
+    public_key(key)?
+        .verify_strict(&payload, &Signature::from_bytes(&signature))
+        .map_err(|_| invalid("controller backup signature verification failed"))?;
+    Ok(serde_json::from_slice(&payload)?)
+}
+
+fn validate_bindings(
+    receipt: &Receipt,
+    manifest: &ProductionManifest,
+) -> Result<(), DeploymentError> {
+    let evidence = manifest
+        .controller_only_backup
+        .as_ref()
+        .ok_or_else(|| invalid("controller-only backup metadata is missing"))?;
+    receipt.archive_ciphertexts.validate()?;
+    receipt.archive_plaintexts.validate()?;
+    for digest in [
+        &receipt.plan_sha256,
+        &receipt.backup_set_sha256,
+        &receipt.environment_sha256,
+        &receipt.go_candidate_sha256,
+        &receipt.go_rollback_sha256,
+        &receipt.web_candidate_sha256,
+        &receipt.web_rollback_sha256,
+        &receipt.go_rollback_payload_sha256,
+        &receipt.frontend_rollback_sha256,
+    ] {
+        require_sha256(digest)?;
+    }
+    if receipt.format != 1
+        || receipt.deployment_id != manifest.deployment_id
+        || receipt.expected_host != EXPECTED_HOST
+        || receipt.plan_sha256 != evidence.plan_sha256
+        || receipt.backup_set_sha256 != manifest.controller_backup_sha256
+        || receipt.database_schema != manifest.database_schema
+        || !valid_database_schema(&receipt.database_schema)
+        || receipt.environment_sha256 != manifest.environment_restore_sha256
+        || receipt.go_candidate_sha256 != manifest.go.candidate_sha256
+        || receipt.go_rollback_sha256 != manifest.go.rollback_sha256
+        || receipt.web_candidate_sha256 != manifest.web.candidate_sha256
+        || receipt.web_rollback_sha256 != manifest.web.rollback_sha256
+        || receipt.frontend_rollback_sha256 != manifest.frontend.old_index_sha256
+        || receipt.archive_plaintexts.database != manifest.database_backup_sha256
+    {
+        return Err(invalid(
+            "controller backup receipt bindings differ from immutable deployment",
+        ));
+    }
+    // Historical prepare evidence does not expire. Its verification still must
+    // describe a recent capture at the time it was originally signed.
+    if receipt.captured_utc.timestamp() <= 0
+        || receipt.verified_utc.timestamp() <= 0
+        || receipt.captured_utc > receipt.verified_utc + chrono::Duration::seconds(30)
+        || receipt.verified_utc - receipt.captured_utc > chrono::Duration::hours(24)
+    {
+        return Err(invalid("controller backup capture time is invalid"));
+    }
+    Ok(())
+}
+
+fn validate_prepare(receipt: &Receipt) -> Result<(), DeploymentError> {
+    if receipt.purpose != "prepare" || !receipt.deployment_manifest_sha256.is_empty() {
+        return Err(invalid(
+            "controller backup initial receipt is not prepare evidence",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_confirmation(
+    confirmation: &Receipt,
+    initial: &Receipt,
+    manifest_sha256: &str,
+    now: DateTime<Utc>,
+) -> Result<(), DeploymentError> {
+    require_sha256(manifest_sha256)?;
+    if confirmation.purpose != "confirm"
+        || confirmation.deployment_manifest_sha256 != manifest_sha256
+        || confirmation.verified_utc > now + chrono::Duration::seconds(30)
+        || now - confirmation.verified_utc >= chrono::Duration::minutes(5)
+        || confirmation.captured_utc != initial.captured_utc
+        || confirmation.backup_set_sha256 != initial.backup_set_sha256
+        || confirmation.go_rollback_payload_sha256 != initial.go_rollback_payload_sha256
+        || confirmation.archive_ciphertexts != initial.archive_ciphertexts
+        || confirmation.archive_plaintexts != initial.archive_plaintexts
+    {
+        return Err(invalid(
+            "controller backup confirmation is stale or mismatched",
+        ));
+    }
+    Ok(())
+}
+
+fn read_receipt(path: &Path, require_root_owner: bool) -> Result<Vec<u8>, DeploymentError> {
+    clean_absolute(path)?;
+    if fs::canonicalize(path)?.as_os_str() != path.as_os_str() {
+        return Err(DeploymentError::UnsafePath(
+            "receipt contains symlink components".to_owned(),
+        ));
+    }
+    let parent = path
+        .parent()
+        .ok_or_else(|| invalid("receipt has no state directory"))?;
+    require_real(parent, true, require_root_owner)?;
+    if fs::metadata(parent)?.permissions().mode() & 0o777 != 0o700 {
+        return Err(DeploymentError::UnsafePath(
+            "receipt state must remain private".to_owned(),
+        ));
+    }
+    let descriptor = rustix::fs::open(
+        path,
+        rustix::fs::OFlags::RDONLY
+            | rustix::fs::OFlags::NOFOLLOW
+            | rustix::fs::OFlags::CLOEXEC
+            | rustix::fs::OFlags::NONBLOCK,
+        rustix::fs::Mode::empty(),
+    )
+    .map_err(io::Error::from)?;
+    let file = File::from(descriptor);
+    let metadata = file.metadata()?;
+    if !metadata.is_file()
+        || metadata.nlink() != 1
+        || metadata.len() == 0
+        || metadata.len() > MAX_RECEIPT_BYTES
+        || metadata.permissions().mode() & 0o7777 != 0o600
+        || (require_root_owner && metadata.uid() != 0)
+    {
+        return Err(DeploymentError::UnsafePath(
+            "receipt must be a private single-link file".to_owned(),
+        ));
+    }
+    let mut bytes = Vec::new();
+    file.take(MAX_RECEIPT_BYTES + 1).read_to_end(&mut bytes)?;
+    if bytes.len() as u64 > MAX_RECEIPT_BYTES || bytes.len() as u64 != metadata.len() {
+        return Err(invalid("controller backup receipt changed during read"));
+    }
+    Ok(bytes)
+}
+
+fn read_initial(
+    workspace: &Workspace,
+    manifest: &ProductionManifest,
+    require_root_owner: bool,
+) -> Result<Receipt, DeploymentError> {
+    validate_schema(workspace, manifest)?;
+    let evidence = manifest
+        .controller_only_backup
+        .as_ref()
+        .ok_or_else(|| invalid("controller-only backup metadata is missing"))?;
+    let bytes = read_receipt(&evidence.receipt_path, require_root_owner)?;
+    if sha256_bytes(&bytes) != evidence.receipt_sha256 {
+        return Err(invalid("controller backup initial receipt digest changed"));
+    }
+    let receipt = decode_receipt(&bytes, &evidence.public_key)?;
+    validate_prepare(&receipt)?;
+    Ok(receipt)
+}
+
+pub(super) fn verify_initial(
+    workspace: &Workspace,
+    manifest: &ProductionManifest,
+    require_root_owner: bool,
+) -> Result<(), DeploymentError> {
+    let receipt = read_initial(workspace, manifest, require_root_owner)?;
+    // Preparation bound the signed payload digest to the then-active N-1 binary.
+    // Historical reads must not compare it to the now-active candidate provider.
+    validate_bindings(&receipt, manifest)
+}
+
+pub(super) fn verify_confirmation(
+    workspace: &Workspace,
+    manifest: &ProductionManifest,
+    require_root_owner: bool,
+) -> Result<(), DeploymentError> {
+    let initial = read_initial(workspace, manifest, require_root_owner)?;
+    let evidence = manifest
+        .controller_only_backup
+        .as_ref()
+        .ok_or_else(|| invalid("controller-only backup metadata is missing"))?;
+    validate_bindings(&initial, manifest)?;
+    let bytes = read_receipt(
+        &workspace.state.join("controller-backup-confirmation.json"),
+        require_root_owner,
+    )?;
+    let confirmation = decode_receipt(&bytes, &evidence.public_key)?;
+    validate_bindings(&confirmation, manifest)?;
+    // Pin exact on-disk manifest bytes, including whitespace, not serialization.
+    let manifest_bytes = read_receipt(&workspace.manifest, require_root_owner)?;
+    let current: ProductionManifest = serde_json::from_slice(&manifest_bytes)?;
+    if serde_json::to_vec(&current)? != serde_json::to_vec(manifest)? {
+        return Err(invalid("deployment manifest changed during confirmation"));
+    }
+    validate_confirmation(
+        &confirmation,
+        &initial,
+        &sha256_bytes(&manifest_bytes),
+        Utc::now(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/apps/api-rust/src/deployment/controller_backup/tests.rs
+++ b/apps/api-rust/src/deployment/controller_backup/tests.rs
@@ -1,0 +1,873 @@
+use std::{
+    os::unix::fs::symlink,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use ed25519_dalek::{Signer, SigningKey};
+use serde_json::{Value, json};
+
+use super::*;
+
+fn key() -> SigningKey {
+    SigningKey::from_bytes(&[7; 32])
+}
+
+fn key_hex() -> String {
+    hex::encode(key().verifying_key().to_bytes())
+}
+
+fn sign_raw(payload: &[u8]) -> Vec<u8> {
+    serde_json::to_vec(&Envelope {
+        format: 1,
+        payload: STANDARD.encode(payload),
+        signature: hex::encode(key().sign(payload).to_bytes()),
+    })
+    .unwrap()
+}
+
+fn sign(receipt: &Receipt) -> Vec<u8> {
+    sign_raw(&serde_json::to_vec(receipt).unwrap())
+}
+
+fn now() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-09-07T12:00:00Z")
+        .unwrap()
+        .with_timezone(&Utc)
+}
+
+fn workspace(root: PathBuf) -> Workspace {
+    let state = root.join("state");
+    Workspace {
+        id: "signed-receipt-test".to_owned(),
+        staging: root.join("staging"),
+        manifest: state.join("deployment.json"),
+        status: state.join("status.json"),
+        probe_token: state.join("probe-token"),
+        state,
+        root,
+    }
+}
+
+fn manifest(workspace: &Workspace) -> ProductionManifest {
+    let transition = |name: &str| {
+        json!({
+            "candidate_package_name": name,
+            "rollback_package_name": name,
+            "changed": true,
+            "candidate_path": workspace.staging.join(format!("{name}-new.pkg.tar.zst")),
+            "rollback_path": workspace.staging.join(format!("{name}-old.pkg.tar.zst")),
+            "candidate_identity": format!("{name} 0.2.14-1"),
+            "rollback_identity": format!("{name} 0.2.13-1"),
+            "candidate_sha256": "a".repeat(64),
+            "rollback_sha256": "b".repeat(64),
+            "candidate_git_revision": "a".repeat(40),
+            "rollback_git_revision": "b".repeat(40),
+            "candidate_contract_revision": "c".repeat(64),
+            "rollback_contract_revision": "c".repeat(64),
+        })
+    };
+    serde_json::from_value(json!({
+        "format": 8,
+        "deployment_id": workspace.id,
+        "operator_user": "lmm-api-deploy",
+        "go": transition("lmm-api-go-bin"),
+        "web": transition("lmm-api-web-bin"),
+        "frontend": {
+            "old_target": "releases/old", "new_target": "releases/new",
+            "old_index_sha256": "c".repeat(64), "new_index_sha256": "d".repeat(64),
+        },
+        "probe_binary": workspace.staging.join(GO_PROVIDER),
+        "probe_binary_sha256": "d".repeat(64),
+        "operator_binary": workspace.staging.join(GO_PROVIDER),
+        "operator_binary_sha256": "d".repeat(64),
+        "expected_version": "0.2.14", "old_version": "0.2.13",
+        "previous_provider_target": GO_PROVIDER, "new_provider_target": GO_PROVIDER,
+        "backup_dir": "", "backups_enabled": true, "backup_evidence_format": 3,
+        "database_backup_sha256": "e".repeat(64),
+        "target_backup_sha256": "", "controller_backup_sha256": "f".repeat(64),
+        "offhost_backup_sha256": "",
+        "controller_only_backup": {
+            "public_key": key_hex(), "plan_sha256": "1".repeat(64),
+            "receipt_path": workspace.state.join("controller-backup-receipt.json"),
+            "receipt_sha256": "2".repeat(64),
+        },
+        "database_schema": "public", "observation_seconds": 120,
+        "service_restart_baseline": 0,
+        "config_restore_path": workspace.state.join("config-restore"),
+        "environment_restore_sha256": "3".repeat(64),
+    }))
+    .unwrap()
+}
+
+fn receipt(manifest: &ProductionManifest) -> Receipt {
+    Receipt {
+        format: 1,
+        purpose: "prepare".to_owned(),
+        deployment_id: manifest.deployment_id.clone(),
+        expected_host: EXPECTED_HOST.to_owned(),
+        plan_sha256: manifest
+            .controller_only_backup
+            .as_ref()
+            .unwrap()
+            .plan_sha256
+            .clone(),
+        verified_utc: now(),
+        captured_utc: now() - chrono::Duration::minutes(10),
+        deployment_manifest_sha256: String::new(),
+        backup_set_sha256: manifest.controller_backup_sha256.clone(),
+        database_schema: manifest.database_schema.clone(),
+        environment_sha256: manifest.environment_restore_sha256.clone(),
+        go_candidate_sha256: manifest.go.candidate_sha256.clone(),
+        go_rollback_sha256: manifest.go.rollback_sha256.clone(),
+        web_candidate_sha256: manifest.web.candidate_sha256.clone(),
+        web_rollback_sha256: manifest.web.rollback_sha256.clone(),
+        go_rollback_payload_sha256: "4".repeat(64),
+        frontend_rollback_sha256: manifest.frontend.old_index_sha256.clone(),
+        archive_ciphertexts: ArchiveDigests {
+            application: "5".repeat(64),
+            frontend: "6".repeat(64),
+            configuration: "7".repeat(64),
+            database: "8".repeat(64),
+        },
+        archive_plaintexts: ArchiveDigests {
+            application: "9".repeat(64),
+            frontend: "a".repeat(64),
+            configuration: "b".repeat(64),
+            database: manifest.database_backup_sha256.clone(),
+        },
+    }
+}
+
+fn context() -> (Workspace, ProductionManifest, Receipt) {
+    let workspace = workspace(Path::new(WORK_ROOT).join("signed-receipt-test"));
+    let manifest = manifest(&workspace);
+    let receipt = receipt(&manifest);
+    (workspace, manifest, receipt)
+}
+
+fn confirmation(initial: &Receipt) -> Receipt {
+    let mut confirmation = initial.clone();
+    confirmation.purpose = "confirm".to_owned();
+    confirmation.deployment_manifest_sha256 = "a".repeat(64);
+    confirmation
+}
+
+#[test]
+fn go_signed_receipt_and_immutable_manifest_are_compatible() {
+    let Ok(root) = std::env::var("LMM_CONTROLLER_BACKUP_INTEROP_FIXTURE_DIR") else {
+        return;
+    };
+    let root = PathBuf::from(root);
+    let manifest: ProductionManifest =
+        serde_json::from_slice(&fs::read(root.join("manifest.json")).unwrap()).unwrap();
+    let evidence = manifest.controller_only_backup.as_ref().unwrap();
+    let raw = fs::read(root.join("receipt.json")).unwrap();
+    assert_eq!(sha256_bytes(&raw), evidence.receipt_sha256);
+    let decoded = decode_receipt(&raw, &evidence.public_key).unwrap();
+    validate_prepare(&decoded).unwrap();
+    validate_bindings(&decoded, &manifest).unwrap();
+}
+
+#[test]
+fn exact_signed_payload_bytes_accept_whitespace_without_reserialization() {
+    let (_, manifest, receipt) = context();
+    let pretty = serde_json::to_vec_pretty(&receipt).unwrap();
+    let decoded = decode_receipt(&sign_raw(&pretty), &key_hex()).unwrap();
+    assert!(validate_bindings(&decoded, &manifest).is_ok());
+}
+
+#[test]
+fn whitespace_tampering_without_resigning_is_rejected() {
+    let (_, _, receipt) = context();
+    let mut envelope: Envelope = serde_json::from_slice(&sign(&receipt)).unwrap();
+    let mut payload = STANDARD.decode(&envelope.payload).unwrap();
+    payload.push(b' ');
+    envelope.payload = STANDARD.encode(payload);
+    assert!(decode_receipt(&serde_json::to_vec(&envelope).unwrap(), &key_hex()).is_err());
+}
+
+#[test]
+fn forgery_and_wrong_key_are_rejected() {
+    let (_, _, receipt) = context();
+    let bytes = sign(&receipt);
+    let wrong_key = hex::encode(SigningKey::from_bytes(&[8; 32]).verifying_key().to_bytes());
+    assert!(decode_receipt(&bytes, &wrong_key).is_err());
+    let mut envelope: Envelope = serde_json::from_slice(&bytes).unwrap();
+    envelope.signature = "0".repeat(128);
+    assert!(decode_receipt(&serde_json::to_vec(&envelope).unwrap(), &key_hex()).is_err());
+}
+
+#[test]
+fn malformed_signature_key_and_base64_are_rejected() {
+    let (_, _, receipt) = context();
+    for signature in ["0".repeat(126), "A".repeat(128), "g".repeat(128)] {
+        let mut envelope: Envelope = serde_json::from_slice(&sign(&receipt)).unwrap();
+        envelope.signature = signature;
+        assert!(decode_receipt(&serde_json::to_vec(&envelope).unwrap(), &key_hex()).is_err());
+    }
+    for key in [key_hex().to_uppercase(), "0".repeat(64), "a".repeat(62)] {
+        assert!(decode_receipt(&sign(&receipt), &key).is_err());
+    }
+    let mut envelope: Envelope = serde_json::from_slice(&sign(&receipt)).unwrap();
+    envelope.payload.push('!');
+    assert!(decode_receipt(&serde_json::to_vec(&envelope).unwrap(), &key_hex()).is_err());
+}
+
+#[test]
+fn strict_json_rejects_unknown_duplicate_and_trailing_fields() {
+    let (_, _, receipt) = context();
+    let json = String::from_utf8(serde_json::to_vec(&receipt).unwrap()).unwrap();
+    for raw in [
+        json.replacen('{', "{\"unknown\":true,", 1),
+        json.replacen('{', "{\"format\":1,", 1),
+        format!("{json} {{}}"),
+    ] {
+        assert!(decode_receipt(&sign_raw(raw.as_bytes()), &key_hex()).is_err());
+    }
+    let json = String::from_utf8(sign(&receipt)).unwrap();
+    for raw in [
+        json.replacen('{', "{\"unknown\":true,", 1),
+        json.replacen('{', "{\"format\":1,", 1),
+    ] {
+        assert!(decode_receipt(raw.as_bytes(), &key_hex()).is_err());
+    }
+}
+
+#[test]
+fn archive_maps_require_exactly_four_unique_valid_digests() {
+    let (_, manifest, receipt) = context();
+    for map in ["archive_ciphertexts", "archive_plaintexts"] {
+        for operation in ["missing", "extra", "uppercase", "duplicate"] {
+            let mut value = serde_json::to_value(&receipt).unwrap();
+            match operation {
+                "missing" => {
+                    value[map].as_object_mut().unwrap().remove("database");
+                }
+                "extra" => {
+                    value[map]["extra"] = json!("a".repeat(64));
+                }
+                "uppercase" => {
+                    value[map]["database"] = json!("A".repeat(64));
+                }
+                _ => {}
+            }
+            let mut raw = serde_json::to_string(&value).unwrap();
+            if operation == "duplicate" {
+                raw = raw.replacen(
+                    &format!("\"{map}\":{{"),
+                    &format!("\"{map}\":{{\"database\":\"{}\",", "a".repeat(64)),
+                    1,
+                );
+            }
+            let result = decode_receipt(&sign_raw(raw.as_bytes()), &key_hex())
+                .and_then(|decoded| validate_bindings(&decoded, &manifest));
+            assert!(result.is_err(), "accepted {map}/{operation}");
+        }
+    }
+}
+
+#[test]
+fn valid_signatures_cannot_override_any_immutable_binding() {
+    let (_, manifest, receipt) = context();
+    for field in [
+        "deployment_id",
+        "expected_host",
+        "plan_sha256",
+        "backup_set_sha256",
+        "database_schema",
+        "environment_sha256",
+        "go_candidate_sha256",
+        "go_rollback_sha256",
+        "web_candidate_sha256",
+        "web_rollback_sha256",
+        "frontend_rollback_sha256",
+    ] {
+        let mut value = serde_json::to_value(&receipt).unwrap();
+        value[field] = json!("0".repeat(64));
+        let decoded =
+            decode_receipt(&sign_raw(&serde_json::to_vec(&value).unwrap()), &key_hex()).unwrap();
+        assert!(
+            validate_bindings(&decoded, &manifest).is_err(),
+            "accepted {field}"
+        );
+    }
+    let mut value = receipt;
+    value.archive_plaintexts.database = "0".repeat(64);
+    assert!(validate_bindings(&value, &manifest).is_err());
+}
+
+#[test]
+fn historical_prepare_verification_does_not_expire() {
+    let (_, manifest, mut receipt) = context();
+    receipt.verified_utc -= chrono::Duration::days(90);
+    receipt.captured_utc -= chrono::Duration::days(90);
+    let decoded = decode_receipt(&sign(&receipt), &key_hex()).unwrap();
+    validate_prepare(&decoded).unwrap();
+    assert!(validate_bindings(&decoded, &manifest).is_ok());
+}
+
+#[test]
+fn invalid_capture_times_and_non_utc_timestamps_are_rejected() {
+    let (_, manifest, receipt) = context();
+    for captured in [
+        now() - chrono::Duration::hours(25),
+        now() + chrono::Duration::seconds(31),
+    ] {
+        let mut changed = receipt.clone();
+        changed.captured_utc = captured;
+        assert!(validate_bindings(&changed, &manifest).is_err());
+    }
+    let mut value = serde_json::to_value(&receipt).unwrap();
+    value["verified_utc"] = json!("2026-09-07T13:00:00+01:00");
+    assert!(decode_receipt(&sign_raw(&serde_json::to_vec(&value).unwrap()), &key_hex()).is_err());
+}
+
+#[test]
+fn confirmation_accepts_fresh_signature_with_exact_manifest_digest() {
+    let (_, manifest, initial) = context();
+    let confirmation = decode_receipt(&sign(&confirmation(&initial)), &key_hex()).unwrap();
+    validate_bindings(&confirmation, &manifest).unwrap();
+    assert!(validate_confirmation(&confirmation, &initial, &"a".repeat(64), now()).is_ok());
+}
+
+#[test]
+fn fresh_confirmation_cannot_renew_a_snapshot_older_than_twenty_four_hours() {
+    let (_, manifest, mut initial) = context();
+    initial.verified_utc -= chrono::Duration::days(90);
+    initial.captured_utc -= chrono::Duration::days(90);
+    let mut fresh = confirmation(&initial);
+    fresh.verified_utc = now();
+    assert!(validate_bindings(&fresh, &manifest).is_err());
+}
+
+#[test]
+fn confirmation_freshness_boundaries_are_enforced() {
+    let (_, _, initial) = context();
+    for seconds in [-301, -300, 31] {
+        let mut confirmation = confirmation(&initial);
+        confirmation.verified_utc = now() + chrono::Duration::seconds(seconds);
+        assert!(validate_confirmation(&confirmation, &initial, &"a".repeat(64), now()).is_err());
+    }
+    for seconds in [-299, 0, 30] {
+        let mut confirmation = confirmation(&initial);
+        confirmation.verified_utc = now() + chrono::Duration::seconds(seconds);
+        assert!(validate_confirmation(&confirmation, &initial, &"a".repeat(64), now()).is_ok());
+    }
+}
+
+#[test]
+fn confirmation_rejects_prepare_replay_wrong_manifest_and_collection_drift() {
+    let (_, _, initial) = context();
+    assert!(validate_confirmation(&initial, &initial, &"a".repeat(64), now()).is_err());
+    let valid = confirmation(&initial);
+    assert!(validate_prepare(&valid).is_err());
+    assert!(validate_confirmation(&valid, &initial, &"b".repeat(64), now()).is_err());
+    for field in [
+        "captured_utc",
+        "backup_set_sha256",
+        "go_rollback_payload_sha256",
+        "archive_ciphertexts",
+        "archive_plaintexts",
+    ] {
+        let mut value = serde_json::to_value(&valid).unwrap();
+        match field {
+            "captured_utc" => value[field] = json!(now()),
+            "archive_ciphertexts" | "archive_plaintexts" => {
+                value[field]["application"] = json!("0".repeat(64))
+            }
+            _ => value[field] = json!("0".repeat(64)),
+        }
+        let changed: Receipt = serde_json::from_value(value).unwrap();
+        assert!(
+            validate_confirmation(&changed, &initial, &"a".repeat(64), now()).is_err(),
+            "accepted {field}"
+        );
+    }
+}
+
+fn plan() -> ReleasePlan {
+    let package = ReleasePackagePlan {
+        package_path: PathBuf::from("/controller/package.pkg.tar.zst"),
+        package_sha256: "a".repeat(64),
+        name: "lmm-api-go-bin".to_owned(),
+        version: "0.2.14".to_owned(),
+        identity: "lmm-api-go-bin 0.2.14-1".to_owned(),
+        git_revision: "b".repeat(40),
+        contract_revision: "c".repeat(64),
+        payload_sha256: "d".repeat(64),
+        release_asset: PathBuf::from("/controller/release"),
+        release_asset_sha256: "a".repeat(64),
+        signature_bundle: PathBuf::from("/controller/signature"),
+        signature_bundle_sha256: "b".repeat(64),
+        release_tag: "go-v0.2.14".to_owned(),
+        workflow: "release.yml".to_owned(),
+    };
+    let provider = ReleaseFilePlan {
+        path: PathBuf::from("/controller/lmm-api-go"),
+        sha256: "d".repeat(64),
+    };
+    ReleasePlan {
+        format: 6,
+        deployment_id: "signed-receipt-test".to_owned(),
+        created_utc: now(),
+        controller_workspace: PathBuf::from("/controller/work"),
+        repository: "LightJunction/api.lmm.best".to_owned(),
+        target_alias: "ArchDmit".to_owned(),
+        expected_host: EXPECTED_HOST.to_owned(),
+        operator_user: "lmm-api-deploy".to_owned(),
+        expected_version: "0.2.14".to_owned(),
+        go_candidate: package.clone(),
+        go_rollback: package.clone(),
+        web_candidate: package.clone(),
+        web_rollback: package,
+        probe_binary: provider.clone(),
+        operator_binary: Some(provider),
+        go_changed: true,
+        web_changed: false,
+        observation_seconds: 120,
+        preserve_edge_policy: false,
+        with_backups: false,
+        backup_mode: "disabled".to_owned(),
+        controller_backup_dir: PathBuf::new(),
+        controller_backup_public_key: String::new(),
+        age_recipient: None,
+    }
+}
+
+#[test]
+fn disabled_plan_accepts_go_web_and_combined_changes() {
+    for (go, web) in [(true, false), (false, true), (true, true)] {
+        let mut plan = plan();
+        plan.go_changed = go;
+        plan.web_changed = web;
+        assert!(
+            validate_release_plan(&plan).is_ok(),
+            "rejected go={go}/web={web}"
+        );
+    }
+}
+
+#[test]
+fn go_empty_legacy_recipient_struct_grants_no_backup_authority() {
+    let mut plan = plan();
+    plan.age_recipient = Some(ReleaseFilePlan {
+        path: PathBuf::new(),
+        sha256: String::new(),
+    });
+    assert!(validate_release_plan(&plan).is_ok());
+}
+
+#[test]
+fn disabled_plan_rejects_stray_backup_fields() {
+    for field in [
+        "with_backups",
+        "controller_backup_dir",
+        "controller_backup_public_key",
+        "age_recipient",
+        "backup_mode",
+    ] {
+        let mut value = serde_json::to_value(plan()).unwrap();
+        value[field] = match field {
+            "with_backups" => json!(true),
+            "controller_backup_dir" => json!("/controller/backups"),
+            "controller_backup_public_key" => json!(key_hex()),
+            "age_recipient" => json!({"path": "/controller/recipient", "sha256": "a".repeat(64)}),
+            _ => json!(""),
+        };
+        let plan: ReleasePlan = serde_json::from_value(value).unwrap();
+        assert!(validate_release_plan(&plan).is_err(), "accepted {field}");
+    }
+}
+
+#[test]
+fn controller_plan_requires_explicit_mode_absolute_path_and_key() {
+    let mut plan = plan();
+    plan.with_backups = true;
+    plan.backup_mode = "controller-only".to_owned();
+    plan.controller_backup_dir = PathBuf::from("/controller/backups");
+    plan.controller_backup_public_key = key_hex();
+    validate_release_plan(&plan).unwrap();
+    for path in [
+        "",
+        "relative",
+        "/controller/../backups",
+        "/controller/./backups",
+        "/controller/backups/",
+    ] {
+        plan.controller_backup_dir = PathBuf::from(path);
+        assert!(validate_release_plan(&plan).is_err(), "accepted {path}");
+    }
+}
+
+#[test]
+fn format_five_remains_legacy_and_cannot_mix_new_policy() {
+    let mut plan = plan();
+    plan.format = 5;
+    plan.backup_mode.clear();
+    plan.with_backups = true;
+    validate_release_plan(&plan).unwrap();
+    plan.with_backups = false;
+    assert!(validate_release_plan(&plan).is_err());
+    plan.go_changed = false;
+    validate_release_plan(&plan).unwrap();
+    plan.backup_mode = "disabled".to_owned();
+    assert!(validate_release_plan(&plan).is_err());
+}
+
+#[test]
+fn schema_rejects_mixed_controller_evidence_and_unsafe_schema_names() {
+    let (workspace, manifest, _) = context();
+    validate_manifest_schema(&workspace, &manifest).unwrap();
+    for field in [
+        "backup_dir",
+        "target_backup_sha256",
+        "offhost_backup_sha256",
+        "backup_evidence_format",
+        "backups_enabled",
+        "controller_only_backup",
+    ] {
+        let mut value = serde_json::to_value(&manifest).unwrap();
+        value[field] = match field {
+            "backup_dir" => json!("/target/backups"),
+            "backup_evidence_format" => json!(2),
+            "backups_enabled" => json!(false),
+            "controller_only_backup" => Value::Null,
+            _ => json!("a".repeat(64)),
+        };
+        let changed = serde_json::from_value(value).unwrap();
+        assert!(
+            validate_manifest_schema(&workspace, &changed).is_err(),
+            "accepted {field}"
+        );
+    }
+    for schema in [
+        "",
+        "Public",
+        "pg_catalog",
+        "pg_temp",
+        "information_schema",
+        "a,b",
+        "a;DROP",
+        "1app",
+    ] {
+        let mut changed = manifest.clone();
+        changed.database_schema = schema.to_owned();
+        assert!(
+            validate_manifest_schema(&workspace, &changed).is_err(),
+            "accepted {schema}"
+        );
+    }
+    assert!(valid_database_schema("_application_2"));
+}
+
+#[test]
+fn receipt_path_is_exact_not_just_a_path_within_workspace() {
+    let (workspace, mut manifest, _) = context();
+    for path in [
+        workspace.state.join("other.json"),
+        workspace.state.join("./controller-backup-receipt.json"),
+    ] {
+        manifest
+            .controller_only_backup
+            .as_mut()
+            .unwrap()
+            .receipt_path = path;
+        assert!(validate_manifest_schema(&workspace, &manifest).is_err());
+    }
+}
+
+#[test]
+fn disabled_manifest_accepts_go_web_and_combined_changes() {
+    for (go, web) in [(true, false), (false, true), (true, true)] {
+        let (workspace, mut manifest, _) = context();
+        manifest.backups_enabled = false;
+        manifest.backup_evidence_format = 0;
+        manifest.controller_only_backup = None;
+        manifest.controller_backup_sha256.clear();
+        manifest.database_backup_sha256.clear();
+        for (transition, changed) in [(&mut manifest.go, go), (&mut manifest.web, web)] {
+            transition.changed = changed;
+            if !changed {
+                transition.rollback_identity = transition.candidate_identity.clone();
+                transition.rollback_sha256 = transition.candidate_sha256.clone();
+            }
+        }
+        if !web {
+            manifest.frontend.old_target = manifest.frontend.new_target.clone();
+            manifest.frontend.old_index_sha256 = manifest.frontend.new_index_sha256.clone();
+        }
+        assert!(
+            validate_manifest_schema(&workspace, &manifest).is_ok(),
+            "rejected go={go}/web={web}"
+        );
+    }
+}
+
+#[test]
+fn disabled_manifest_rejects_every_stray_evidence_field() {
+    let (workspace, mut manifest, _) = context();
+    manifest.backups_enabled = false;
+    manifest.backup_evidence_format = 0;
+    manifest.controller_only_backup = None;
+    manifest.controller_backup_sha256.clear();
+    manifest.database_backup_sha256.clear();
+    validate_manifest_schema(&workspace, &manifest).unwrap();
+    for field in [
+        "backup_dir",
+        "backup_evidence_format",
+        "database_backup_sha256",
+        "target_backup_sha256",
+        "controller_backup_sha256",
+        "offhost_backup_sha256",
+        "controller_only_backup",
+    ] {
+        let mut value = serde_json::to_value(&manifest).unwrap();
+        value[field] = match field {
+            "backup_dir" => json!("/target/backups"),
+            "backup_evidence_format" => json!(3),
+            "controller_only_backup" => {
+                serde_json::to_value(context().1.controller_only_backup).unwrap()
+            }
+            _ => json!("a".repeat(64)),
+        };
+        let changed = serde_json::from_value(value).unwrap();
+        assert!(
+            validate_manifest_schema(&workspace, &changed).is_err(),
+            "accepted {field}"
+        );
+    }
+}
+
+#[test]
+fn legacy_evidence_zero_and_two_schema_remain_readable() {
+    for format in [0, 2] {
+        let (workspace, mut manifest, _) = context();
+        manifest.controller_only_backup = None;
+        manifest.backup_evidence_format = format;
+        manifest.backup_dir = Path::new(BACKUP_ROOT).join(&manifest.deployment_id);
+        if format == 0 {
+            manifest.controller_backup_sha256.clear();
+        } else {
+            manifest.target_backup_sha256 = "a".repeat(64);
+            manifest.offhost_backup_sha256 = "b".repeat(64);
+        }
+        assert!(
+            validate_manifest_schema(&workspace, &manifest).is_ok(),
+            "rejected legacy {format}"
+        );
+    }
+}
+
+static SEQUENCE: AtomicUsize = AtomicUsize::new(0);
+
+struct Files {
+    workspace: Workspace,
+    manifest: ProductionManifest,
+}
+
+impl Files {
+    fn new() -> Self {
+        let root = std::env::temp_dir().join(format!(
+            "lmm-controller-backup-test-{}-{}",
+            std::process::id(),
+            SEQUENCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let workspace = workspace(root);
+        fs::create_dir_all(&workspace.state).unwrap();
+        fs::set_permissions(&workspace.state, fs::Permissions::from_mode(0o700)).unwrap();
+        fs::create_dir(&workspace.staging).unwrap();
+        let mut manifest = manifest(&workspace);
+        let bytes = sign(&receipt(&manifest));
+        let evidence = manifest.controller_only_backup.as_mut().unwrap();
+        evidence.receipt_sha256 = sha256_bytes(&bytes);
+        Self::write_private(&evidence.receipt_path, &bytes);
+        Self {
+            workspace,
+            manifest,
+        }
+    }
+
+    fn with_evidence() -> Self {
+        let mut files = Self::new();
+        for transition in [&mut files.manifest.go, &mut files.manifest.web] {
+            Self::write_private(&transition.candidate_path, b"candidate-package");
+            transition.candidate_sha256 = sha256_bytes(b"candidate-package");
+            Self::write_private(&transition.rollback_path, b"rollback-package");
+            transition.rollback_sha256 = sha256_bytes(b"rollback-package");
+        }
+        Self::write_private(&files.manifest.probe_binary, b"candidate-provider");
+        symlink(GO_PROVIDER, files.workspace.staging.join("lmm-api")).unwrap();
+        fs::set_permissions(
+            &files.manifest.probe_binary,
+            fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        files.manifest.probe_binary_sha256 = sha256_bytes(b"candidate-provider");
+        files.manifest.operator_binary_sha256 = files.manifest.probe_binary_sha256.clone();
+        fs::create_dir(&files.manifest.config_restore_path).unwrap();
+        Self::write_private(
+            &files.manifest.config_restore_path.join("lmm-api-go.env"),
+            b"SQL_DSN=postgres://fixture\n",
+        );
+        files.manifest.environment_restore_sha256 = sha256_bytes(b"SQL_DSN=postgres://fixture\n");
+        let mut initial = receipt(&files.manifest);
+        initial.verified_utc = Utc::now();
+        initial.captured_utc = initial.verified_utc - chrono::Duration::minutes(10);
+        let bytes = sign(&initial);
+        let evidence = files.manifest.controller_only_backup.as_mut().unwrap();
+        evidence.receipt_sha256 = sha256_bytes(&bytes);
+        Self::write_private(&evidence.receipt_path, &bytes);
+        Self::write_private(
+            &files.workspace.manifest,
+            &serde_json::to_vec(&files.manifest).unwrap(),
+        );
+        let mut fresh = confirmation(&initial);
+        fresh.deployment_manifest_sha256 =
+            sha256_bytes(&fs::read(&files.workspace.manifest).unwrap());
+        Self::write_private(
+            &files
+                .workspace
+                .state
+                .join("controller-backup-confirmation.json"),
+            &sign(&fresh),
+        );
+        files
+    }
+
+    fn write_private(path: &Path, bytes: &[u8]) {
+        fs::write(path, bytes).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).unwrap();
+    }
+}
+
+impl Drop for Files {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.workspace.root);
+    }
+}
+
+#[test]
+fn native_manifest_and_confirmation_readers_verify_the_complete_evidence_chain() {
+    let files = Files::with_evidence();
+    let manifest = files.workspace.read_manifest(false).unwrap();
+    assert!(verify_confirmation_evidence(&files.workspace, &manifest, false).is_ok());
+}
+
+#[test]
+fn confirmation_pins_exact_manifest_bytes_including_whitespace() {
+    let files = Files::with_evidence();
+    let mut bytes = fs::read(&files.workspace.manifest).unwrap();
+    bytes.push(b'\n');
+    Files::write_private(&files.workspace.manifest, &bytes);
+    assert!(verify_confirmation_evidence(&files.workspace, &files.manifest, false).is_err());
+}
+
+#[test]
+fn confirmation_reader_rejects_a_missing_confirmation_file() {
+    let files = Files::with_evidence();
+    fs::remove_file(
+        files
+            .workspace
+            .state
+            .join("controller-backup-confirmation.json"),
+    )
+    .unwrap();
+    assert!(verify_confirmation_evidence(&files.workspace, &files.manifest, false).is_err());
+}
+
+#[test]
+fn full_manifest_reader_preserves_operator_proof_validation() {
+    let files = Files::with_evidence();
+    Files::write_private(&files.manifest.operator_binary, b"tampered-provider");
+    assert!(files.workspace.read_manifest(false).is_err());
+}
+
+#[test]
+fn pinned_initial_receipt_rejects_even_a_validly_resigned_replacement() {
+    let files = Files::new();
+    read_initial(&files.workspace, &files.manifest, false).unwrap();
+    let mut changed = receipt(&files.manifest);
+    changed.verified_utc += chrono::Duration::seconds(1);
+    let path = &files
+        .manifest
+        .controller_only_backup
+        .as_ref()
+        .unwrap()
+        .receipt_path;
+    Files::write_private(path, &sign(&changed));
+    assert!(read_initial(&files.workspace, &files.manifest, false).is_err());
+}
+
+#[test]
+fn private_receipt_reader_rejects_links_public_modes_and_oversized_files() {
+    for damage in [
+        "hardlink",
+        "symlink",
+        "public",
+        "public-parent",
+        "oversized",
+        "empty",
+        "parent-symlink",
+    ] {
+        let files = Files::new();
+        let path = &files
+            .manifest
+            .controller_only_backup
+            .as_ref()
+            .unwrap()
+            .receipt_path;
+        match damage {
+            "hardlink" => fs::hard_link(path, files.workspace.state.join("linked.json")).unwrap(),
+            "symlink" => {
+                let destination = files.workspace.state.join("actual.json");
+                fs::rename(path, &destination).unwrap();
+                symlink(destination, path).unwrap();
+            }
+            "parent-symlink" => {
+                let destination = files.workspace.root.join("real-state");
+                fs::rename(&files.workspace.state, &destination).unwrap();
+                symlink(destination, &files.workspace.state).unwrap();
+            }
+            "public" => fs::set_permissions(path, fs::Permissions::from_mode(0o644)).unwrap(),
+            "public-parent" => {
+                fs::set_permissions(&files.workspace.state, fs::Permissions::from_mode(0o755))
+                    .unwrap()
+            }
+            "oversized" => Files::write_private(path, &vec![b' '; MAX_RECEIPT_BYTES as usize + 1]),
+            _ => Files::write_private(path, b""),
+        }
+        assert!(
+            read_initial(&files.workspace, &files.manifest, false).is_err(),
+            "accepted {damage}"
+        );
+    }
+}
+
+#[test]
+fn rollback_reader_does_not_require_receipts_controller_or_candidate_files() {
+    let mut files = Files::new();
+    for transition in [&mut files.manifest.go, &mut files.manifest.web] {
+        Files::write_private(&transition.rollback_path, b"retained-rollback-package");
+        transition.rollback_sha256 = sha256_bytes(b"retained-rollback-package");
+    }
+    fs::create_dir(&files.manifest.config_restore_path).unwrap();
+    Files::write_private(
+        &files.manifest.config_restore_path.join("lmm-api-go.env"),
+        b"SQL_DSN=postgres://fixture\n",
+    );
+    files.manifest.environment_restore_sha256 = sha256_bytes(b"SQL_DSN=postgres://fixture\n");
+    Files::write_private(
+        &files.workspace.manifest,
+        &serde_json::to_vec(&files.manifest).unwrap(),
+    );
+    fs::remove_file(
+        &files
+            .manifest
+            .controller_only_backup
+            .as_ref()
+            .unwrap()
+            .receipt_path,
+    )
+    .unwrap();
+    assert!(files.workspace.read_manifest_for_rollback(false).is_ok());
+}

--- a/docs/backend-cli-deployment-contract.md
+++ b/docs/backend-cli-deployment-contract.md
@@ -64,6 +64,19 @@ A provider switch can occur while a deployment is awaiting confirmation.
 Therefore either provider MUST be able to read, validate, confirm, or manually
 roll back a transaction created by the other provider.
 
+## Optional production backups
+
+Release-plan format 6 requires an explicit `disabled` or `controller-only` backup
+mode. Go-only, Web-only, and combined releases may disable backups. Selected
+controller-only backups require authenticated verification of the complete local
+collection; target hosts receive signed metadata rather than archives or keys.
+Both providers MUST validate evidence format 3 and retain legacy readers for
+existing transactions. Optional backups do not replace verified N-1 packages or
+configuration rollback state.
+
+[Controller-only backup evidence](controller-only-backup-format.md) defines the
+wire format, freshness rules, transfer/retry behavior and recovery requirements.
+
 ## Manual rollback
 
 Production deployment has no scheduled or automatic rollback. It MUST NOT create

--- a/docs/controller-only-backup-format.md
+++ b/docs/controller-only-backup-format.md
@@ -1,0 +1,53 @@
+# Controller-only production backup evidence
+
+This change replaces automatic target/controller/off-host backup creation for new release plans with an explicitly selected controller-owned import. Native source streaming is not part of this change. An independently authorized source-encrypted collection must finish before import. Target hosts receive only signed verification receipts; private keys, archives, dumps and ciphertext never leave the controller during import/stage/confirm.
+
+## Modes and compatibility
+
+New release plans use format 6 and `backup_mode` equal to `disabled` or `controller-only`. `with_backups` must agree with the mode. Disabled is valid for Go-only, Web-only and combined changes and must have no backup paths, keys or evidence; it performs no backup commands. Controller-only requires `controller_backup_dir` (absolute, private, no symlink components) and `controller_backup_public_key` (32-byte Ed25519 key, lowercase hex). Planning creates/reuses a private 64-byte Ed25519 signing key at `<workspace>/state/controller-backup.key`; the key is never staged. `--age-identity-file` remains a controller-only runtime argument, never a manifest value.
+
+Format 5 plans and evidence formats 0/2 remain readable for already-created transactions/recovery. New plans must not silently select legacy target/off-host replication. Go and Rust must both read new production evidence and reject malformed mixed modes. Rust controller-side operations remain explicitly unsupported; no shell fallback is introduced.
+
+Production manifest/status formats stay 8/2. New selected evidence uses `backup_evidence_format: 3`, `backups_enabled: true`, empty `backup_dir`, `target_backup_sha256` and `offhost_backup_sha256`. `controller_backup_sha256` is the imported backup-set.json digest; `database_backup_sha256` is the decrypted custom PostgreSQL archive digest. A new optional `controller_only_backup` object contains `public_key`, `plan_sha256`, `receipt_path`, `receipt_sha256`. Receipt path is exactly `<workspace>/state/controller-backup-receipt.json`. Disabled manifests have no such object/evidence. Retained rollback packages and small configuration rollback state remain independent of optional backup mode.
+
+## Imported collection
+
+A complete import directory contains exactly `backup-set.json`, `.complete`, `application.age`, `frontend.age`, `configuration.age`, `database.age`. Directory mode is 0700; members are private nonempty single-link regular files, owned by the invoking controller user; no symlink component is accepted. Unknown members, partials and keys are rejected. `.complete` contains the lowercase SHA-256 of the exact `backup-set.json` bytes plus a newline.
+
+`backup-set.json` (strict JSON, no unknown/duplicate fields) has:
+
+- `format`: 1
+- `deployment_id`, `expected_host` (`arch-dmit`), `captured_utc` (RFC3339 UTC)
+- `database_schema`, `environment_sha256`
+- `go_rollback_sha256`, `web_rollback_sha256` (exact N-1 package digests)
+- `go_rollback_payload_sha256`, `frontend_rollback_sha256`
+- `archives`: exactly four keys `application`, `frontend`, `configuration`, `database`, each with `ciphertext_sha256`, `plaintext_sha256`, `ciphertext_bytes`, `plaintext_bytes`.
+
+The collection belongs to the current deployment ID, not a relabelled old transaction. Its package/payload/index identities must match the frozen plan. Its schema must be a valid explicit PostgreSQL schema; its capture time cannot be future (>30s) or older than 24 hours. The final receipt reports the actual snapshot time, not a claim that decrypting old bytes creates a new snapshot.
+
+Decrypt each member sequentially using age into a unique private workspace scratch directory. Enforce complete successful decryption/EOF, declared lengths and plaintext/ciphertext hashes. Never include age/PG stderr or secret content in errors. Remove successful plaintext scratch on exit; failed encrypted originals are not deleted. Full tar traversal is required for application/frontend/configuration (plain tar or gzip tar), with limits, unique canonical relative paths, no links/devices/traversal, and complete gzip checksum/EOF. Required regular members: application `usr/bin/lmm-api-go` matching N-1 provider payload; frontend `index.html` matching N-1 index; configuration `etc/lmm-api-go/lmm-api-go.env` matching `environment_sha256`. Validate configuration syntax with the existing non-evaluating parser and PostgreSQL authority. Validate the entire decrypted custom PostgreSQL archive with `pg_restore --file=/dev/null`, not only `--list`; no production database is contacted. No archive extraction or full plaintext upload is permitted.
+
+## Signed receipt
+
+The envelope is strict JSON `{ "format": 1, "payload": "<base64 raw JSON>", "signature": "<128 lowercase hex>" }`, capped at 64 KiB. Keys and signature points must be canonical, non-small-order Ed25519 points; required fields cannot be missing, null, duplicated or differently cased. Ed25519 signs the exact decoded payload bytes; consumers never reserialize them to verify. Payload fields are:
+
+- `format`: 1, `purpose`: `prepare` or `confirm`
+- `deployment_id`, `expected_host`, `plan_sha256`
+- `verified_utc`, `captured_utc`
+- `deployment_manifest_sha256`: empty for prepare, actual immutable manifest SHA for confirm
+- `backup_set_sha256`, `database_schema`, `environment_sha256`
+- `go_candidate_sha256`, `go_rollback_sha256`, `web_candidate_sha256`, `web_rollback_sha256`
+- `go_rollback_payload_sha256`, `frontend_rollback_sha256`
+- `archive_ciphertexts`, `archive_plaintexts`: exactly the four archive-kind-to-digest mappings above.
+
+The controller publishes receipts from private temporary files. On the target, it verifies a unique root-owned `0600`, single-link `.partial` file before renaming it to the receipt path. Initial publication uses no-clobber semantics; confirmation may replace only the small confirmation receipt. A failed transfer leaves its partial metadata for audit and retries with a new temporary name. It does not leave incomplete bytes at the immutable receipt path.
+
+The public key is fixed in the immutable release plan before receipt creation. The trusted controller dispatch carries that key and the plan SHA to the native target transaction. The target checks signature, exact deployment/host/plan, all package identities and schema/environment/index bindings against its verified live N-1/retained configuration state. Prepare verification age must be strictly below five minutes (allow <=30s future skew). The initial receipt is immutable, hashed into the deployment manifest, and never rewritten during confirm. Subsequent archive-evidence checks verify its signature/bindings/digest but do not expire the historical prepare timestamp.
+
+Confirmation deep-verifies the original controller collection again, signs a fresh `purpose=confirm` receipt binding the exact immutable deployment-manifest SHA, and stages only `<workspace>/state/controller-backup-confirmation.json`. Target Go/Rust confirm verifies the same frozen public key and immutable bindings with verification age strictly below five minutes before becoming CONFIRMED. The snapshot must still be within 24 hours; re-verification does not renew its capture time. This prevents checksum-only claims and timestamp refresh without renewed controller verification. No circular digest exists: prepare payload binds the preexisting release-plan SHA; deployment manifest binds prepare receipt SHA; fresh confirm payload then binds deployment manifest SHA.
+
+## Failure and recovery
+
+Reject missing evidence, corrupt/truncated age or archive data, identity/schema/payload mismatch, forged/replayed signatures, cross-transaction receipts, stale confirmations, and unknown/mixed evidence before activation/confirmation. Do not create a production backup tree or contact an off-host. Post-mutation errors retain ROLLBACK_REQUIRED/locks and do not automatically roll back. Rollback uses exact N-1 packages and retained configuration without requiring controller availability, candidate bytes or backup receipts. The controller uses `/usr/bin/lmm-api` for recovery when its one-hop provider target and both path hashes match the frozen candidate package payload. Otherwise it requires the verified release-scoped operator. It refuses an unverified installed N-1 executable. Old binaries may reject the new evidence format; retain/re-stage a verified compatible operator for recovery rather than pretending Go 0.2.13 can read it. A Web-only plan that keeps an older unsupported Go CLI cannot use format-3 selected backups until a compatible provider has been released and validated.
+
+An expired initial receipt stops preparation before decryption or SSH. Create a new deployment ID and collect evidence bound to that ID; the controller does not renew or relabel an immutable initial receipt in place. A missing persisted receipt requires restoration of the original evidence or a new transaction.


### PR DESCRIPTION
## 变更说明 / Summary

Align the deployment CLI with the controller-only backup policy without placing backup archives or keys on production. New format-6 plans explicitly select disabled or controller-only backups. Go-only, Web-only, and combined releases may omit backups; selected backups require complete local age/archive/PostgreSQL verification and signed format-3 receipts.

Initial receipts remain immutable. Partial transfers use unique private files and atomic publication; confirmation binds the exact target manifest and freshly re-verifies the original collection. Recovery can use the installed CLI only when its provider link, ownership, mode, and both hashes match the frozen package payload. Native rollback remains independent of backup availability. Legacy format-5 plans and evidence readers remain supported.

This does not transfer Rust business routes, change bounty/payment behavior, publish a release, or activate production. Older Go providers cannot be assumed to understand format-3 evidence: the planned first selected-backup rollout upgrades to the compatible Go provider before the new Web release.

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change

上游参考 / Upstream reference: N/A — repository-specific deployment protocol and controller storage policy.

## 关联 Issue / Related issue

N/A — operator-requested deployment and backup-policy repair; no issue is closed by this PR.

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [x] 新功能 / Feature
- [x] 部署、CI 或构建 / Deployment, CI, or build
- [x] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
GOPROXY=off go test -mod=readonly -p 1 ./internal/appcli -count=1
PASS (latest full package run: 12.016s)

go vet -mod=readonly -p 1 ./internal/appcli
PASS

LMM_CONTROLLER_BACKUP_REAL_TOOLS_TEST=1 go test -p 1 ./internal/appcli -run '^TestControllerBackupImportWithRealAgeAndPostgres$' -count=1 -v
PASS: real age, isolated PostgreSQL custom dump, truncated dump rejection, authenticated EOF corruption rejection. No TCP listener or production database was used.

Full real Rust deployment/provider modules in a SHA-verified isolated harness
47 tests PASS, including Go-generated signed receipt/manifest interoperability.
The Rust source hashes still match that run. This is NOT the full Rust server/workspace CI or all TLS feature combinations.

git diff --check
PASS
```

Full repository CI (Go/Web, Rust all features and real PostgreSQL/Valkey, route alignment, AUR contracts) must pass on this PR before release publication. No production mutation has been performed.

## 截图或日志 / Screenshots or logs

Local owned verification logs: `go-appcli-publication-gate.log`, `go-appcli-publication-vet.log`, `go-real-backup-tools-gate.log`. Tests cover mocked complete controller import/prepare/manifest-bound confirmation, interrupted SCP retry, no-clobber races, expiry refusal before decrypt/SSH, strict signed JSON, and receipt-independent native rollback. GNU stat metadata now uses numeric mode/type values, including empty files, rather than locale-dependent type descriptions.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

测试数据是合成数据，没有新增 UI 文案。完整仓库 CI 结果由本 PR 的检查提供，不把本地模块检查冒充全部 CI。
