### PR TITLE
perf(rust): avoid native relay request body copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ authenticated users then see it once after their next login.
 
 <!-- Add user-facing or operational changes here before the next release. -->
 
+- Rust OpenAI-compatible native relay paths now retain the aggregated request
+  body in a reference-counted buffer, avoiding an extra full-payload copy before
+  the upstream request and preserving streaming first-content latency for large
+  prompts.
+
 - Added automatic administrator assistant tasks through the existing protected
   management routes, source-derived request contracts, and live pricing audits.
 - Recheck administrator roles and browser sessions for every tool action; keep

--- a/apps/api-rust/src/routes/assistant.rs
+++ b/apps/api-rust/src/routes/assistant.rs
@@ -522,7 +522,7 @@ impl AssistantAgentBackend for PgAssistantAgentBackend {
             request_id: turn.request_id.clone(),
             headers,
             request: canonical,
-            raw_body: turn.body.clone(),
+            raw_body: axum::body::Bytes::copy_from_slice(&turn.body),
         };
         let result = match self.upstream.forward(&reservation.target, &request).await {
             Ok(result) => result,

--- a/apps/api-rust/src/routes/relay_openai.rs
+++ b/apps/api-rust/src/routes/relay_openai.rs
@@ -30,7 +30,7 @@ use crate::{
 use async_trait::async_trait;
 use axum::{
     Router,
-    body::{Body, to_bytes},
+    body::{Body, Bytes, to_bytes},
     extract::{Request, State},
     http::{HeaderMap, HeaderName, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
@@ -67,7 +67,7 @@ pub struct OpenAiRelayRequest {
     /// Original JSON bytes.  The transactional adapter uses these to replay a
     /// failed attempt and to retain provider fields which are intentionally
     /// outside the canonical cross-provider subset.
-    pub raw_body: Vec<u8>,
+    pub raw_body: Bytes,
 }
 
 /// OpenAI endpoint families sharing the relay executor.
@@ -739,7 +739,7 @@ async fn relay(
         request_id: request_id.clone(),
         headers,
         request: canonical,
-        raw_body: body.to_vec(),
+        raw_body: body,
     };
     let result = match state.service.relay(relay_request).await {
         Ok(result) => result,
@@ -1618,7 +1618,7 @@ mod tests {
                 completion_request_to_canonical(br#"{"model":"mock-model","prompt":"hello"}"#),
                 "build canonical relay test request",
             )?,
-            raw_body: raw_body.to_vec(),
+            raw_body: Bytes::copy_from_slice(raw_body),
         })
     }
 
@@ -1899,7 +1899,7 @@ mod tests {
             captured.authorization.as_deref(),
             Some("Bearer channel-secret")
         );
-        assert_eq!(captured.body.as_ref(), request.raw_body.as_slice());
+        assert_eq!(captured.body.as_ref(), request.raw_body.as_ref());
         assert_eq!(result.headers["x-upstream-trace"], "mock-json");
         let (body, content_type) = match result.body {
             OpenAiRelayBody::Upstream { body, content_type } => (body, content_type),

--- a/apps/api-rust/tests/relay_openai.rs
+++ b/apps/api-rust/tests/relay_openai.rs
@@ -3,7 +3,7 @@ use std::{net::IpAddr, str::FromStr};
 
 use async_trait::async_trait;
 use axum::{
-    body::{Body, to_bytes},
+    body::{Body, Bytes, to_bytes},
     http::{Request, StatusCode, header},
 };
 use lmm_api_rs::RequestContext;
@@ -81,6 +81,51 @@ fn completed() -> OpenAiRelayResult {
 }
 
 #[tokio::test]
+async fn openai_routes_share_original_request_storage_with_replays() {
+    let payload = Bytes::from(
+        serde_json::to_vec(&serde_json::json!({
+            "model": "gpt-4o", "stream": true, "prompt": "hello",
+            "provider_field": "x".repeat(16 * 1024),
+        }))
+        .expect("payload"),
+    );
+    for path in [
+        "/v1/chat/completions",
+        "/v1/completions",
+        "/v1/responses",
+        "/v1/responses/compact",
+    ] {
+        let service = service(Ok(completed()));
+        let router = openai_relay_router(OpenAiRelayHttpState::new(service.clone(), "test"));
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(path)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.clone()))
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(response.status(), StatusCode::OK, "{path}");
+        let requests = service.requests.lock().expect("requests");
+        let raw_body = &requests[0].raw_body;
+        assert_eq!(&raw_body[..], payload.as_ref());
+        assert!(
+            std::ptr::eq(raw_body.as_ptr(), payload.as_ptr()),
+            "{path}: the relay must reuse the aggregated body, not copy its payload"
+        );
+        let replay = raw_body.clone();
+        assert!(
+            std::ptr::eq(replay.as_ptr(), payload.as_ptr()),
+            "{path}: preparing an upstream replay must share the original payload"
+        );
+        assert_eq!(&replay[..], payload.as_ref());
+    }
+}
+
+#[tokio::test]
 async fn chat_route_authenticates_through_service_and_returns_legacy_headers() {
     let service = service(Ok(completed()));
     let router = openai_relay_router(OpenAiRelayHttpState::new(service.clone(), "v0.0.0"));
@@ -112,7 +157,7 @@ async fn chat_route_authenticates_through_service_and_returns_legacy_headers() {
     assert_eq!(requests[0].endpoint, OpenAiRelayEndpoint::ChatCompletions);
     assert_eq!(requests[0].request.model, "gpt-4o");
     assert_eq!(
-        requests[0].raw_body,
+        requests[0].raw_body.as_ref(),
         br#"{"model":"gpt-4o","messages":[{"role":"user","content":"hello"}]}"#
     );
     assert!(!requests[0].request_id.is_empty());
@@ -182,7 +227,7 @@ async fn completions_preserves_the_original_wire_body_for_the_adapter() {
     assert_eq!(requests[0].endpoint, OpenAiRelayEndpoint::Completions);
     assert_eq!(requests[0].request.model, "gpt-4o");
     assert_eq!(
-        requests[0].raw_body,
+        requests[0].raw_body.as_ref(),
         br#"{"model":"gpt-4o","prompt":"write a haiku","stream":false,"suffix":"."}"#
     );
 }

--- a/apps/api-rust/tests/relay_openai_first_token.rs
+++ b/apps/api-rust/tests/relay_openai_first_token.rs
@@ -1,0 +1,220 @@
+use std::{
+    convert::Infallible,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use axum::{
+    Router,
+    body::{Body, Bytes, to_bytes},
+    extract::Request,
+    http::{StatusCode, header},
+    response::IntoResponse,
+    routing::post,
+};
+use futures_util::{StreamExt, stream};
+use lmm_api_rs::routes::relay_openai::{
+    OpenAiRelayAuthorization, OpenAiRelayFailure, OpenAiRelayHttpState, OpenAiRelayRequest,
+    OpenAiRelayResult, OpenAiRelayService, OpenAiUpstreamClient, OpenAiUpstreamTarget,
+    openai_relay_router,
+};
+use tokio::{
+    net::TcpListener,
+    sync::{Mutex, oneshot},
+    task::JoinHandle,
+};
+use tower::ServiceExt;
+
+const FIRST: &[u8] = b"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n";
+const DONE: &[u8] = b"data: [DONE]\n\n";
+
+struct ForwardRelay {
+    client: OpenAiUpstreamClient,
+    target: OpenAiUpstreamTarget,
+}
+
+#[async_trait]
+impl OpenAiRelayService for ForwardRelay {
+    async fn authenticate(&self, _: OpenAiRelayAuthorization) -> Result<(), OpenAiRelayFailure> {
+        Ok(())
+    }
+
+    async fn relay(
+        &self,
+        request: OpenAiRelayRequest,
+    ) -> Result<OpenAiRelayResult, OpenAiRelayFailure> {
+        self.client.forward(&self.target, &request).await
+    }
+}
+
+// Abort the loopback server even if a test assertion fails.
+struct Server(JoinHandle<()>);
+
+impl Drop for Server {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
+async fn relay_to(upstream: Router) -> (Router, Server) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("listen");
+    let address = listener.local_addr().expect("address");
+    let server = Server(tokio::spawn(async move {
+        axum::serve(listener, upstream).await.expect("serve");
+    }));
+    let service = Arc::new(ForwardRelay {
+        client: OpenAiUpstreamClient::new(
+            reqwest::Client::builder()
+                .no_proxy()
+                .build()
+                .expect("client"),
+            Duration::from_secs(5),
+        ),
+        target: OpenAiUpstreamTarget {
+            base_url: format!("http://{address}"),
+            api_key: "local-test-only".to_owned(),
+        },
+    });
+    (
+        openai_relay_router(OpenAiRelayHttpState::new(service, "test")),
+        server,
+    )
+}
+
+fn request(body: Bytes) -> Request {
+    Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(body))
+        .expect("request")
+}
+
+#[tokio::test]
+async fn native_relay_delivers_content_before_upstream_finishes() {
+    let payload = Bytes::from_static(
+        br#"{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":"hi"}]}"#,
+    );
+    let (finish, wait) = oneshot::channel();
+    let wait = Arc::new(Mutex::new(Some(wait)));
+    let expected = payload.clone();
+    let upstream = Router::new().route(
+        "/v1/chat/completions",
+        post(move |request: Request| {
+            let wait = wait.clone();
+            let expected = expected.clone();
+            async move {
+                assert_eq!(
+                    to_bytes(request.into_body(), 1024)
+                        .await
+                        .expect("request body"),
+                    expected
+                );
+                let wait = wait.lock().await.take().expect("one upstream request");
+                let first = stream::once(async { Ok::<_, Infallible>(Bytes::from_static(FIRST)) });
+                let tail = stream::once(async move {
+                    wait.await.expect("release upstream tail");
+                    Ok::<_, Infallible>(Bytes::from_static(DONE))
+                });
+                (
+                    [(header::CONTENT_TYPE, "text/event-stream")],
+                    Body::from_stream(first.chain(tail)),
+                )
+                    .into_response()
+            }
+        }),
+    );
+    let (relay, _server) = relay_to(upstream).await;
+    let mut chunks = tokio::time::timeout(Duration::from_secs(5), async {
+        let response = relay
+            .oneshot(request(payload))
+            .await
+            .expect("relay response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()["x-accel-buffering"], "no");
+        let mut chunks = response.into_body().into_data_stream();
+        let mut received = Vec::new();
+        while received.len() < FIRST.len() {
+            received.extend_from_slice(&chunks.next().await.expect("first content").expect("body"));
+        }
+        assert_eq!(received, FIRST);
+        chunks
+    })
+    .await
+    .expect("first content must arrive while upstream is still held open");
+
+    finish.send(()).expect("upstream still waiting");
+    let tail = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut tail = Vec::new();
+        while let Some(chunk) = chunks.next().await {
+            tail.extend_from_slice(&chunk.expect("tail"));
+        }
+        tail
+    })
+    .await
+    .expect("stream completes");
+    assert_eq!(tail, DONE);
+}
+
+/// Local gateway timing only: no database, remote model, or incoming network upload.
+/// Run with `cargo test --release --test relay_openai_first_token -- --ignored --nocapture`.
+#[tokio::test]
+#[ignore = "manual first-content latency measurement; not a timing-sensitive CI gate"]
+async fn measure_native_relay_first_content() {
+    let upstream = Router::new().route(
+        "/v1/chat/completions",
+        post(|request: Request| async move {
+            let _body = to_bytes(request.into_body(), 64 * 1024 * 1024)
+                .await
+                .expect("request body");
+            (
+                [(header::CONTENT_TYPE, "text/event-stream")],
+                Body::from_stream(stream::iter([
+                    Ok::<_, Infallible>(Bytes::from_static(FIRST)),
+                    Ok(Bytes::from_static(DONE)),
+                ])),
+            )
+        }),
+    );
+    let (relay, _server) = relay_to(upstream).await;
+    for size in [1024, 1024 * 1024, 16 * 1024 * 1024] {
+        let payload = Bytes::from(
+            serde_json::to_vec(&serde_json::json!({
+                "model": "gpt-4o", "stream": true,
+                "messages": [{"role": "user", "content": "x".repeat(size)}],
+            }))
+            .expect("payload"),
+        );
+        let mut samples = Vec::new();
+        for iteration in 0..45 {
+            let input = request(payload.clone());
+            let started = Instant::now();
+            let response = relay.clone().oneshot(input).await.expect("response");
+            assert_eq!(response.status(), StatusCode::OK);
+            let mut chunks = response.into_body().into_data_stream();
+            let mut received = Vec::new();
+            while received.len() < FIRST.len() {
+                received.extend_from_slice(&chunks.next().await.expect("content").expect("body"));
+            }
+            let elapsed = started.elapsed();
+            assert!(received.starts_with(FIRST));
+            // Drain after timing so the next request can reuse the upstream connection.
+            while let Some(chunk) = chunks.next().await {
+                received.extend_from_slice(&chunk.expect("tail"));
+            }
+            assert_eq!(received, [FIRST, DONE].concat());
+            if iteration >= 5 {
+                samples.push(elapsed);
+            }
+        }
+        samples.sort_unstable();
+        println!(
+            "body_bytes={} samples={} first_content_p50_us={} first_content_p95_us={}",
+            payload.len(),
+            samples.len(),
+            samples[20].as_micros(),
+            samples[37].as_micros()
+        );
+    }
+}


### PR DESCRIPTION
## 变更说明 / Summary

Rust OpenAI-compatible native relay routes now keep the already-aggregated request body in `axum::Bytes` instead of copying it into a second `Vec<u8>`. Upstream replay uses the cheap reference-counted clone, so large prompts avoid one full-payload allocation/copy before the request is sent.

Added:
- a regression test covering all four native OpenAI endpoints and shared request storage;
- a loopback SSE test proving content arrives before the upstream stream finishes;
- an ignored local first-content benchmark;
- an Unreleased changelog entry.

The assistant backend still makes its existing one copy when adapting its owned `Vec<u8>` turn body; no quota, billing, transaction, provider selection, or production route ownership behavior changes.

## 与上游的关系 / Upstream relationship

- [x] LMM API 独有变更 / LMM API-specific change
- [ ] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: N/A. This is a scoped optimization of the Rust migration candidate; Go remains the production baseline.

## 关联 Issue / Related issue

N/A. I searched existing issues and PRs for first-token, zero-copy, request-body, and stream work; no duplicate Rust change was found.

## 变更类型 / Type of change

- [ ] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [x] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [x] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
cd apps/api-rust && cargo fmt --all --check
result: PASS

cd apps/api-rust && cargo clippy --locked --test relay_openai --test relay_openai_first_token -- -D warnings
result: PASS

cd apps/api-rust && cargo test --release --locked -j 2 --test relay_openai --test relay_openai_first_token
result: 8 OpenAI route tests passed; first-content streaming regression passed; 1 manual benchmark ignored by design

cd apps/api-rust && cargo test --release --locked -j 2 --lib routes::relay_openai
result: 15 tests passed

cargo test --release --locked --test relay_openai_first_token -- --ignored --nocapture
result: local loopback benchmark passed. Before: 1 MiB p50 369 us, 16 MiB p50 12,357 us. After: 1 MiB p50 282 us, 16 MiB p50 8,197 us. p95 also improved (1 MiB 493 -> 325 us; 16 MiB 13,070 -> 9,366 us).
```

The benchmark measures gateway first-content latency against a local held-open SSE producer. It does not claim a production provider/model latency reduction.

## 截图或日志 / Screenshots or logs

N/A; command output above is the redacted evidence.

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。