### PR TITLE
fix(go): accept mixed-case audio extensions

### DIFF
--- a/apps/api-go/common/audio.go
+++ b/apps/api-go/common/audio.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/LIghtJUNction/api.lmm.best/constant"
 
@@ -22,6 +23,7 @@ import (
 // 它不再依赖外部的 ffmpeg 或 ffprobe 程序。
 func GetAudioDuration(ctx context.Context, f io.ReadSeeker, ext string) (duration float64, err error) {
 	SysLog(fmt.Sprintf("GetAudioDuration: ext=%s", ext))
+	ext = strings.ToLower(ext)
 	// 根据文件扩展名选择解析器
 	switch ext {
 	case ".mp3":

--- a/apps/api-go/common/audio_test.go
+++ b/apps/api-go/common/audio_test.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestGetAudioDurationNormalizesExtensionCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		lower string
+		mixed string
+	}{
+		{name: "wav upper", lower: ".wav", mixed: ".WAV"},
+		{name: "wav mixed", lower: ".wav", mixed: ".WaV"},
+		{name: "mp3 upper", lower: ".mp3", mixed: ".MP3"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lowerDuration, lowerErr := GetAudioDuration(context.Background(), bytes.NewReader(nil), tt.lower)
+			mixedDuration, mixedErr := GetAudioDuration(context.Background(), bytes.NewReader(nil), tt.mixed)
+
+			if lowerDuration != mixedDuration {
+				t.Fatalf("duration mismatch for %q and %q: %v != %v", tt.lower, tt.mixed, lowerDuration, mixedDuration)
+			}
+			if (lowerErr == nil) != (mixedErr == nil) {
+				t.Fatalf("error presence mismatch for %q and %q: %v != %v", tt.lower, tt.mixed, lowerErr, mixedErr)
+			}
+			if lowerErr != nil && lowerErr.Error() != mixedErr.Error() {
+				t.Fatalf("error mismatch for %q and %q: %q != %q", tt.lower, tt.mixed, lowerErr, mixedErr)
+			}
+		})
+	}
+}
+
+func TestGetAudioDurationRejectsUnknownExtension(t *testing.T) {
+	_, err := GetAudioDuration(context.Background(), bytes.NewReader(nil), ".UNKNOWN")
+	if err == nil || err.Error() != "unsupported audio format: .unknown" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
# LMM API Pull Request

## 变更说明 / Summary

在 `common.GetAudioDuration` 的共享入口统一将扩展名转为小写，使 `.WAV`、`.WaV`、`.MP3` 等文件名与现有小写格式走同一解析器。未知格式仍保持拒绝，解码失败语义不变。

补充表驱动回归测试，比较相同输入在小写/大写/混合大小写扩展名下的时长与错误结果，并确认未知大写扩展名仍返回 unsupported。

## 与上游的关系 / Upstream relationship

- [ ] LMM API 独有变更 / LMM API-specific change
- [x] 上游尚未合并的修复或功能 / Change not yet merged upstream
- [ ] 同步或移植上游变更 / Upstream sync or backport
- [ ] 不适用（文档、CI、仓库维护等）/ Not applicable

上游参考 / Upstream reference: QuantumNous/new-api#7319

## 关联 Issue / Related issue

Closes #253

## 变更类型 / Type of change

- [x] Bug 修复 / Bug fix
- [ ] 新功能 / Feature
- [ ] 重构或性能优化 / Refactor or performance
- [ ] 前端或交互 / Frontend or UX
- [ ] 部署、CI 或构建 / Deployment, CI, or build
- [ ] 文档或仓库维护 / Documentation or maintenance

## 验证 / Verification

```text
Source review: PASS
- shared dispatch point normalizes `ext` before the existing switch
- supported-format set is unchanged
- unknown-format rejection remains intact

CI: PASS (run 34664659919; Go, Rust, Web and route/behavior gates).
CodeQL and i18n: PASS.
The audio regression covers dispatch/error parity; successful audio decoding fixtures remain a test coverage limitation.
```

## 截图或日志 / Screenshots or logs

无界面改动。

## 提交检查 / Checklist

- [x] 我已搜索本仓库的 [Issues](https://github.com/LIghtJUNction/api.lmm.best/issues) 和 [PRs](https://github.com/LIghtJUNction/api.lmm.best/pulls)，确认没有重复工作。
- [x] 此 PR 只包含与当前目标相关的改动，未混入格式化或其他无关变更。
- [x] 我已说明该变更对当前产品流程或兼容行为的影响，并保留必要的来源、版权和许可证信息。
- [x] 我已检查兼容性；如有破坏性变化，已在说明中明确列出迁移方式。
- [x] 我已补充或更新相关测试，并在上方记录实际验证结果；如未测试，已说明原因。
- [x] 我已更新受影响的文档、示例配置和多语言文案（如适用）。
- [x] 代码、日志、截图和提交记录中不包含 API Key、Cookie、Token、密码、DSN 或其他敏感信息。

## Sourcery 摘要

使音频扩展名处理不区分大小写，同时不改变支持的格式或错误语义。

错误修复：
- 接受扩展名为大写或大小写混合的音频文件，同时保留现有的不支持格式和解码错误行为。

测试：
- 添加回归测试，覆盖不区分大小写的受支持扩展名，以及对未知扩展名的拒绝。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make audio extension handling case-insensitive without changing supported formats or error semantics.

Bug Fixes:
- Accept audio files with upper- or mixed-case extensions while preserving existing unsupported-format and decoding-error behavior.

Tests:
- Add regression coverage for case-insensitive supported extensions and rejection of unknown extensions.

</details>
